### PR TITLE
docs: use `-D` instead of `--save-dev`

### DIFF
--- a/website/src/docs/official-plugins/expo-atlas.mdx
+++ b/website/src/docs/official-plugins/expo-atlas.mdx
@@ -18,7 +18,7 @@ Expo Atlas is a bundle analyzer and visualizer that helps you understand and opt
 
 Install the Expo Atlas plugin as a development dependency using your preferred package manager:
 
-<PackageManagerTabs command="install --save-dev @rozenite/expo-atlas-plugin" />
+<PackageManagerTabs command="install -D @rozenite/expo-atlas-plugin" />
 
 ## Configuration
 

--- a/website/src/docs/official-plugins/network-activity.mdx
+++ b/website/src/docs/official-plugins/network-activity.mdx
@@ -18,7 +18,7 @@ The Network Activity plugin is a powerful debugging tool that helps you monitor 
 
 Install the Network Activity plugin as a development dependency using your preferred package manager:
 
-<PackageManagerTabs command="install --save-dev @rozenite/network-activity-plugin" />
+<PackageManagerTabs command="install -D @rozenite/network-activity-plugin" />
 
 ## Configuration
 

--- a/website/src/docs/official-plugins/overview.mdx
+++ b/website/src/docs/official-plugins/overview.mdx
@@ -41,11 +41,11 @@ Monitor network requests in your React Native app with a comprehensive network i
 
 Plugins should be installed as development dependencies since they are only needed during development:
 
-<PackageManagerTabs command="install --save-dev @rozenite/expo-atlas-plugin" />
+<PackageManagerTabs command="install -D @rozenite/expo-atlas-plugin" />
 
-<PackageManagerTabs command="install --save-dev @rozenite/tanstack-query-plugin" />
+<PackageManagerTabs command="install -D @rozenite/tanstack-query-plugin" />
 
-<PackageManagerTabs command="install --save-dev @rozenite/network-activity-plugin" />
+<PackageManagerTabs command="install -D @rozenite/network-activity-plugin" />
 
 ## Configuration
 

--- a/website/src/docs/official-plugins/tanstack-query.mdx
+++ b/website/src/docs/official-plugins/tanstack-query.mdx
@@ -19,7 +19,7 @@ TanStack Query (formerly React Query) is a powerful data synchronization library
 
 Install the TanStack Query plugin as a development dependency using your preferred package manager:
 
-<PackageManagerTabs command="install --save-dev @rozenite/tanstack-query-plugin" />
+<PackageManagerTabs command="install -D @rozenite/tanstack-query-plugin" />
 
 ## Configuration
 


### PR DESCRIPTION
### Summary

`--save-dev` is only supported by `npm` & `pnpm`, while `-D` is supported by all