### PR TITLE
proposal: make withRozenite composable

### DIFF
--- a/packages/metro/src/index.ts
+++ b/packages/metro/src/index.ts
@@ -16,11 +16,35 @@ export type RozeniteMetroConfig<TMetroConfig = unknown> = Omit<
   ) => Promise<TMetroConfig> | TMetroConfig;
 };
 
-export const withRozenite = async <T extends MetroConfig>(
+export function withRozenite<T extends MetroConfig>(
+  config: () => Promise<T>,
+  options: RozeniteMetroConfig<T>
+): Promise<T>
+export function withRozenite<T extends MetroConfig>(
+  config: () => T,
+  options: RozeniteMetroConfig<T>
+): T
+export function withRozenite<T extends MetroConfig>(
+  config: Promise<T>,
+  options: RozeniteMetroConfig<T>
+): Promise<T>
+export function withRozenite<T extends MetroConfig>(
+  config: T,
+  options: RozeniteMetroConfig<T>
+): T
+export function withRozenite<T extends MetroConfig>(
   config: T | Promise<T>,
   options: RozeniteMetroConfig<T> = {}
-): Promise<T> => {
-  const resolvedConfig = await config;
+): Promise<T> | T {
+  if (typeof config === 'function') {
+    config = config()
+  }
+
+  if (config instanceof Promise) {
+    return config.then(config => withRozenite(config, options))
+  }
+
+  const resolvedConfig = config;
   const projectRoot = resolvedConfig.projectRoot ?? process.cwd();
 
   if (isBundling(projectRoot)) {


### PR DESCRIPTION
This is a proposal PR to make `withRozenite` composable - meaning it retains the shape of the `MetroConfig` passed into it and doesn't automatically turn it into a `Promise<MetroConfig>` - which is not accepted by a number of libraries. It also allows passing a function to `withRozenite` as `metro.config.js` which is a valid export of `metro.config.js`

This change would also make `enhanceMetroConfig` redundant, as you could compose the configs together.

For example, if `withRozeniteExpoAtlasPlugin` also implemented this pattern you could compose them together

```js
withRozeniteExpoAtlasPlugin(withRozenite(config))
```

I'm just skimming through the project, so if there is a deeper reason for `enhanceMetroConfig` feel free to close this PR 😄 I created this as a PR instead of an issue to demonstrate how it could be implemented.