### PR TITLE
feat(middleware): resolve dev middleware from Expo

### DIFF
--- a/packages/middleware/src/resolve.ts
+++ b/packages/middleware/src/resolve.ts
@@ -8,13 +8,58 @@ export const getReactNativePackagePath = (projectRoot: string): string => {
   return path.dirname(input);
 };
 
-export const getDevMiddlewarePath = (projectRoot: string): string => {
+export const getExpoPackagePath = (projectRoot: string): string | null => {
+  try {
+    const input = require.resolve('expo', { paths: [projectRoot] });
+    return path.dirname(input);
+  } catch (error) {
+    // Check if error is due to non-existing package
+    if (
+      error &&
+      typeof error === 'object' &&
+      'code' in error &&
+      error.code === 'MODULE_NOT_FOUND'
+    ) {
+      return null;
+    }
+
+    throw error;
+  }
+};
+
+const getDevMiddlewarePathFromExpo = (projectRoot: string): string | null => {
+  const expoPackagePath = getExpoPackagePath(projectRoot);
+
+  if (!expoPackagePath) {
+    return null;
+  }
+
+  const expoCliPath = require.resolve('@expo/cli', {
+    paths: [expoPackagePath],
+  });
+
+  return require.resolve('@react-native/dev-middleware', {
+    paths: [expoCliPath],
+  });
+};
+
+const getDevMiddlewarePathFromReactNative = (projectRoot: string): string => {
+  const reactNativePackagePath = getReactNativePackagePath(projectRoot);
+
   const reactNativeCommunityCliPluginPath = require.resolve(
     '@react-native/community-cli-plugin',
-    { paths: [getReactNativePackagePath(projectRoot)] }
+    { paths: [reactNativePackagePath] }
   );
 
   return require.resolve('@react-native/dev-middleware', {
     paths: [reactNativeCommunityCliPluginPath],
   });
+};
+
+export const getDevMiddlewarePath = (projectRoot: string): string => {
+  // If this is an Expo project, we need to resolve the dev middleware from the Expo package.
+  return (
+    getDevMiddlewarePathFromExpo(projectRoot) ??
+    getDevMiddlewarePathFromReactNative(projectRoot)
+  );
 };


### PR DESCRIPTION
This pull request updates the algorithm used to resolve @react-native/dev-middleware. Rozenite will now attempt to resolve the package from Expo (if available), and fall back to React Native if not. This should fix occasional issues with Rozenite not loading correctly.