### PR TITLE
feat(metro): expose enabled property

### DIFF
--- a/apps/playground/metro.config.js
+++ b/apps/playground/metro.config.js
@@ -47,6 +47,7 @@ module.exports = withRozenite(
     // watchFolders: ["../../packages/expo-atlas-plugin"],
   }),
   {
+    enabled: true,
     enhanceMetroConfig: (config) =>
       withRozeniteExpoAtlasPlugin(withRozeniteReduxDevTools(config)),
   }

--- a/packages/metro/package.json
+++ b/packages/metro/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@rozenite/middleware": "workspace:*",
+    "@rozenite/tools": "workspace:*",
     "tslib": "^2.3.0"
   },
   "devDependencies": {

--- a/packages/metro/src/index.ts
+++ b/packages/metro/src/index.ts
@@ -1,5 +1,6 @@
 import { type MetroConfig } from '@react-native/metro-config';
 import { initializeRozenite, type RozeniteConfig } from '@rozenite/middleware';
+import { logger } from '@rozenite/tools';
 import path from 'node:path';
 import { isBundling } from './is-bundling.js';
 
@@ -7,6 +8,12 @@ export type RozeniteMetroConfig<TMetroConfig = unknown> = Omit<
   RozeniteConfig,
   'projectRoot'
 > & {
+  /**
+   * Whether to enable Rozenite.
+   * If false, Rozenite will not be initialized and the config will be returned as is.
+   * @default false
+   */
+  enabled?: boolean;
   /**
    * Certain Rozenite plugins require Metro to be configured in a specific way.
    * This option allows you to modify the Metro config in a way that is safe to do when bundling.
@@ -23,7 +30,21 @@ export const withRozenite = async <T extends MetroConfig>(
   const resolvedConfig = await config;
   const projectRoot = resolvedConfig.projectRoot ?? process.cwd();
 
-  if (isBundling(projectRoot)) {
+  if (options.enabled === undefined) {
+    logger.info(
+      'Rozenite will no longer be enabled by default in the next version.'
+    );
+    logger.info(
+      'To continue using Rozenite, please set `enabled` in the options.'
+    );
+    logger.info('Remember to make it conditional to avoid bundling issues.');
+
+    if (isBundling(projectRoot)) {
+      return resolvedConfig;
+    }
+  }
+
+  if (options.enabled === false) {
     return resolvedConfig;
   }
 

--- a/packages/metro/tsconfig.lib.json
+++ b/packages/metro/tsconfig.lib.json
@@ -13,6 +13,9 @@
   "include": ["src/**/*.ts"],
   "references": [
     {
+      "path": "../tools/tsconfig.lib.json"
+    },
+    {
       "path": "../middleware/tsconfig.lib.json"
     }
   ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -337,6 +337,9 @@ importers:
       '@rozenite/middleware':
         specifier: workspace:*
         version: link:../middleware
+      '@rozenite/tools':
+        specifier: workspace:*
+        version: link:../tools
       tslib:
         specifier: ^2.3.0
         version: 2.8.1


### PR DESCRIPTION
Unfortunately, the React Native ecosystem is so diverse that it's difficult to keep up with all the ways Metro is invoked by the React Native CLI and Expo. Instead of constantly chasing edge cases and adding new scripts to the "probably bundling" list, users will now be able to conditionally enable Rozenite in development by providing the enabled option. This option can be set via an environment variable - for example, if ROZENITE_ENABLED is set, the option will be true. This change will significantly reduce maintenance overhead and make Rozenite even more versatile.