### PR TITLE
feat(middleware): add log level

### DIFF
--- a/.nx/version-plans/version-plan-1755761792813.md
+++ b/.nx/version-plans/version-plan-1755761792813.md
@@ -1,0 +1,8 @@
+---
+'@rozenite/metro': prerelease
+'@rozenite/repack': prerelease
+'@rozenite/middleware': prerelease
+'@rozenite/redux-devtools-plugin': prerelease
+---
+
+It's now possible to set the log level of the internal Rozenite logger, which will propagate to all official plugins and be applied whenever it is possible to set the logging level for third-party libraries.

--- a/packages/metro/src/index.ts
+++ b/packages/metro/src/index.ts
@@ -24,7 +24,6 @@ export const withRozenite = async <T extends MetroConfig>(
   const projectRoot = resolvedConfig.projectRoot ?? process.cwd();
 
   if (isBundling(projectRoot)) {
-    console.info('[Rozenite] Skipping initialization for bundling');
     return resolvedConfig;
   }
 

--- a/packages/middleware/src/config.ts
+++ b/packages/middleware/src/config.ts
@@ -1,3 +1,5 @@
+import { RozeniteLogLevel } from './logger.js';
+
 export type RozeniteProjectType = 'expo' | 'react-native-cli';
 
 export type RozeniteConfig = {
@@ -17,4 +19,10 @@ export type RozeniteConfig = {
    * Useful if built-in heuristics fail to detect the project type.
    */
   projectType?: RozeniteProjectType;
+
+  /**
+   * The log level to use.
+   * @default 'info'
+   */
+  logLevel?: RozeniteLogLevel;
 };

--- a/packages/middleware/src/index.ts
+++ b/packages/middleware/src/index.ts
@@ -17,17 +17,21 @@ export type RozeniteInstance = {
 export const initializeRozenite = (
   options: RozeniteConfig
 ): RozeniteInstance => {
+  options.logLevel =
+    process.env.ROZENITE_DEBUG === 'true'
+      ? 'debug'
+      : options.logLevel ?? 'info';
+  logger.setLevel(options.logLevel);
+
   verifyReactNativeVersion(options.projectRoot);
 
-  if (process.env.ROZENITE_DEBUG === 'true') {
-    logger.debug('Rozenite is running in debug mode.');
-    logger.debug(`Resolution root: ${options.projectRoot}`);
-    logger.debug(
-      `Resolved react-native to: ${getReactNativePackagePath(
-        options.projectRoot
-      )}`
-    );
-  }
+  logger.debug('Rozenite is running in debug mode.');
+  logger.debug(`Resolution root: ${options.projectRoot}`);
+  logger.debug(
+    `Resolved react-native to: ${getReactNativePackagePath(
+      options.projectRoot
+    )}`
+  );
 
   const devModePackage = getDevModePackage(options.projectRoot);
 

--- a/packages/middleware/src/logger.ts
+++ b/packages/middleware/src/logger.ts
@@ -1,21 +1,57 @@
+export type RozeniteLogLevel = 'none' | 'error' | 'warn' | 'info' | 'debug';
+
 const PREFIX = '[Rozenite]';
 
-export const logger = {
-  info: (message: string, ...args: unknown[]) => {
+const LOG_LEVELS: Record<RozeniteLogLevel, number> = {
+  none: 0,
+  error: 1,
+  warn: 2,
+  info: 3,
+  debug: 4,
+};
+
+let logLevel: RozeniteLogLevel = 'info';
+
+const setLevel = (level: RozeniteLogLevel) => {
+  logLevel = level;
+
+  // Temporarily set the log level in the environment variable for the plugins
+  // to use it in their own logging.
+  process.env.ROZENITE_LOG_LEVEL = level;
+};
+
+const shouldLog = (messageLevel: RozeniteLogLevel): boolean => {
+  return LOG_LEVELS[messageLevel] <= LOG_LEVELS[logLevel];
+};
+
+const info = (message: string, ...args: unknown[]) => {
+  if (shouldLog('info')) {
     console.log(`${PREFIX} ${message}`, ...args);
-  },
+  }
+};
 
-  warn: (message: string, ...args: unknown[]) => {
+const warn = (message: string, ...args: unknown[]) => {
+  if (shouldLog('warn')) {
     console.warn(`${PREFIX} ${message}`, ...args);
-  },
+  }
+};
 
-  error: (message: string, ...args: unknown[]) => {
+const error = (message: string, ...args: unknown[]) => {
+  if (shouldLog('error')) {
     console.error(`${PREFIX} ${message}`, ...args);
-  },
+  }
+};
 
-  debug: (message: string, ...args: unknown[]) => {
-    if (process.env.ROZENITE_DEBUG === 'true') {
-      console.log(`${PREFIX} [DEBUG] ${message}`, ...args);
-    }
-  },
+const debug = (message: string, ...args: unknown[]) => {
+  if (shouldLog('debug')) {
+    console.log(`${PREFIX} [DEBUG] ${message}`, ...args);
+  }
+};
+
+export const logger = {
+  setLevel,
+  info,
+  warn,
+  error,
+  debug,
 };

--- a/packages/redux-devtools-plugin/src/metro.ts
+++ b/packages/redux-devtools-plugin/src/metro.ts
@@ -11,6 +11,8 @@ export const withRozeniteReduxDevTools = <
     setupWebSocketRelay({
       hostname: 'localhost',
       port: REDUX_DEVTOOLS_PORT,
+      // This environment variable is set by Rozenite middleware.
+      logLevel: process.env.ROZENITE_LOG_LEVEL,
     });
   });
 


### PR DESCRIPTION
It's now possible to set the log level of the internal Rozenite logger, which will propagate to all official plugins and be applied whenever it is possible to set the logging level for third-party libraries.