### PR TITLE
fix(metro): prevent hanging in EAS builds

### DIFF
--- a/packages/metro/src/is-bundling.ts
+++ b/packages/metro/src/is-bundling.ts
@@ -11,6 +11,23 @@ export const isBundling = (projectRoot: string): boolean => {
     'react-native'
   );
 
+  // Special case: no exports
+  const expoEasBinRelativePath = 'eas-cli/bin/run';
+
+  // Check for Expo EAS bundling
+  if (command === 'build') {
+    if (
+      expoEasBinRelativePath &&
+      executablePath.endsWith(expoEasBinRelativePath)
+    ) {
+      return true;
+    }
+
+    if (executablePath.endsWith('node_modules/.bin/eas')) {
+      return true;
+    }
+  }
+
   // Check for Expo bundling
   if (command === 'export') {
     // Check direct binary path


### PR DESCRIPTION
Currently, if the Redux DevTools plugin is used, the build process hangs when using EAS, since another CLI is involved in orchestrating the build. This quick fix is intended to prevent that and give me time to develop a more resilient solution.