### PR TITLE
feat(middleware): verify React Native version

### DIFF
--- a/.nx/version-plans/version-plan-1754390683064.md
+++ b/.nx/version-plans/version-plan-1754390683064.md
@@ -1,0 +1,5 @@
+---
+'@rozenite/middleware': prerelease
+---
+
+Added React Native version verification to prevent Rozenite from starting on unsupported versions, improving user experience by providing clear feedback when the tool doesn't load in older React Native DevTools. Enhanced logging capabilities through the introduction of ROZENITE_DEBUG environment variable, enabling additional logging for dependency resolution processes.

--- a/packages/middleware/package.json
+++ b/packages/middleware/package.json
@@ -40,15 +40,17 @@
     "@rozenite/runtime": "workspace:*",
     "ejs": "^3.1.10",
     "express": "^5.1.0",
+    "semver": "^7.7.2",
     "serve-static": "^2.2.0",
     "tslib": "^2.3.0"
   },
   "devDependencies": {
+    "@react-native/debugger-frontend": "~0.76.0",
+    "@react-native/dev-middleware": "~0.76.0",
     "@types/ejs": "^3.1.5",
     "@types/express": "^5.0.3",
-    "@types/serve-static": "^1.15.8",
-    "@react-native/debugger-frontend": "~0.76.0",
-    "@react-native/dev-middleware": "~0.76.0"
+    "@types/semver": "^7.7.0",
+    "@types/serve-static": "^1.15.8"
   },
   "engines": {
     "node": ">=22"

--- a/packages/middleware/src/index.ts
+++ b/packages/middleware/src/index.ts
@@ -5,6 +5,7 @@ import { logger } from './logger.js';
 import { getInstalledPlugins } from './auto-discovery.js';
 import type { RozeniteConfig } from './config.js';
 import { getDevModePackage } from './dev-mode.js';
+import { verifyReactNativeVersion } from './verify-react-native-version.js';
 
 export type RozeniteMiddleware = Application;
 export type RozeniteInstance = {
@@ -15,6 +16,8 @@ export type RozeniteInstance = {
 export const initializeRozenite = (
   options: RozeniteConfig
 ): RozeniteInstance => {
+  verifyReactNativeVersion(options.projectRoot);
+
   const devModePackage = getDevModePackage(options.projectRoot);
 
   if (devModePackage) {
@@ -38,7 +41,7 @@ export const initializeRozenite = (
   return {
     middleware: getMiddleware(
       allInstalledPlugins,
-      options.destroyOnDetachPlugins || [],
+      options.destroyOnDetachPlugins || []
     ),
     devModePackage,
   };

--- a/packages/middleware/src/index.ts
+++ b/packages/middleware/src/index.ts
@@ -6,6 +6,7 @@ import { getInstalledPlugins } from './auto-discovery.js';
 import type { RozeniteConfig } from './config.js';
 import { getDevModePackage } from './dev-mode.js';
 import { verifyReactNativeVersion } from './verify-react-native-version.js';
+import { getDevMiddlewarePath, getReactNativePackagePath } from './resolve.js';
 
 export type RozeniteMiddleware = Application;
 export type RozeniteInstance = {
@@ -17,6 +18,21 @@ export const initializeRozenite = (
   options: RozeniteConfig
 ): RozeniteInstance => {
   verifyReactNativeVersion(options.projectRoot);
+
+  if (process.env.ROZENITE_DEBUG === 'true') {
+    logger.debug('Rozenite is running in debug mode.');
+    logger.debug(`Resolution root: ${options.projectRoot}`);
+    logger.debug(
+      `Resolved react-native to: ${getReactNativePackagePath(
+        options.projectRoot
+      )}`
+    );
+    logger.debug(
+      `Resolved @react-native/dev-middleware to: ${getDevMiddlewarePath(
+        options.projectRoot
+      )}`
+    );
+  }
 
   const devModePackage = getDevModePackage(options.projectRoot);
 

--- a/packages/middleware/src/logger.ts
+++ b/packages/middleware/src/logger.ts
@@ -14,7 +14,7 @@ export const logger = {
   },
 
   debug: (message: string, ...args: unknown[]) => {
-    if (process.env.NODE_ENV === 'development') {
+    if (process.env.ROZENITE_DEBUG === 'true') {
       console.log(`${PREFIX} [DEBUG] ${message}`, ...args);
     }
   },

--- a/packages/middleware/src/resolve.ts
+++ b/packages/middleware/src/resolve.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 
 const require = createRequire(import.meta.url);
 
-const getReactNativePackagePath = (projectRoot: string): string => {
+export const getReactNativePackagePath = (projectRoot: string): string => {
   const input = require.resolve('react-native', { paths: [projectRoot] });
   return path.dirname(input);
 };

--- a/packages/middleware/src/verify-react-native-version.ts
+++ b/packages/middleware/src/verify-react-native-version.ts
@@ -1,0 +1,27 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import semver from 'semver';
+import { logger } from './logger.js';
+import { getReactNativePackagePath } from './resolve.js';
+
+const REQUIRED_REACT_NATIVE_VERSION = '0.76.0';
+
+export const verifyReactNativeVersion = (projectRoot: string): void => {
+  const reactNativePath = getReactNativePackagePath(projectRoot);
+  const packageJsonPath = path.join(reactNativePath, 'package.json');
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+  const reactNativeVersion = packageJson.version;
+
+  if (
+    semver.satisfies(reactNativeVersion, `>=${REQUIRED_REACT_NATIVE_VERSION}`)
+  ) {
+    return;
+  }
+
+  logger.error(
+    `React Native DevTools requires React Native ${REQUIRED_REACT_NATIVE_VERSION} or higher.\n` +
+      `   Current version: ${reactNativeVersion}\n` +
+      `   Please upgrade your React Native version to continue using Rozenite.`
+  );
+  process.exit(1);
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,7 +72,7 @@ importers:
         version: 0.76.9(@babel/core@7.28.0)(@babel/preset-env@7.28.0(@babel/core@7.28.0))
       '@react-native/metro-config':
         specifier: ~0.76.3
-        version: 0.76.9(@babel/preset-env@7.28.0(@babel/core@7.28.0))
+        version: 0.76.9(@babel/core@7.28.0)(@babel/preset-env@7.28.0(@babel/core@7.28.0))
       '@swc-node/register':
         specifier: ~1.9.1
         version: 1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.8.3)
@@ -331,7 +331,7 @@ importers:
     devDependencies:
       '@react-native/metro-config':
         specifier: ~0.76.0
-        version: 0.76.9(@babel/preset-env@7.28.0(@babel/core@7.28.0))
+        version: 0.76.9(@babel/core@7.28.0)(@babel/preset-env@7.28.0(@babel/core@7.28.0))
 
   packages/middleware:
     dependencies:
@@ -344,6 +344,9 @@ importers:
       express:
         specifier: ^5.1.0
         version: 5.1.0
+      semver:
+        specifier: ^7.7.2
+        version: 7.7.2
       serve-static:
         specifier: ^2.2.0
         version: 2.2.0
@@ -363,6 +366,9 @@ importers:
       '@types/express':
         specifier: ^5.0.3
         version: 5.0.3
+      '@types/semver':
+        specifier: ^7.7.0
+        version: 7.7.0
       '@types/serve-static':
         specifier: ^1.15.8
         version: 1.15.8
@@ -2871,6 +2877,8 @@ packages:
   '@react-native/babel-preset@0.76.0':
     resolution: {integrity: sha512-HgQt4MyuWLcnrIglXn7GNPPVwtzZ4ffX+SUisdhmPtJCHuP8AOU3HsgOKLhqVfEGWTBlE4kbWoTmmLU87IJaOw==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@babel/core': '*'
 
   '@react-native/babel-preset@0.76.9':
     resolution: {integrity: sha512-TbSeCplCM6WhL3hR2MjC/E1a9cRnMLz7i767T7mP90oWkklEjyPxWl+0GGoVGnJ8FC/jLUupg/HvREKjjif6lw==}
@@ -2922,10 +2930,14 @@ packages:
   '@react-native/metro-babel-transformer@0.76.0':
     resolution: {integrity: sha512-aq0MrjaOxDitSqQbttBcOt+5tjemCabhEX2gGthy8cNeZokBa2raoHQInDo9iBBN1ePKDCwKGypyC8zKA5dksQ==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@babel/core': '*'
 
   '@react-native/metro-babel-transformer@0.76.9':
     resolution: {integrity: sha512-HGq11347UHNiO/NvVbAO35hQCmH8YZRs7in7nVq7SL99pnpZK4WXwLdAXmSuwz5uYqOuwnKYDlpadz8fkE94Mg==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@babel/core': '*'
 
   '@react-native/metro-config@0.76.9':
     resolution: {integrity: sha512-LWsj7mUfujALUa+iGuEGzW4BqtuHa8zI3zS2T+uIjy2vI40+hRoP70iPOEiesNwVQTq/uSZELbe3HAo4WaX5gA==}
@@ -4124,6 +4136,9 @@ packages:
 
   '@types/semver@7.5.8':
     resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
+
+  '@types/semver@7.7.0':
+    resolution: {integrity: sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==}
 
   '@types/send@0.17.5':
     resolution: {integrity: sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==}
@@ -13701,7 +13716,7 @@ snapshots:
       - '@babel/preset-env'
       - supports-color
 
-  '@react-native/babel-preset@0.76.0(@babel/preset-env@7.28.0(@babel/core@7.28.0))':
+  '@react-native/babel-preset@0.76.0(@babel/core@7.28.0)(@babel/preset-env@7.28.0(@babel/core@7.28.0))':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-proposal-export-default-from': 7.27.1(@babel/core@7.28.0)
@@ -13831,10 +13846,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@react-native/community-cli-plugin@0.76.0(@babel/preset-env@7.28.0(@babel/core@7.28.0))(@react-native-community/cli-server-api@15.0.1)(encoding@0.1.13)':
+  '@react-native/community-cli-plugin@0.76.0(@babel/core@7.28.0)(@babel/preset-env@7.28.0(@babel/core@7.28.0))(@react-native-community/cli-server-api@15.0.1)(encoding@0.1.13)':
     dependencies:
       '@react-native/dev-middleware': 0.76.0
-      '@react-native/metro-babel-transformer': 0.76.0(@babel/preset-env@7.28.0(@babel/core@7.28.0))
+      '@react-native/metro-babel-transformer': 0.76.0(@babel/core@7.28.0)(@babel/preset-env@7.28.0(@babel/core@7.28.0))
       chalk: 4.1.2
       execa: 5.1.1
       invariant: 2.2.4
@@ -13846,6 +13861,7 @@ snapshots:
     optionalDependencies:
       '@react-native-community/cli-server-api': 15.0.1
     transitivePeerDependencies:
+      - '@babel/core'
       - '@babel/preset-env'
       - bufferutil
       - encoding
@@ -13878,17 +13894,17 @@ snapshots:
 
   '@react-native/js-polyfills@0.76.9': {}
 
-  '@react-native/metro-babel-transformer@0.76.0(@babel/preset-env@7.28.0(@babel/core@7.28.0))':
+  '@react-native/metro-babel-transformer@0.76.0(@babel/core@7.28.0)(@babel/preset-env@7.28.0(@babel/core@7.28.0))':
     dependencies:
       '@babel/core': 7.28.0
-      '@react-native/babel-preset': 0.76.0(@babel/preset-env@7.28.0(@babel/core@7.28.0))
+      '@react-native/babel-preset': 0.76.0(@babel/core@7.28.0)(@babel/preset-env@7.28.0(@babel/core@7.28.0))
       hermes-parser: 0.23.1
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - '@babel/preset-env'
       - supports-color
 
-  '@react-native/metro-babel-transformer@0.76.9(@babel/preset-env@7.28.0(@babel/core@7.28.0))':
+  '@react-native/metro-babel-transformer@0.76.9(@babel/core@7.28.0)(@babel/preset-env@7.28.0(@babel/core@7.28.0))':
     dependencies:
       '@babel/core': 7.28.0
       '@react-native/babel-preset': 0.76.9(@babel/core@7.28.0)(@babel/preset-env@7.28.0(@babel/core@7.28.0))
@@ -13898,13 +13914,14 @@ snapshots:
       - '@babel/preset-env'
       - supports-color
 
-  '@react-native/metro-config@0.76.9(@babel/preset-env@7.28.0(@babel/core@7.28.0))':
+  '@react-native/metro-config@0.76.9(@babel/core@7.28.0)(@babel/preset-env@7.28.0(@babel/core@7.28.0))':
     dependencies:
       '@react-native/js-polyfills': 0.76.9
-      '@react-native/metro-babel-transformer': 0.76.9(@babel/preset-env@7.28.0(@babel/core@7.28.0))
+      '@react-native/metro-babel-transformer': 0.76.9(@babel/core@7.28.0)(@babel/preset-env@7.28.0(@babel/core@7.28.0))
       metro-config: 0.81.5
       metro-runtime: 0.81.5
     transitivePeerDependencies:
+      - '@babel/core'
       - '@babel/preset-env'
       - supports-color
 
@@ -15590,6 +15607,8 @@ snapshots:
       '@types/node': 18.16.9
 
   '@types/semver@7.5.8': {}
+
+  '@types/semver@7.7.0': {}
 
   '@types/send@0.17.5':
     dependencies:
@@ -21842,7 +21861,7 @@ snapshots:
       '@jest/create-cache-key-function': 29.7.0
       '@react-native/assets-registry': 0.76.0
       '@react-native/codegen': 0.76.0(@babel/preset-env@7.28.0(@babel/core@7.28.0))
-      '@react-native/community-cli-plugin': 0.76.0(@babel/preset-env@7.28.0(@babel/core@7.28.0))(@react-native-community/cli-server-api@15.0.1)(encoding@0.1.13)
+      '@react-native/community-cli-plugin': 0.76.0(@babel/core@7.28.0)(@babel/preset-env@7.28.0(@babel/core@7.28.0))(@react-native-community/cli-server-api@15.0.1)(encoding@0.1.13)
       '@react-native/gradle-plugin': 0.76.0
       '@react-native/js-polyfills': 0.76.0
       '@react-native/normalize-colors': 0.76.0
@@ -21894,7 +21913,7 @@ snapshots:
       '@jest/create-cache-key-function': 29.7.0
       '@react-native/assets-registry': 0.76.0
       '@react-native/codegen': 0.76.0(@babel/preset-env@7.28.0(@babel/core@7.28.0))
-      '@react-native/community-cli-plugin': 0.76.0(@babel/preset-env@7.28.0(@babel/core@7.28.0))(@react-native-community/cli-server-api@15.0.1)(encoding@0.1.13)
+      '@react-native/community-cli-plugin': 0.76.0(@babel/core@7.28.0)(@babel/preset-env@7.28.0(@babel/core@7.28.0))(@react-native-community/cli-server-api@15.0.1)(encoding@0.1.13)
       '@react-native/gradle-plugin': 0.76.0
       '@react-native/js-polyfills': 0.76.0
       '@react-native/normalize-colors': 0.76.0
@@ -21946,7 +21965,7 @@ snapshots:
       '@jest/create-cache-key-function': 29.7.0
       '@react-native/assets-registry': 0.76.0
       '@react-native/codegen': 0.76.0(@babel/preset-env@7.28.0(@babel/core@7.28.0))
-      '@react-native/community-cli-plugin': 0.76.0(@babel/preset-env@7.28.0(@babel/core@7.28.0))(@react-native-community/cli-server-api@15.0.1)(encoding@0.1.13)
+      '@react-native/community-cli-plugin': 0.76.0(@babel/core@7.28.0)(@babel/preset-env@7.28.0(@babel/core@7.28.0))(@react-native-community/cli-server-api@15.0.1)(encoding@0.1.13)
       '@react-native/gradle-plugin': 0.76.0
       '@react-native/js-polyfills': 0.76.0
       '@react-native/normalize-colors': 0.76.0


### PR DESCRIPTION
Added React Native version verification to prevent Rozenite from starting on unsupported versions, improving user experience by providing clear feedback when the tool doesn't load in older React Native DevTools. Enhanced logging capabilities through the introduction of ROZENITE_DEBUG environment variable, enabling additional logging for dependency resolution processes.

Closes #29