### PR TITLE
fix(runtime): persist panel state on detach

### DIFF
--- a/packages/runtime/src/rn-devtools/plugin-view.ts
+++ b/packages/runtime/src/rn-devtools/plugin-view.ts
@@ -14,6 +14,8 @@ export class PluginView
 
     this.#src = url;
 
+    this.setHideOnDetach();
+
     SDK.TargetManager.TargetManager.instance().observeModels(
       RozenitePluginModel,
       this


### PR DESCRIPTION
This fix ensures that DevTools panels maintain their state when users switch between different panels.

## Before

Panels were destroyed when switched away from, causing users to lose their work, scroll position, and any data they had entered.

https://github.com/user-attachments/assets/63c02fb6-ac95-4227-b5b9-d51edd68f7f2

## After

Panels are now _hidden_ instead of _destroyed_, preserving the user's context and improving the overall DevTools experience.

https://github.com/user-attachments/assets/95856027-003c-4c22-91a2-ea2594217884