### PR TITLE
fix(metro): bundling in Xcode

### DIFF
--- a/.nx/version-plans/version-plan-1757063298892.md
+++ b/.nx/version-plans/version-plan-1757063298892.md
@@ -1,0 +1,5 @@
+---
+'@rozenite/metro': prerelease
+---
+
+Rozenite will no longer apply plugins during app bundling initiated by Xcode.

--- a/packages/metro/src/is-bundling.ts
+++ b/packages/metro/src/is-bundling.ts
@@ -38,6 +38,10 @@ export const isBundling = (projectRoot: string): boolean => {
     if (executablePath.endsWith('node_modules/.bin/react-native')) {
       return true;
     }
+
+    if (reactNativeBinRelativePath && executablePath.endsWith('scripts/bundle.js')) {
+      return true;
+    }
   }
 
   return false;

--- a/packages/metro/src/is-bundling.ts
+++ b/packages/metro/src/is-bundling.ts
@@ -40,10 +40,7 @@ export const isBundling = (projectRoot: string): boolean => {
     }
 
     // Check Xcode's bundle.js script
-    if (
-      reactNativeBinRelativePath &&
-      reactNativeBinRelativePath.endsWith('scripts/bundle.js')
-    ) {
+    if (executablePath.endsWith('scripts/bundle.js')) {
       return true;
     }
   }

--- a/packages/metro/src/is-bundling.ts
+++ b/packages/metro/src/is-bundling.ts
@@ -39,7 +39,11 @@ export const isBundling = (projectRoot: string): boolean => {
       return true;
     }
 
-    if (reactNativeBinRelativePath && executablePath.endsWith('scripts/bundle.js')) {
+    // Check Xcode's bundle.js script
+    if (
+      reactNativeBinRelativePath &&
+      reactNativeBinRelativePath.endsWith('scripts/bundle.js')
+    ) {
       return true;
     }
   }


### PR DESCRIPTION
When creating a build to test in TestFlight, i have encountered that it is infinitely in building process.

Debug the issue and found out that isBundling is always false and will setup the metro config with incorrect values

<img width="774" height="693" alt="image" src="https://github.com/user-attachments/assets/75c50974-c131-4cf8-96d9-fa7aef36ea69" />
