### PR TITLE
fix: do not execute plugins on 'web' and 'server' environments

### DIFF
--- a/.nx/version-plans/version-plan-1754922503856.md
+++ b/.nx/version-plans/version-plan-1754922503856.md
@@ -1,0 +1,9 @@
+---
+'@rozenite/metro': prerelease
+'@rozenite/network-activity-plugin': prerelease
+'@rozenite/mmkv-plugin': prerelease
+'@rozenite/tanstack-query-plugin': prerelease
+'@rozenite/react-devtools-plugin': prerelease
+---
+
+We are going to prevent any logic from being executed on both 'web' and 'server' environments. Additionally, there was a change needed in Metro to resolve missing WebSocketInterceptor in react-native-web environment.

--- a/packages/metro/src/index.ts
+++ b/packages/metro/src/index.ts
@@ -61,6 +61,25 @@ export const withRozenite = async <T extends MetroConfig>(
             ),
           }
         : resolvedConfig.resolver?.extraNodeModules,
+      resolveRequest: (context, moduleName, platform) => {
+        // Unfortunately, 'web' doesn't include certain internal modules like 'react-native/Libraries/WebSocket/WebSocketInterceptor'.
+        // This is currently the only module that we need to mock, but it may change in the future.
+        if (
+          moduleName === 'react-native/Libraries/WebSocket/WebSocketInterceptor'
+        ) {
+          return {
+            type: 'empty',
+          };
+        }
+
+        return (
+          resolvedConfig.resolver?.resolveRequest?.(
+            context,
+            moduleName,
+            platform
+          ) ?? context.resolveRequest(context, moduleName, platform)
+        );
+      },
     },
     server: {
       ...resolvedConfig.server,

--- a/packages/mmkv-plugin/react-native.ts
+++ b/packages/mmkv-plugin/react-native.ts
@@ -1,6 +1,11 @@
 export let useMMKVDevTools: typeof import('./src/react-native/useMMKVDevTools').useMMKVDevTools;
 
-if (process.env.NODE_ENV !== 'production') {
+const isWeb =
+  typeof window !== 'undefined' && window.navigator.product !== 'ReactNative';
+const isDev = process.env.NODE_ENV !== 'production';
+const isServer = typeof window === 'undefined';
+
+if (isDev && !isWeb && !isServer) {
   useMMKVDevTools =
     require('./src/react-native/useMMKVDevTools').useMMKVDevTools;
 } else {

--- a/packages/network-activity-plugin/react-native.ts
+++ b/packages/network-activity-plugin/react-native.ts
@@ -1,6 +1,11 @@
 export let useNetworkActivityDevTools: typeof import('./src/react-native/useNetworkActivityDevTools').useNetworkActivityDevTools;
 
-if (process.env.NODE_ENV !== 'production') {
+const isWeb =
+  typeof window !== 'undefined' && window.navigator.product !== 'ReactNative';
+const isDev = process.env.NODE_ENV !== 'production';
+const isServer = typeof window === 'undefined';
+
+if (isDev && !isWeb && !isServer) {
   useNetworkActivityDevTools =
     require('./src/react-native/useNetworkActivityDevTools').useNetworkActivityDevTools;
 } else {

--- a/packages/network-activity-plugin/src/react-native/http/xhr-interceptor.ts
+++ b/packages/network-activity-plugin/src/react-native/http/xhr-interceptor.ts
@@ -11,6 +11,7 @@ import { XHRPostData } from '../../shared/client';
  * Source: https://github.com/facebook/react-native/blob/2c683c5787dd03ac15d2aad45dcc53650529ee7f/packages/react-native/src/private/devsupport/devmenu/elementinspector/XHRInterceptor.js
  */
 
+const XMLHttpRequest = global.XMLHttpRequest || window.XMLHttpRequest;
 const originalXHROpen = XMLHttpRequest.prototype.open;
 const originalXHRSend = XMLHttpRequest.prototype.send;
 const originalXHRSetRequestHeader = XMLHttpRequest.prototype.setRequestHeader;

--- a/packages/redux-devtools-plugin/react-native.ts
+++ b/packages/redux-devtools-plugin/react-native.ts
@@ -1,6 +1,11 @@
 export let rozeniteDevToolsEnhancer: typeof import('./src/runtime').rozeniteDevToolsEnhancer;
 
-if (process.env.NODE_ENV !== 'production') {
+const isWeb =
+  typeof window !== 'undefined' && window.navigator.product !== 'ReactNative';
+const isDev = process.env.NODE_ENV !== 'production';
+const isServer = typeof window === 'undefined';
+
+if (isDev && !isWeb && !isServer) {
   rozeniteDevToolsEnhancer = require('./src/runtime').rozeniteDevToolsEnhancer;
 } else {
   rozeniteDevToolsEnhancer =

--- a/packages/tanstack-query-plugin/react-native.ts
+++ b/packages/tanstack-query-plugin/react-native.ts
@@ -1,6 +1,11 @@
 export let useTanStackQueryDevTools: typeof import('./src/react-native/useTanStackQueryDevTools').useTanStackQueryDevTools;
 
-if (process.env.NODE_ENV !== 'production') {
+const isWeb =
+  typeof window !== 'undefined' && window.navigator.product !== 'ReactNative';
+const isDev = process.env.NODE_ENV !== 'production';
+const isServer = typeof window === 'undefined';
+
+if (isDev && !isWeb && !isServer) {
   useTanStackQueryDevTools =
     require('./src/react-native/useTanStackQueryDevTools').useTanStackQueryDevTools;
 } else {


### PR DESCRIPTION
We are going to prevent any logic from being executed on both 'web' and 'server' environments. Additionally, there was a change needed in Metro to resolve missing WebSocketInterceptor in react-native-web environment.