### PR TITLE
fix(plugin-bridge): delay in message processing

### DIFF
--- a/.nx/version-plans/version-plan-1754476732875.md
+++ b/.nx/version-plans/version-plan-1754476732875.md
@@ -1,0 +1,5 @@
+---
+'@rozenite/plugin-bridge': prerelease
+---
+
+This pull request fixes an issue where promises started in message handlers were significantly delayed, sometimes by nearly 10 seconds. The exact cause is unknown, but I suspect it’s related to them originating from the 'execute code' action on the DevTools side. A similar issue was previously observed during domain initialization. The same fix has been applied, and it appears to be working correctly now.

--- a/packages/plugin-bridge/src/channel/factory.ts
+++ b/packages/plugin-bridge/src/channel/factory.ts
@@ -2,12 +2,22 @@ import { getCdpChannel } from './device/cdp-channel';
 import { getPanelChannel } from './browser/panel-channel';
 import { Channel } from './types';
 
-export const getChannel = async (): Promise<Channel> => {
-  const isPanel = '__ROZENITE_PANEL__' in window;
+let channel: Promise<Channel> | Channel | null = null;
 
-  if (isPanel) {
-    return getPanelChannel();
+export const getChannel = async (): Promise<Channel> => {
+  // Channel can be safely reused, because it's not scoped to the plugin.
+
+  if (channel) {
+    return channel;
   }
 
-  return getCdpChannel();
+  const isPanel = '__ROZENITE_PANEL__' in window;
+  channel = isPanel ? getPanelChannel() : getCdpChannel();
+
+  // Replace promise with channel when it's ready.
+  channel.then((instance) => {
+    channel = instance;
+  });
+
+  return channel;
 };


### PR DESCRIPTION
This pull request fixes an issue where promises started in message handlers were significantly delayed, sometimes by nearly 10 seconds. The exact cause is unknown, but I suspect it’s related to them originating from the 'execute code' action on the DevTools side. A similar issue was previously observed during domain initialization. The same fix has been applied, and it appears to be working correctly now.