### PR TITLE
fix(metro): detect bundle mode and prevent hanging

### DIFF
--- a/.nx/version-plans/version-plan-1754897026339.md
+++ b/.nx/version-plans/version-plan-1754897026339.md
@@ -1,0 +1,5 @@
+---
+'@rozenite/metro': prerelease
+---
+
+Introduces the 'enhanceMetroConfig 'configuration property, designed to apply Metro config plugins like Expo Atlas and Redux DevTools. Unlike the previous method, the function passed to this property won’t run during bundling, which helps prevent the Metro process from hanging indefinitely with certain plugins (such as Redux DevTools).

--- a/apps/playground/metro.config.js
+++ b/apps/playground/metro.config.js
@@ -37,17 +37,17 @@ const customConfig = {
 };
 
 module.exports = withRozenite(
-  withRozeniteExpoAtlasPlugin(
-    withRozeniteReduxDevTools(
-      withNxMetro(mergeConfig(defaultConfig, customConfig), {
-        // Change this to true to see debugging info.
-        // Useful if you have issues resolving modules
-        debug: false,
-        // all the file extensions used for imports other than 'ts', 'tsx', 'js', 'jsx', 'json'
-        extensions: [],
-        // Specify folders to watch, in addition to Nx defaults (workspace libraries and node_modules)
-        // watchFolders: ["../../packages/expo-atlas-plugin"],
-      })
-    )
-  )
+  withNxMetro(mergeConfig(defaultConfig, customConfig), {
+    // Change this to true to see debugging info.
+    // Useful if you have issues resolving modules
+    debug: false,
+    // all the file extensions used for imports other than 'ts', 'tsx', 'js', 'jsx', 'json'
+    extensions: [],
+    // Specify folders to watch, in addition to Nx defaults (workspace libraries and node_modules)
+    // watchFolders: ["../../packages/expo-atlas-plugin"],
+  }),
+  {
+    enhanceMetroConfig: (config) =>
+      withRozeniteExpoAtlasPlugin(withRozeniteReduxDevTools(config)),
+  }
 );

--- a/packages/metro/src/is-bundling.ts
+++ b/packages/metro/src/is-bundling.ts
@@ -1,0 +1,31 @@
+import { getBinaryRelativePath } from './packages.js';
+
+export const isBundling = (projectRoot: string): boolean => {
+  const executablePath = process.argv[1];
+  const command = process.argv[2];
+
+  // Relative -> expo/bin/cli.js | react-native/cli.js
+  const expoBinRelativePath = getBinaryRelativePath(projectRoot, 'expo');
+  const reactNativeBinRelativePath = getBinaryRelativePath(
+    projectRoot,
+    'react-native'
+  );
+
+  if (
+    expoBinRelativePath &&
+    executablePath.endsWith(expoBinRelativePath) &&
+    command === 'export'
+  ) {
+    return true;
+  }
+
+  if (
+    reactNativeBinRelativePath &&
+    executablePath.endsWith(reactNativeBinRelativePath) &&
+    command === 'bundle'
+  ) {
+    return true;
+  }
+
+  return false;
+};

--- a/packages/metro/src/packages.ts
+++ b/packages/metro/src/packages.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+export const getBinaryRelativePath = (
+  projectRoot: string,
+  packageName: string
+): string | null => {
+  try {
+    const packagePath = require.resolve(`${packageName}/package.json`, {
+      paths: [projectRoot],
+    });
+    const packageJson = JSON.parse(readFileSync(packagePath, 'utf8'));
+    const binRelativePath = packageJson.bin?.[packageName];
+
+    if (!binRelativePath) {
+      return null;
+    }
+
+    return path.join(packageName, binRelativePath);
+  } catch {
+    return null;
+  }
+};

--- a/website/src/docs/official-plugins/expo-atlas.mdx
+++ b/website/src/docs/official-plugins/expo-atlas.mdx
@@ -30,8 +30,9 @@ const config = {
   // Your existing Metro configuration
 };
 
-module.exports = withRozenite(withRozeniteExpoAtlasPlugin(config), {
+module.exports = withRozenite(config, {
   // Your Rozenite configuration
+  enhanceMetroConfig: (config) => withRozeniteExpoAtlasPlugin(config),
 });
 ```
 

--- a/website/src/docs/official-plugins/redux-devtools.mdx
+++ b/website/src/docs/official-plugins/redux-devtools.mdx
@@ -58,10 +58,18 @@ export default store;
 Wrap your Metro configuration with `withRozeniteReduxDevTools`:
 
 ```javascript title="metro.config.js"
-import { withRozeniteReduxDevTools } from '@rozenite/redux-devtools-plugin/metro';
+const { withRozenite } = require('@rozenite/metro');
+const {
+  withRozeniteReduxDevTools,
+} = require('@rozenite/redux-devtools-plugin/metro');
 
-export default withRozeniteReduxDevTools({
-  // your existing metro config
+const config = {
+  // Your existing Metro configuration
+};
+
+module.exports = withRozenite(config, {
+  // Your Rozenite configuration
+  enhanceMetroConfig: (config) => withRozeniteReduxDevTools(config),
 });
 ```
 


### PR DESCRIPTION
Introduces the 'enhanceMetroConfig 'configuration property, designed to apply Metro config plugins like Expo Atlas and Redux DevTools. Unlike the previous method, the function passed to this property won’t run during bundling, which helps prevent the Metro process from hanging indefinitely with certain plugins (such as Redux DevTools).