### PR TITLE
fix(redux-devtools-plugin): import Redux DevTools CLI dynamically

### DIFF
--- a/.nx/version-plans/version-plan-1753962216341.md
+++ b/.nx/version-plans/version-plan-1753962216341.md
@@ -1,0 +1,7 @@
+---
+__default__: prerelease
+---
+
+### @rozenite/redux-devtools-plugin
+
+- Fixed compatibility issue with @redux-devtools/cli when running in CommonJS environments

--- a/packages/redux-devtools-plugin/src/metro.ts
+++ b/packages/redux-devtools-plugin/src/metro.ts
@@ -1,15 +1,17 @@
 import type { ConfigT as MetroConfig } from 'metro-config';
 import { REDUX_DEVTOOLS_PORT } from './constants';
-import setupWebSocketRelay from '@redux-devtools/cli';
 
 export const withRozeniteReduxDevTools = <
   T extends MetroConfig | Promise<MetroConfig>
 >(
   config: T
 ): T => {
-  setupWebSocketRelay({
-    hostname: 'localhost',
-    port: REDUX_DEVTOOLS_PORT,
+  // This is ESM only, so we need to import it dynamically in case of CJS
+  import('@redux-devtools/cli').then(({ default: setupWebSocketRelay }) => {
+    setupWebSocketRelay({
+      hostname: 'localhost',
+      port: REDUX_DEVTOOLS_PORT,
+    });
   });
 
   return config;


### PR DESCRIPTION
Fixed compatibility issue with @redux-devtools/cli when running in CommonJS environments.