### PR TITLE
fix(plugin-bridge): resolving in non-exports environments

### DIFF
--- a/.nx/version-plans/version-plan-1753803685928.md
+++ b/.nx/version-plans/version-plan-1753803685928.md
@@ -22,6 +22,10 @@ The Rozenite Redux DevTools Plugin provides Redux state inspection and debugging
 
 - Bring back support for 'metro.ts' entry files
 
+### @rozenite/plugin-bridge
+
+- Improved module resolution compatibility for environments without package.json exports support, including Metro bundler configurations that don't enable unstable_enablePackageExports
+
 ## Migration Guide
 
 - No migration required for existing packages

--- a/packages/plugin-bridge/package.json
+++ b/packages/plugin-bridge/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0-alpha.5",
   "description": "Communication layer for React Native DevTools plugins across React Native and web environments",
   "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],
@@ -25,21 +28,9 @@
   "license": "MIT",
   "exports": {
     ".": {
-      "types": {
-        "browser": "./dist/index.d.ts",
-        "react-native": "./dist/index.d.ts",
-        "default": "./dist/index.d.ts"
-      },
-      "import": {
-        "browser": "./dist/index.js",
-        "react-native": "./dist/index.js",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "browser": "./dist/index.cjs",
-        "react-native": "./dist/index.cjs",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
   "dependencies": {


### PR DESCRIPTION
Improved module resolution compatibility for environments without package.json exports support, including Metro bundler configurations that don't enable unstable_enablePackageExports