### PR TITLE
feat(redux-devtools-plugin): support remote connections

### DIFF
--- a/packages/redux-devtools-plugin/src/react-native.d.ts
+++ b/packages/redux-devtools-plugin/src/react-native.d.ts
@@ -1,0 +1,8 @@
+declare module 'react-native/Libraries/Core/Devtools/getDevServer' {
+  export type DevServerInfo = {
+    url: string;
+    fullBundleUrl?: string;
+    bundleLoadedFromServer: boolean;
+  };
+  export default function getDevServer(): DevServerInfo;
+}

--- a/packages/redux-devtools-plugin/src/runtime.ts
+++ b/packages/redux-devtools-plugin/src/runtime.ts
@@ -1,5 +1,6 @@
 import { devToolsEnhancer } from '@redux-devtools/remote';
 import { Platform } from 'react-native';
+import getDevServer from 'react-native/Libraries/Core/Devtools/getDevServer';
 import { REDUX_DEVTOOLS_PORT } from './constants';
 
 // @ts-expect-error - Symbol.asyncIterator is not defined in the global scope, but required by the redux-devtools/remote package.
@@ -19,10 +20,15 @@ const getDeviceId = (): string => {
   throw new Error('Unsupported platform');
 };
 
+const getHostname = (): string => {
+  const devServer = getDevServer();
+  return devServer.url.split('://')[1].split(':')[0];
+};
+
 export const rozeniteDevToolsEnhancer = (): StoreEnhancer => {
   return devToolsEnhancer({
     name: getDeviceId(),
-    hostname: Platform.OS === 'android' ? '10.0.2.2' : 'localhost',
+    hostname: getHostname(),
     port: REDUX_DEVTOOLS_PORT,
     secure: false,
     realtime: true,


### PR DESCRIPTION
This pull request enables Rozenite's Redux DevTools plugin to work with remote devices. Until now, it could only connect to local emulators, as the hostname was hardcoded to the loopback interface. From now on, the plugin will inherit the hostname of the dev server, making it possible to connect to Redux DevTools from remote devices.