### PR TITLE
fix(network-activity-plugin): handle 204 on response

### DIFF
--- a/.nx/version-plans/version-plan-1754935600331.md
+++ b/.nx/version-plans/version-plan-1754935600331.md
@@ -1,0 +1,5 @@
+---
+'@rozenite/network-activity-plugin': prerelease
+---
+
+Resolved an issue in the Network Activity Plugin (204 requests). The issue was caused by receiving a response with status code 204 and no content. The original code attempted to check the .size property on a null object.

--- a/packages/network-activity-plugin/src/react-native/http/network-inspector.ts
+++ b/packages/network-activity-plugin/src/react-native/http/network-inspector.ts
@@ -6,6 +6,11 @@ import { XHRInterceptor } from './xhr-interceptor';
 const networkRequestsRegistry = getNetworkRequestsRegistry();
 
 const getResponseSize = (request: XMLHttpRequest): number => {
+  // Handle a case of 204 where no-content was sent.
+  if (request.response === null) {
+    return 0;
+  }
+
   if (typeof request.response === 'object') {
     return request.response.size;
   }


### PR DESCRIPTION
If the user gets 204, No-Content the `.size` will fail.


Issue is that Javascript returned true to the following statement
`typeof null === 'object'` -> `true`

Added some code to handle that case. 

