### PR TITLE
fix(plugin-bridge): crash on web

### DIFF
--- a/.nx/version-plans/version-plan-1754894014540.md
+++ b/.nx/version-plans/version-plan-1754894014540.md
@@ -1,0 +1,5 @@
+---
+'@rozenite/plugin-bridge': prerelease
+---
+
+The communication layer provided by React Native DevTools is not available on the web; therefore, we should not attempt to create a client when the 'web' platform is detected. Instead, a warning will be printed indicating that the platform is unsupported.

--- a/packages/plugin-bridge/src/channel/device/cdp-channel.ts
+++ b/packages/plugin-bridge/src/channel/device/cdp-channel.ts
@@ -1,4 +1,6 @@
+import { isWeb } from '../../web.js';
 import { Channel } from '../types.js';
+import { UnsupportedPlatformError } from '../../errors.js';
 
 export type CdpMessageListener = (message: unknown) => void;
 
@@ -117,5 +119,9 @@ const getCdpDomainProxy = async (): Promise<Channel> => {
 };
 
 export const getCdpChannel = async (): Promise<Channel> => {
+  if (isWeb()) {
+    throw new UnsupportedPlatformError('web');
+  }
+
   return getCdpDomainProxy();
 };

--- a/packages/plugin-bridge/src/channel/factory.ts
+++ b/packages/plugin-bridge/src/channel/factory.ts
@@ -15,9 +15,14 @@ export const getChannel = async (): Promise<Channel> => {
   channel = isPanel ? getPanelChannel() : getCdpChannel();
 
   // Replace promise with channel when it's ready.
-  channel.then((instance) => {
-    channel = instance;
-  });
+  channel
+    .then((instance) => {
+      channel = instance;
+    })
+    .catch(() => {
+      // Silently handle rejections to prevent uncaught promise rejections
+      // The error will still be propagated to the caller through the returned promise
+    });
 
   return channel;
 };

--- a/packages/plugin-bridge/src/channel/factory.ts
+++ b/packages/plugin-bridge/src/channel/factory.ts
@@ -12,17 +12,15 @@ export const getChannel = async (): Promise<Channel> => {
   }
 
   const isPanel = '__ROZENITE_PANEL__' in window;
-  channel = isPanel ? getPanelChannel() : getCdpChannel();
+  const channelPromise = isPanel ? getPanelChannel() : getCdpChannel();
 
-  // Replace promise with channel when it's ready.
-  channel
-    .then((instance) => {
-      channel = instance;
-    })
-    .catch(() => {
-      // Silently handle rejections to prevent uncaught promise rejections
-      // The error will still be propagated to the caller through the returned promise
-    });
-
-  return channel;
+  try {
+    const instance = await channelPromise;
+    channel = instance;
+    return instance;
+  } catch (error) {
+    // Clear the cached promise on error so subsequent calls can retry
+    channel = null;
+    throw error;
+  }
 };

--- a/packages/plugin-bridge/src/client.ts
+++ b/packages/plugin-bridge/src/client.ts
@@ -1,6 +1,8 @@
 import { getChannel } from './channel/factory.js';
 import { getDevToolsMessage } from './message';
 import { Subscription } from './types';
+import { isWeb } from './web.js';
+import { UnsupportedPlatformError } from './errors.js';
 
 const clients = new Map<
   string,
@@ -91,6 +93,10 @@ export const getRozeniteDevToolsClient = async <
 >(
   pluginId: string
 ): Promise<RozeniteDevToolsClient<TEventMap>> => {
+  if (isWeb()) {
+    throw new UnsupportedPlatformError('web');
+  }
+
   const existingClient = clients.get(pluginId);
 
   if (existingClient != null) {

--- a/packages/plugin-bridge/src/client.ts
+++ b/packages/plugin-bridge/src/client.ts
@@ -1,8 +1,6 @@
 import { getChannel } from './channel/factory.js';
 import { getDevToolsMessage } from './message';
 import { Subscription } from './types';
-import { isWeb } from './web.js';
-import { UnsupportedPlatformError } from './errors.js';
 
 const clients = new Map<
   string,
@@ -93,10 +91,6 @@ export const getRozeniteDevToolsClient = async <
 >(
   pluginId: string
 ): Promise<RozeniteDevToolsClient<TEventMap>> => {
-  if (isWeb()) {
-    throw new UnsupportedPlatformError('web');
-  }
-
   const existingClient = clients.get(pluginId);
 
   if (existingClient != null) {

--- a/packages/plugin-bridge/src/errors.ts
+++ b/packages/plugin-bridge/src/errors.ts
@@ -1,0 +1,6 @@
+export class UnsupportedPlatformError extends Error {
+  constructor(platform: string) {
+    super(`Unsupported platform: ${platform}`);
+    this.name = 'UnsupportedPlatformError';
+  }
+}

--- a/packages/plugin-bridge/src/index.ts
+++ b/packages/plugin-bridge/src/index.ts
@@ -3,3 +3,4 @@ export type { RozeniteDevToolsClient } from './client';
 export type { Subscription } from './types';
 export type { UseRozeniteDevToolsClientOptions } from './useRozeniteDevToolsClient';
 export { getRozeniteDevToolsClient } from './client';
+export { UnsupportedPlatformError } from './errors';

--- a/packages/plugin-bridge/src/useRozeniteDevToolsClient.ts
+++ b/packages/plugin-bridge/src/useRozeniteDevToolsClient.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { RozeniteDevToolsClient, getRozeniteDevToolsClient } from './client';
+import { UnsupportedPlatformError } from './errors';
 
 export type UseRozeniteDevToolsClientOptions<
   TEventMap extends Record<string, unknown> = Record<string, unknown>
@@ -30,7 +31,17 @@ export const useRozeniteDevToolsClient = <
           setClient(client);
         }
       } catch (error) {
+        if (error instanceof UnsupportedPlatformError) {
+          // We don't want to show an error for unsupported platforms.
+          // It's expected that the client will be null.
+          console.warn(
+            `[Rozenite, ${pluginId}] Unsupported platform, skipping setup.`
+          );
+          return;
+        }
+
         console.error('Error setting up client', error);
+
         if (isMounted) {
           setError(error);
         }

--- a/packages/plugin-bridge/src/web.ts
+++ b/packages/plugin-bridge/src/web.ts
@@ -1,0 +1,6 @@
+export const isWeb = (): boolean => {
+  // Checking for window.document to not depend on the 'react-native' package.
+  return (
+    typeof window !== 'undefined' && typeof window.document !== 'undefined'
+  );
+};


### PR DESCRIPTION
The communication layer provided by React Native DevTools is not available on the web; therefore, we should not attempt to create a client when the 'web' platform is detected. Instead, a warning will be printed indicating that the platform is unsupported.

Closes #21 