### PR TITLE
feat: handle multiple bundlers

### DIFF
--- a/packages/cli/src/commands/init-command.ts
+++ b/packages/cli/src/commands/init-command.ts
@@ -1,32 +1,19 @@
 import {
   getProjectType,
-  getBundlerType,
-  type BundlerType,
-  UnknownBundlerType,
+  type BundlerType
 } from '@rozenite/tools';
-import { intro, outro, promptConfirm } from '../utils/prompts.js';
+import { getAvailableBundlerTypes } from 'node_modules/@rozenite/tools/src/project-type.js';
+import { wrapConfigFile } from '../utils/config-wrapper.js';
+import { isGitRepositoryClean } from '../utils/git.js';
+import { logger } from '../utils/logger.js';
 import {
   getExecForPackageManager,
   installDevDependency,
   isProject,
 } from '../utils/packages.js';
+import { intro, outro, promptConfirm } from '../utils/prompts.js';
 import { spawn } from '../utils/spawn.js';
-import { wrapConfigFile } from '../utils/config-wrapper.js';
 import { step } from '../utils/steps.js';
-import { isGitRepositoryClean } from '../utils/git.js';
-import { logger } from '../utils/logger.js';
-
-const safeGetBundlerType = (projectRoot: string): BundlerType | null => {
-  try {
-    return getBundlerType(projectRoot);
-  } catch (error) {
-    if (error instanceof UnknownBundlerType) {
-      return null;
-    }
-
-    throw error;
-  }
-};
 
 const formatBundlerType = (bundlerType: BundlerType): string => {
   return bundlerType === 'metro' ? 'Metro' : 'Re.Pack';
@@ -41,7 +28,7 @@ export const initCommand = async (projectRoot: string) => {
   }
 
   const projectType = getProjectType(projectRoot);
-  let bundlerType = safeGetBundlerType(projectRoot);
+  const bundlerTypes = getAvailableBundlerTypes(projectRoot);
   const isClean = await isGitRepositoryClean(projectRoot);
 
   // Check if project has uncommitted changes
@@ -52,7 +39,7 @@ export const initCommand = async (projectRoot: string) => {
   }
 
   // Create Metro configuration for Expo projects
-  if (projectType === 'expo' && bundlerType === null) {
+  if (projectType === 'expo' && !bundlerTypes.length) {
     await step(
       {
         start: 'Creating Metro configuration for Expo project...',
@@ -69,42 +56,44 @@ export const initCommand = async (projectRoot: string) => {
         );
       }
     );
-    bundlerType = 'metro';
+    bundlerTypes.push('metro');
   }
 
-  if (bundlerType === null) {
+  if (!bundlerTypes.length) {
     throw new Error(
       'Could not determine bundler type. Please ensure you have a metro.config.js or rspack.config.js file.'
     );
   }
 
-  // Install the appropriate Rozenite package
-  const packageName =
-    bundlerType === 'metro' ? '@rozenite/metro' : '@rozenite/repack';
+  for (const bundlerType of bundlerTypes) {
+    // Install the appropriate Rozenite package
+    const packageName =
+      bundlerType === 'metro' ? '@rozenite/metro' : '@rozenite/repack';
 
-  await step(
-    {
-      start: `Installing ${packageName}...`,
-      stop: `${packageName} installed`,
-      error: `Failed to install ${packageName}`,
-    },
-    async () => {
-      await installDevDependency(projectRoot, packageName);
-    }
-  );
+    await step(
+      {
+        start: `Installing ${packageName}...`,
+        stop: `${packageName} installed`,
+        error: `Failed to install ${packageName}`,
+      },
+      async () => {
+        await installDevDependency(projectRoot, packageName);
+      }
+    );
 
-  // Wrap the configuration file
-  const formattedBundlerType = formatBundlerType(bundlerType);
-  await step(
-    {
-      start: `Configuring ${formattedBundlerType} to use Rozenite...`,
-      stop: `${formattedBundlerType} configuration updated`,
-      error: `Failed to update ${formattedBundlerType} configuration`,
-    },
-    async () => {
-      await wrapConfigFile(projectRoot, bundlerType);
-    }
-  );
+    // Wrap the configuration file
+    const formattedBundlerType = formatBundlerType(bundlerType);
+    await step(
+      {
+        start: `Configuring ${formattedBundlerType} to use Rozenite...`,
+        stop: `${formattedBundlerType} configuration updated`,
+        error: `Failed to update ${formattedBundlerType} configuration`,
+      },
+      async () => {
+        await wrapConfigFile(projectRoot, bundlerType);
+      }
+    );
+  }
 
   outro('You are now ready to use Rozenite!');
 };

--- a/packages/tools/src/project-type.ts
+++ b/packages/tools/src/project-type.ts
@@ -1,5 +1,5 @@
-import path from 'node:path';
 import fs from 'node:fs';
+import path from 'node:path';
 
 const MODULE_EXTENSIONS = ['.js', '.mjs', '.cjs', '.ts', '.cts', '.mts'];
 const METRO_CONFIG_FILE = 'metro.config.js';
@@ -61,14 +61,26 @@ export const getProjectType = (projectRoot: string): ProjectType => {
   return 'react-native-cli';
 };
 
-export const getBundlerType = (projectRoot: string): BundlerType => {
+export const getAvailableBundlerTypes = (projectRoot: string): BundlerType[] => {
+  const bundlers: BundlerType[] = [];
+
   if (isSourceFilePresent(projectRoot, METRO_CONFIG_FILE)) {
-    return 'metro';
+    bundlers.push('metro');
   }
 
   if (isSourceFilePresent(projectRoot, REPACK_CONFIG_FILE)) {
-    return 'repack';
+    bundlers.push('repack');
   }
 
-  throw new UnknownBundlerType(projectRoot);
+  return bundlers;
+}
+
+export const getBundlerType = (projectRoot: string): BundlerType => {
+  const [bundlerType] = getAvailableBundlerTypes(projectRoot);
+
+  if (!bundlerType) {
+    throw new UnknownBundlerType(projectRoot);
+  }
+
+  return bundlerType;
 };


### PR DESCRIPTION
While creating a new app with RePack, you can find both `metro.config` and `rspack.config` files.

At the moment, the CLI is giving priority to Metro, so if you want to also configure RePack you have to delete Metro's config first. This PR address this behaviour.