### PR TITLE
feat(network-activity-plugin): Override and mock network responses

### DIFF
--- a/packages/network-activity-plugin/src/react-native/http/network-inspector.ts
+++ b/packages/network-activity-plugin/src/react-native/http/network-inspector.ts
@@ -294,6 +294,9 @@ export const getNetworkInspector = (
       Object.defineProperty(request, 'responseType', {
         writable: true,
       });
+      Object.defineProperty(request, 'status', {
+        writable: true,
+      });
       Object.defineProperty(request, 'response', {
         writable: true,
       });
@@ -302,7 +305,8 @@ export const getNetworkInspector = (
       });
 
       request.responseType = 'json';
-
+      // @ts-expect-error - Mocking status
+      request.status = override.status;
       // @ts-expect-error - Mocking response
       request.response = override.body;
       // @ts-expect-error - Mocking responseText

--- a/packages/network-activity-plugin/src/react-native/http/overrides-registry.ts
+++ b/packages/network-activity-plugin/src/react-native/http/overrides-registry.ts
@@ -1,0 +1,32 @@
+import { RequestOverride } from '../../shared/client';
+
+export type OverridesRegistry = {
+  setOverrides: (newOverrides: [string, RequestOverride][]) => void;
+  getOverrideForUrl: (url: string) => RequestOverride | undefined;
+};
+
+const createOverridesRegistry = (): OverridesRegistry => {
+  let overrides = new Map<string, RequestOverride>();
+
+  const setOverrides = (newOverrides: [string, RequestOverride][]) => {
+    overrides = new Map(newOverrides);
+  };
+
+  const getOverrideForUrl = (url: string) => {
+    return overrides.get(url);
+  };
+
+  return {
+    setOverrides,
+    getOverrideForUrl,
+  };
+};
+
+let registryInstance: OverridesRegistry | null = null;
+
+export const getOverridesRegistry = (): OverridesRegistry => {
+  if (!registryInstance) {
+    registryInstance = createOverridesRegistry();
+  }
+  return registryInstance;
+};

--- a/packages/network-activity-plugin/src/react-native/http/xhr-interceptor.ts
+++ b/packages/network-activity-plugin/src/react-native/http/xhr-interceptor.ts
@@ -49,11 +49,14 @@ type XHRInterceptorResponseCallback = (
   request: XMLHttpRequest
 ) => void;
 
+type XHRInterceptorOverrideCallback = (request: XMLHttpRequest) => void;
+
 let openCallback: XHRInterceptorOpenCallback | null;
 let sendCallback: XHRInterceptorSendCallback | null;
 let requestHeaderCallback: XHRInterceptorRequestHeaderCallback | null;
 let headerReceivedCallback: XHRInterceptorHeaderReceivedCallback | null;
 let responseCallback: XHRInterceptorResponseCallback | null;
+let overrideCallback: XHRInterceptorOverrideCallback | null;
 
 let isInterceptorEnabled = false;
 
@@ -98,6 +101,13 @@ export const XHRInterceptor = {
    */
   setRequestHeaderCallback(callback: XHRInterceptorRequestHeaderCallback) {
     requestHeaderCallback = callback;
+  },
+
+  /**
+   * Invoked before XMLHttpRequest.send(...) is called.
+   */
+  setOverrideCallback(callback: XHRInterceptorOverrideCallback) {
+    overrideCallback = callback;
   },
 
   isInterceptorEnabled(): boolean {
@@ -181,6 +191,10 @@ export const XHRInterceptor = {
                   this
                 );
               }
+
+              if (overrideCallback) {
+                overrideCallback(this);
+              }
             }
           },
           false
@@ -210,5 +224,6 @@ export const XHRInterceptor = {
     sendCallback = null;
     headerReceivedCallback = null;
     requestHeaderCallback = null;
+    overrideCallback = null;
   },
 };

--- a/packages/network-activity-plugin/src/react-native/useNetworkActivityDevTools.ts
+++ b/packages/network-activity-plugin/src/react-native/useNetworkActivityDevTools.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { useRozeniteDevToolsClient } from '@rozenite/plugin-bridge';
 import { getNetworkInspector } from './http/network-inspector';
+import { getOverridesRegistry } from './http/overrides-registry';
 import { NetworkActivityEventMap } from '../shared/client';
 import { getWebSocketInspector } from './websocket/websocket-inspector';
 import { WebSocketEventMap } from '../shared/websocket-events';
@@ -12,6 +13,8 @@ import {
   NetworkActivityDevToolsConfig,
   validateConfig,
 } from './config';
+
+const overridesRegistry = getOverridesRegistry();
 
 export const useNetworkActivityDevTools = (
   config: NetworkActivityDevToolsConfig = DEFAULT_CONFIG
@@ -45,6 +48,9 @@ export const useNetworkActivityDevTools = (
       }),
       client.onMessage('network-disable', () => {
         isRecordingEnabledRef.current = false;
+      }),
+      client.onMessage('set-overrides', (data) => {
+        overridesRegistry.setOverrides(data.overrides);
       }),
     ];
 

--- a/packages/network-activity-plugin/src/shared/client.ts
+++ b/packages/network-activity-plugin/src/shared/client.ts
@@ -84,6 +84,12 @@ export type Initiator = {
 
 export type ResourceType = 'XHR' | 'Fetch' | 'Other';
 
+export type RequestOverride = {
+  status?: number;
+  headers?: HttpHeaders;
+  body?: string;
+};
+
 export type NetworkActivityEventMap = {
   // Control events
   'network-enable': unknown;
@@ -128,6 +134,10 @@ export type NetworkActivityEventMap = {
   'response-body': {
     requestId: RequestId;
     body: string | null;
+  };
+
+  'set-overrides': {
+    overrides: [string, RequestOverride][];
   };
 } & WebSocketEventMap &
   SSEEventMap;

--- a/packages/network-activity-plugin/src/shared/client.ts
+++ b/packages/network-activity-plugin/src/shared/client.ts
@@ -86,7 +86,6 @@ export type ResourceType = 'XHR' | 'Fetch' | 'Other';
 
 export type RequestOverride = {
   status?: number;
-  headers?: HttpHeaders;
   body?: string;
 };
 

--- a/packages/network-activity-plugin/src/ui/components/CodeEditor.tsx
+++ b/packages/network-activity-plugin/src/ui/components/CodeEditor.tsx
@@ -1,0 +1,27 @@
+import { forwardRef } from 'react';
+import { cn } from '../utils/cn';
+
+export type CodeEditorProps = {
+  data: string | null;
+  onInput?: (event: React.FormEvent<HTMLPreElement>) => void;
+};
+
+export const CodeEditor = forwardRef<HTMLPreElement, CodeEditorProps>(
+  ({ data, onInput }, ref) => {
+    return (
+      <pre
+        ref={ref}
+        contentEditable
+        suppressContentEditableWarning
+        className={
+          'w-full text-sm font-mono text-gray-300 whitespace-pre-wrap bg-gray-800 p-3 rounded-md border border-gray-700 overflow-x-auto wrap-anywhere ring-offset-blue-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
+        }
+        onInput={onInput}
+      >
+        {data}
+      </pre>
+    );
+  }
+);
+
+CodeEditor.displayName = 'CodeEditor';

--- a/packages/network-activity-plugin/src/ui/components/CodeEditor.tsx
+++ b/packages/network-activity-plugin/src/ui/components/CodeEditor.tsx
@@ -1,8 +1,7 @@
 import { forwardRef } from 'react';
-import { cn } from '../utils/cn';
 
 export type CodeEditorProps = {
-  data: string | null;
+  data: string | undefined;
   onInput?: (event: React.FormEvent<HTMLPreElement>) => void;
 };
 

--- a/packages/network-activity-plugin/src/ui/components/OverrideActions.tsx
+++ b/packages/network-activity-plugin/src/ui/components/OverrideActions.tsx
@@ -1,9 +1,10 @@
 import { Check, CircleSlash2, Pencil } from 'lucide-react';
 import { Button } from './Button';
+import { RequestOverride } from '../../shared/client';
 
 export type OverrideActionsProps = {
-  currentData: string | null;
-  initialData: string | null;
+  currentData: RequestOverride | undefined;
+  initialData: RequestOverride | undefined;
   onOverride: () => void;
   onSaveOverride: () => void;
   onClear: () => void;
@@ -16,9 +17,11 @@ export const OverrideActions = ({
   onSaveOverride,
   onClear,
 }: OverrideActionsProps) => {
-  const hasChanges = currentData !== initialData;
+  const hasChanges =
+    currentData?.body !== initialData?.body ||
+    currentData?.status !== initialData?.status;
 
-  const hasOverride = initialData !== null;
+  const hasOverride = initialData !== undefined;
 
   const AddOverrideAction = (
     <Button

--- a/packages/network-activity-plugin/src/ui/components/OverrideActions.tsx
+++ b/packages/network-activity-plugin/src/ui/components/OverrideActions.tsx
@@ -1,0 +1,67 @@
+import { Check, CircleSlash2, Pencil } from 'lucide-react';
+import { Button } from './Button';
+
+export type OverrideActionsProps = {
+  currentData: string | null;
+  initialData: string | null;
+  onOverride: () => void;
+  onSaveOverride: () => void;
+  onClear: () => void;
+};
+
+export const OverrideActions = ({
+  currentData,
+  initialData,
+  onOverride,
+  onSaveOverride,
+  onClear,
+}: OverrideActionsProps) => {
+  const hasChanges = currentData !== initialData;
+
+  const hasOverride = initialData !== null;
+
+  const AddOverrideAction = (
+    <Button
+      variant="ghost"
+      size="xs"
+      className="text-violet-300 hover:text-violet-300"
+      onClick={onOverride}
+    >
+      <Pencil className="h-2 w-2" />
+      Override
+    </Button>
+  );
+
+  const SaveOverrideAction = (
+    <Button
+      variant="ghost"
+      size="xs"
+      className="text-violet-300 hover:text-violet-300"
+      onClick={onSaveOverride}
+      disabled={!hasChanges}
+    >
+      <Check className="h-2 w-2" />
+      {hasChanges ? 'Save override' : 'Saved'}
+    </Button>
+  );
+
+  const ClearOverrideAction = (
+    <Button
+      variant="ghost"
+      size="xs"
+      className="text-violet-300 hover:text-violet-300 ms-2"
+      onClick={onClear}
+    >
+      <CircleSlash2 className="h-2 w-2" />
+      Clear override
+    </Button>
+  );
+
+  return (
+    <>
+      {hasOverride && ClearOverrideAction}
+
+      {hasOverride ? SaveOverrideAction : AddOverrideAction}
+    </>
+  );
+};

--- a/packages/network-activity-plugin/src/ui/components/RequestList.tsx
+++ b/packages/network-activity-plugin/src/ui/components/RequestList.tsx
@@ -9,9 +9,10 @@ import {
   useReactTable,
 } from '@tanstack/react-table';
 import { ProcessedRequest } from '../state/model';
-import { RequestId } from '../../shared/client';
+import { RequestId, RequestOverride } from '../../shared/client';
 import {
   useNetworkActivityActions,
+  useOverrides,
   useProcessedRequests,
   useSelectedRequestId,
 } from '../state/hooks';
@@ -30,6 +31,7 @@ type NetworkRequest = {
   time: string;
   type: string;
   startTime: string;
+  hasOverride: boolean;
 };
 
 const formatSize = (bytes: number): string => {
@@ -122,11 +124,13 @@ const sortTime: SortingFn<NetworkRequest> = (rowA, rowB, columnId) => {
 };
 
 const processNetworkRequests = (
-  processedRequests: ProcessedRequest[]
+  processedRequests: ProcessedRequest[],
+  overrides: Map<string, RequestOverride>
 ): NetworkRequest[] => {
   return processedRequests.map((request): NetworkRequest => {
     const { domain, path } = extractDomainAndPath(request.name);
     const duration = request.duration || 0;
+    const hasOverride = overrides.has(request.name);
 
     return {
       id: request.id,
@@ -139,6 +143,7 @@ const processNetworkRequests = (
       time: formatDuration(duration),
       type: request.type,
       startTime: formatStartTime(request.timestamp),
+      hasOverride: hasOverride,
     };
   });
 };
@@ -157,6 +162,10 @@ const columns = [
     cell: ({ row, getValue }) => (
       <div className="flex-1 min-w-0 truncate" title={row.original.path}>
         {getValue()}
+
+        {row.original.hasOverride && (
+          <span className="w-2 h-2 rounded-full bg-violet-300 ms-2 inline-block"></span>
+        )}
       </div>
     ),
     sortingFn: 'alphanumeric',
@@ -212,6 +221,7 @@ export const RequestList = ({ filter }: RequestListProps) => {
   const processedRequests = useProcessedRequests();
   const selectedRequestId = useSelectedRequestId();
   const [sorting, setSorting] = useState<SortingState>([]);
+  const overrides = useOverrides();
 
   // Filter requests based on current filter state
   const filteredRequests = useMemo(() => {
@@ -240,8 +250,8 @@ export const RequestList = ({ filter }: RequestListProps) => {
   }, [processedRequests, filter]);
 
   const requests = useMemo(() => {
-    return processNetworkRequests(filteredRequests);
-  }, [filteredRequests]);
+    return processNetworkRequests(filteredRequests, overrides);
+  }, [filteredRequests, overrides]);
 
   const table = useReactTable({
     data: requests,

--- a/packages/network-activity-plugin/src/ui/components/RequestList.tsx
+++ b/packages/network-activity-plugin/src/ui/components/RequestList.tsx
@@ -155,10 +155,7 @@ const columns = [
   columnHelper.accessor('name', {
     header: 'Name',
     cell: ({ row, getValue }) => (
-      <div 
-        className="flex-1 min-w-0 truncate"
-        title={row.original.path}
-      >
+      <div className="flex-1 min-w-0 truncate" title={row.original.path}>
         {getValue()}
       </div>
     ),

--- a/packages/network-activity-plugin/src/ui/components/Section.tsx
+++ b/packages/network-activity-plugin/src/ui/components/Section.tsx
@@ -5,12 +5,14 @@ export type SectionProps = {
   title: string;
   children: React.ReactNode;
   collapsible?: boolean;
+  action?: React.ReactNode;
 };
 
 export const Section = ({
   title,
   children,
   collapsible = true,
+  action,
 }: SectionProps) => {
   const [isCollapsed, setIsCollapsed] = useState(false);
 
@@ -34,7 +36,9 @@ export const Section = ({
         {collapsible && (
           <span className={cn('mr-2', { 'rotate-90': !isCollapsed })}>▶</span>
         )}
-        <span className="font-medium">{title}</span>
+        <span className="font-medium me-auto">{title}</span>
+
+        {action}
       </button>
       {isChildrenVisible && children}
     </div>

--- a/packages/network-activity-plugin/src/ui/components/SidePanel.tsx
+++ b/packages/network-activity-plugin/src/ui/components/SidePanel.tsx
@@ -10,6 +10,7 @@ import { X } from 'lucide-react';
 import {
   useNetworkActivityActions,
   useNetworkActivityStore,
+  useOverrides,
   useSelectedRequest,
 } from '../state/hooks';
 import { NetworkEntry as OldNetworkEntry } from '../types';
@@ -85,6 +86,7 @@ export const SidePanel = () => {
   const actions = useNetworkActivityActions();
   const selectedRequest = useSelectedRequest();
   const client = useNetworkActivityStore((state) => state._client);
+  const overrides = useOverrides();
 
   const onClose = (): void => {
     actions.setSelectedRequest(null);
@@ -128,6 +130,9 @@ export const SidePanel = () => {
     legacyNetworkEntries.set(legacyEntry.requestId, legacyEntry);
   }
 
+  const override = legacyEntry !== null ? overrides.get(legacyEntry.url) : null;
+  const hasResponseOverride = override && override.body ? true : false;
+
   const getTabsListTriggers = () => {
     if (httpDetails) {
       return (
@@ -149,6 +154,9 @@ export const SidePanel = () => {
             className="data-[state=active]:bg-gray-700"
           >
             Response
+            {hasResponseOverride && (
+              <span className="w-2 h-2 rounded-full bg-violet-300 ms-2 inline-block"></span>
+            )}
           </TabsTrigger>
           <TabsTrigger
             value="cookies"

--- a/packages/network-activity-plugin/src/ui/state/hooks.ts
+++ b/packages/network-activity-plugin/src/ui/state/hooks.ts
@@ -42,3 +42,7 @@ export const useWebSocketMessages = (requestId: string) => {
     (state) => state.websocketMessages.get(requestId) || []
   );
 };
+
+export const useOverrides = () => {
+  return useNetworkActivityStore((state) => state.overrides);
+};

--- a/packages/network-activity-plugin/src/ui/state/store.ts
+++ b/packages/network-activity-plugin/src/ui/state/store.ts
@@ -1,7 +1,9 @@
 import { createStore } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
 import {
   NetworkActivityDevToolsClient,
   NetworkActivityEventMap,
+  RequestOverride,
   RequestId,
 } from '../../shared/client';
 import {
@@ -26,6 +28,7 @@ export interface NetworkActivityState {
   selectedRequestId: RequestId | null;
   networkEntries: Map<RequestId, NetworkEntry>;
   websocketMessages: Map<RequestId, WebSocketMessage[]>;
+  overrides: Map<string, RequestOverride>;
 
   // Internal state (not exposed in interface)
   _unsubscribeFunctions?: Array<{ remove: () => void }>;
@@ -36,6 +39,8 @@ export interface NetworkActivityState {
     setRecording: (isRecording: boolean) => void;
     setSelectedRequest: (requestId: RequestId | null) => void;
     clearRequests: () => void;
+    addOverride: (requestUrl: string, override: RequestOverride) => void;
+    clearOverride: (requestUrl: string) => void;
   };
 
   // Event handling
@@ -52,513 +57,595 @@ export interface NetworkActivityState {
 }
 
 export const createNetworkActivityStore = () =>
-  createStore<NetworkActivityState>((set, get) => ({
-    // Initial state
-    isRecording: false,
-    selectedRequestId: null,
-    networkEntries: new Map(),
-    websocketMessages: new Map(),
+  createStore<NetworkActivityState>()(
+    persist(
+      (set, get) => ({
+        // Initial state
+        isRecording: false,
+        selectedRequestId: null,
+        networkEntries: new Map(),
+        websocketMessages: new Map(),
+        overrides: new Map(),
 
-    // Actions
-    actions: {
-      setRecording: (isRecording: boolean) => {
-        const { _client } = get();
-        assert(!!_client, 'Client is not set');
+        // Actions
+        actions: {
+          setRecording: (isRecording: boolean) => {
+            const { _client } = get();
+            assert(!!_client, 'Client is not set');
 
-        _client.send(isRecording ? 'network-enable' : 'network-disable', {});
-        set({ isRecording });
-      },
-      setSelectedRequest: (requestId: RequestId | null) =>
-        set({ selectedRequestId: requestId }),
-      clearRequests: () =>
-        set({
-          networkEntries: new Map(),
-          websocketMessages: new Map(),
-          selectedRequestId: null,
-        }),
-    },
-    // Event handling
-    handleEvent: <K extends keyof NetworkActivityEventMap>(
-      eventType: K,
-      data: NetworkActivityEventMap[K]
-    ) => {
-      switch (eventType) {
-        case 'request-sent': {
-          const eventData = data as NetworkActivityEventMap['request-sent'];
-          set((state) => {
-            const headersWithContentType = applyReactNativeRequestHeadersLogic(
-              eventData.request.headers,
-              eventData.request.postData
+            _client.send(
+              isRecording ? 'network-enable' : 'network-disable',
+              {}
             );
+            set({ isRecording });
+          },
+          setSelectedRequest: (requestId: RequestId | null) =>
+            set({ selectedRequestId: requestId }),
+          clearRequests: () =>
+            set({
+              networkEntries: new Map(),
+              websocketMessages: new Map(),
+              selectedRequestId: null,
+            }),
+          addOverride: (requestUrl: string, override: RequestOverride) => {
+            const { overrides, _client } = get();
+            assert(!!_client, 'Client is not set');
 
-            const requestContentType =
-              getContentTypeMime(headersWithContentType) || 'text/plain';
+            const newOverrides = new Map(overrides);
+            newOverrides.set(requestUrl, override);
 
-            const entry: HttpNetworkEntry = {
-              id: eventData.requestId,
-              type: 'http',
-              timestamp: eventData.timestamp,
-              request: {
-                url: eventData.request.url,
-                method: eventData.request.method,
-                headers: headersWithContentType,
-                body: eventData.request.postData
-                  ? {
-                      type: requestContentType,
-                      data: eventData.request.postData,
-                    }
-                  : undefined,
-              },
-              status: 'pending',
-              initiator: eventData.initiator,
-              resourceType: eventData.type,
-            };
+            _client.send('set-overrides', {
+              overrides: Array.from(newOverrides.entries()),
+            });
+            set({ overrides: newOverrides });
+          },
+          clearOverride: (requestUrl: string) => {
+            const { overrides, _client } = get();
+            assert(!!_client, 'Client is not set');
 
-            const newEntries = new Map(state.networkEntries);
-            newEntries.set(eventData.requestId, entry);
-            return { networkEntries: newEntries };
-          });
-          break;
-        }
+            const newOverrides = new Map(overrides);
+            newOverrides.delete(requestUrl);
 
-        case 'response-received': {
-          const eventData =
-            data as NetworkActivityEventMap['response-received'];
-          set((state) => {
-            const entry = state.networkEntries.get(eventData.requestId);
-            if (!entry || entry.type !== 'http') return state;
+            _client.send('set-overrides', {
+              overrides: Array.from(newOverrides.entries()),
+            });
+            set({ overrides: newOverrides });
+          },
+          cleaaAllOverrides: () => {
+            const { _client } = get();
+            assert(!!_client, 'Client is not set');
 
-            const httpEntry = entry as HttpNetworkEntry;
-            const updatedEntry: HttpNetworkEntry = {
-              ...httpEntry,
-              status: 'loading',
-              response: eventData.response,
-            };
+            _client.send('set-overrides', { overrides: [] });
+            set({ overrides: new Map() });
+          },
+        },
+        // Event handling
+        handleEvent: <K extends keyof NetworkActivityEventMap>(
+          eventType: K,
+          data: NetworkActivityEventMap[K]
+        ) => {
+          switch (eventType) {
+            case 'request-sent': {
+              const eventData = data as NetworkActivityEventMap['request-sent'];
+              set((state) => {
+                const headersWithContentType =
+                  applyReactNativeRequestHeadersLogic(
+                    eventData.request.headers,
+                    eventData.request.postData
+                  );
 
-            const newEntries = new Map(state.networkEntries);
-            newEntries.set(eventData.requestId, updatedEntry);
-            return { networkEntries: newEntries };
-          });
-          break;
-        }
+                const requestContentType =
+                  getContentTypeMime(headersWithContentType) || 'text/plain';
 
-        case 'request-completed': {
-          const eventData =
-            data as NetworkActivityEventMap['request-completed'];
-          set((state) => {
-            const entry = state.networkEntries.get(eventData.requestId);
-            if (!entry || entry.type !== 'http') return state;
-
-            const httpEntry = entry as HttpNetworkEntry;
-            const updatedEntry: HttpNetworkEntry = {
-              ...httpEntry,
-              status: 'finished',
-              duration: eventData.duration,
-              size: eventData.size,
-              ttfb: eventData.ttfb,
-            };
-
-            const newEntries = new Map(state.networkEntries);
-            newEntries.set(eventData.requestId, updatedEntry);
-            return { networkEntries: newEntries };
-          });
-          break;
-        }
-
-        case 'request-failed': {
-          const eventData = data as NetworkActivityEventMap['request-failed'];
-          set((state) => {
-            const entry = state.networkEntries.get(eventData.requestId);
-            if (!entry || entry.type !== 'http') return state;
-
-            const httpEntry = entry as HttpNetworkEntry;
-            const updatedEntry: HttpNetworkEntry = {
-              ...httpEntry,
-              status: 'failed',
-              error: eventData.error,
-            };
-
-            const newEntries = new Map(state.networkEntries);
-            newEntries.set(eventData.requestId, updatedEntry);
-            return { networkEntries: newEntries };
-          });
-          break;
-        }
-
-        case 'response-body': {
-          const eventData = data as NetworkActivityEventMap['response-body'];
-          set((state) => {
-            const entry = state.networkEntries.get(eventData.requestId);
-            if (!entry || entry.type !== 'http') return state;
-
-            const httpEntry = entry as HttpNetworkEntry;
-            const updatedEntry: HttpNetworkEntry = {
-              ...httpEntry,
-              response: httpEntry.response
-                ? {
-                    ...httpEntry.response,
-                    body: eventData.body
+                const entry: HttpNetworkEntry = {
+                  id: eventData.requestId,
+                  type: 'http',
+                  timestamp: eventData.timestamp,
+                  request: {
+                    url: eventData.request.url,
+                    method: eventData.request.method,
+                    headers: headersWithContentType,
+                    body: eventData.request.postData
                       ? {
-                          type:
-                            getContentTypeMime(
-                              httpEntry.response?.headers ?? {}
-                            ) || 'text/plain',
-                          data: eventData.body,
+                          type: requestContentType,
+                          data: eventData.request.postData,
                         }
                       : undefined,
-                  }
-                : undefined,
-            };
+                  },
+                  status: 'pending',
+                  initiator: eventData.initiator,
+                  resourceType: eventData.type,
+                };
 
-            const newEntries = new Map(state.networkEntries);
-            newEntries.set(eventData.requestId, updatedEntry);
-            return { networkEntries: newEntries };
-          });
-          break;
-        }
+                const newEntries = new Map(state.networkEntries);
+                newEntries.set(eventData.requestId, entry);
+                return { networkEntries: newEntries };
+              });
+              break;
+            }
 
-        case 'websocket-connect': {
-          const eventData =
-            data as NetworkActivityEventMap['websocket-connect'];
-          set((state) => {
-            const entry: WebSocketNetworkEntry = {
-              id: `ws-${eventData.socketId}`,
-              type: 'websocket',
-              timestamp: eventData.timestamp,
-              connection: {
-                url: eventData.url,
-                socketId: eventData.socketId,
-                protocols: eventData.protocols || undefined,
-                options: eventData.options,
-              },
-              status: 'connecting',
-            };
+            case 'response-received': {
+              const eventData =
+                data as NetworkActivityEventMap['response-received'];
+              set((state) => {
+                const entry = state.networkEntries.get(eventData.requestId);
+                if (!entry || entry.type !== 'http') return state;
 
-            const newEntries = new Map(state.networkEntries);
-            newEntries.set(entry.id, entry);
+                const httpEntry = entry as HttpNetworkEntry;
+                const updatedEntry: HttpNetworkEntry = {
+                  ...httpEntry,
+                  status: 'loading',
+                  response: eventData.response,
+                };
 
-            const newMessages = new Map(state.websocketMessages);
-            newMessages.set(entry.id, []);
+                const newEntries = new Map(state.networkEntries);
+                newEntries.set(eventData.requestId, updatedEntry);
+                return { networkEntries: newEntries };
+              });
+              break;
+            }
 
-            return {
-              networkEntries: newEntries,
-              websocketMessages: newMessages,
-            };
-          });
-          break;
-        }
+            case 'request-completed': {
+              const eventData =
+                data as NetworkActivityEventMap['request-completed'];
+              set((state) => {
+                const entry = state.networkEntries.get(eventData.requestId);
+                if (!entry || entry.type !== 'http') return state;
 
-        case 'websocket-open': {
-          const eventData = data as NetworkActivityEventMap['websocket-open'];
-          set((state) => {
-            const entry = state.networkEntries.get(`ws-${eventData.socketId}`);
-            if (!entry || entry.type !== 'websocket') return state;
+                const httpEntry = entry as HttpNetworkEntry;
+                const updatedEntry: HttpNetworkEntry = {
+                  ...httpEntry,
+                  status: 'finished',
+                  duration: eventData.duration,
+                  size: eventData.size,
+                  ttfb: eventData.ttfb,
+                };
 
-            const wsEntry = entry as WebSocketNetworkEntry;
-            const updatedEntry: WebSocketNetworkEntry = {
-              ...wsEntry,
-              status: 'open',
-            };
+                const newEntries = new Map(state.networkEntries);
+                newEntries.set(eventData.requestId, updatedEntry);
+                return { networkEntries: newEntries };
+              });
+              break;
+            }
 
-            const newEntries = new Map(state.networkEntries);
-            newEntries.set(entry.id, updatedEntry);
-            return { networkEntries: newEntries };
-          });
-          break;
-        }
+            case 'request-failed': {
+              const eventData =
+                data as NetworkActivityEventMap['request-failed'];
+              set((state) => {
+                const entry = state.networkEntries.get(eventData.requestId);
+                if (!entry || entry.type !== 'http') return state;
 
-        case 'websocket-close': {
-          const eventData = data as NetworkActivityEventMap['websocket-close'];
-          set((state) => {
-            const entry = state.networkEntries.get(`ws-${eventData.socketId}`);
-            if (!entry || entry.type !== 'websocket') return state;
+                const httpEntry = entry as HttpNetworkEntry;
+                const updatedEntry: HttpNetworkEntry = {
+                  ...httpEntry,
+                  status: 'failed',
+                  error: eventData.error,
+                };
 
-            const wsEntry = entry as WebSocketNetworkEntry;
-            const updatedEntry: WebSocketNetworkEntry = {
-              ...wsEntry,
-              status: 'closed',
-              closeCode: eventData.code,
-              closeReason: eventData.reason,
-              duration: eventData.timestamp - wsEntry.timestamp,
-            };
+                const newEntries = new Map(state.networkEntries);
+                newEntries.set(eventData.requestId, updatedEntry);
+                return { networkEntries: newEntries };
+              });
+              break;
+            }
 
-            const newEntries = new Map(state.networkEntries);
-            newEntries.set(entry.id, updatedEntry);
-            return { networkEntries: newEntries };
-          });
-          break;
-        }
+            case 'response-body': {
+              const eventData =
+                data as NetworkActivityEventMap['response-body'];
+              set((state) => {
+                const entry = state.networkEntries.get(eventData.requestId);
+                if (!entry || entry.type !== 'http') return state;
 
-        case 'websocket-message-sent': {
-          const eventData =
-            data as NetworkActivityEventMap['websocket-message-sent'];
-          set((state) => {
-            const socketId = `ws-${eventData.socketId}`;
-            const currentMessages = state.websocketMessages.get(socketId) || [];
+                const httpEntry = entry as HttpNetworkEntry;
+                const updatedEntry: HttpNetworkEntry = {
+                  ...httpEntry,
+                  response: httpEntry.response
+                    ? {
+                        ...httpEntry.response,
+                        body: eventData.body
+                          ? {
+                              type:
+                                getContentTypeMime(
+                                  httpEntry.response?.headers ?? {}
+                                ) || 'text/plain',
+                              data: eventData.body,
+                            }
+                          : undefined,
+                      }
+                    : undefined,
+                };
 
-            const message: WebSocketMessage = {
-              id: getId(`${socketId}-message`),
-              direction: 'sent',
-              data: eventData.data,
-              messageType: eventData.messageType,
-              timestamp: eventData.timestamp,
-            };
+                const newEntries = new Map(state.networkEntries);
+                newEntries.set(eventData.requestId, updatedEntry);
+                return { networkEntries: newEntries };
+              });
+              break;
+            }
 
-            const newMessages = new Map(state.websocketMessages);
-            newMessages.set(
-              socketId,
-              [...currentMessages, message].slice(
-                -MAX_WEBSOCKET_MESSAGES_PER_CONNECTION
-              )
-            );
+            case 'websocket-connect': {
+              const eventData =
+                data as NetworkActivityEventMap['websocket-connect'];
+              set((state) => {
+                const entry: WebSocketNetworkEntry = {
+                  id: `ws-${eventData.socketId}`,
+                  type: 'websocket',
+                  timestamp: eventData.timestamp,
+                  connection: {
+                    url: eventData.url,
+                    socketId: eventData.socketId,
+                    protocols: eventData.protocols || undefined,
+                    options: eventData.options,
+                  },
+                  status: 'connecting',
+                };
 
-            return { websocketMessages: newMessages };
-          });
-          break;
-        }
+                const newEntries = new Map(state.networkEntries);
+                newEntries.set(entry.id, entry);
 
-        case 'websocket-message-received': {
-          const eventData =
-            data as NetworkActivityEventMap['websocket-message-received'];
-          set((state) => {
-            const socketId = `ws-${eventData.socketId}`;
-            const currentMessages = state.websocketMessages.get(socketId) || [];
+                const newMessages = new Map(state.websocketMessages);
+                newMessages.set(entry.id, []);
 
-            const message: WebSocketMessage = {
-              id: getId(`${socketId}-message`),
-              direction: 'received',
-              data: eventData.data,
-              messageType: eventData.messageType,
-              timestamp: eventData.timestamp,
-            };
+                return {
+                  networkEntries: newEntries,
+                  websocketMessages: newMessages,
+                };
+              });
+              break;
+            }
 
-            const newMessages = new Map(state.websocketMessages);
-            newMessages.set(
-              socketId,
-              [...currentMessages, message].slice(
-                -MAX_WEBSOCKET_MESSAGES_PER_CONNECTION
-              )
-            );
+            case 'websocket-open': {
+              const eventData =
+                data as NetworkActivityEventMap['websocket-open'];
+              set((state) => {
+                const entry = state.networkEntries.get(
+                  `ws-${eventData.socketId}`
+                );
+                if (!entry || entry.type !== 'websocket') return state;
 
-            return { websocketMessages: newMessages };
-          });
-          break;
-        }
+                const wsEntry = entry as WebSocketNetworkEntry;
+                const updatedEntry: WebSocketNetworkEntry = {
+                  ...wsEntry,
+                  status: 'open',
+                };
 
-        case 'websocket-error': {
-          const eventData = data as NetworkActivityEventMap['websocket-error'];
-          set((state) => {
-            const entry = state.networkEntries.get(`ws-${eventData.socketId}`);
-            if (!entry || entry.type !== 'websocket') return state;
+                const newEntries = new Map(state.networkEntries);
+                newEntries.set(entry.id, updatedEntry);
+                return { networkEntries: newEntries };
+              });
+              break;
+            }
 
-            const wsEntry = entry as WebSocketNetworkEntry;
-            const updatedEntry: WebSocketNetworkEntry = {
-              ...wsEntry,
-              status: 'error',
-              error: eventData.error,
-            };
+            case 'websocket-close': {
+              const eventData =
+                data as NetworkActivityEventMap['websocket-close'];
+              set((state) => {
+                const entry = state.networkEntries.get(
+                  `ws-${eventData.socketId}`
+                );
+                if (!entry || entry.type !== 'websocket') return state;
 
-            const newEntries = new Map(state.networkEntries);
-            newEntries.set(entry.id, updatedEntry);
-            return { networkEntries: newEntries };
-          });
-          break;
-        }
+                const wsEntry = entry as WebSocketNetworkEntry;
+                const updatedEntry: WebSocketNetworkEntry = {
+                  ...wsEntry,
+                  status: 'closed',
+                  closeCode: eventData.code,
+                  closeReason: eventData.reason,
+                  duration: eventData.timestamp - wsEntry.timestamp,
+                };
 
-        case 'websocket-connection-status-changed': {
-          const eventData =
-            data as NetworkActivityEventMap['websocket-connection-status-changed'];
-          set((state) => {
-            const entry = state.networkEntries.get(`ws-${eventData.socketId}`);
-            if (!entry || entry.type !== 'websocket') return state;
+                const newEntries = new Map(state.networkEntries);
+                newEntries.set(entry.id, updatedEntry);
+                return { networkEntries: newEntries };
+              });
+              break;
+            }
 
-            const wsEntry = entry as WebSocketNetworkEntry;
-            const updatedEntry: WebSocketNetworkEntry = {
-              ...wsEntry,
-              status: eventData.status,
-            };
+            case 'websocket-message-sent': {
+              const eventData =
+                data as NetworkActivityEventMap['websocket-message-sent'];
+              set((state) => {
+                const socketId = `ws-${eventData.socketId}`;
+                const currentMessages =
+                  state.websocketMessages.get(socketId) || [];
 
-            const newEntries = new Map(state.networkEntries);
-            newEntries.set(entry.id, updatedEntry);
-            return { networkEntries: newEntries };
-          });
-          break;
-        }
+                const message: WebSocketMessage = {
+                  id: getId(`${socketId}-message`),
+                  direction: 'sent',
+                  data: eventData.data,
+                  messageType: eventData.messageType,
+                  timestamp: eventData.timestamp,
+                };
 
-        case 'sse-open': {
-          const eventData = data as NetworkActivityEventMap['sse-open'];
-          set((state) => {
-            const entry = state.networkEntries.get(eventData.requestId);
-            if (!entry || entry.type !== 'http') return state;
+                const newMessages = new Map(state.websocketMessages);
+                newMessages.set(
+                  socketId,
+                  [...currentMessages, message].slice(
+                    -MAX_WEBSOCKET_MESSAGES_PER_CONNECTION
+                  )
+                );
 
-            // Transform the existing HTTP entry to SSE
-            const httpEntry = entry as HttpNetworkEntry;
-            const sseEntry: SSENetworkEntry = {
-              ...httpEntry,
-              type: 'sse', // Change type from 'http' to 'sse'
-              status: 'open', // Update status
-              messages: [], // Add SSE-specific field
-              response: eventData.response,
-            };
+                return { websocketMessages: newMessages };
+              });
+              break;
+            }
 
-            const newEntries = new Map(state.networkEntries);
-            newEntries.set(eventData.requestId, sseEntry);
-            return { networkEntries: newEntries };
-          });
-          break;
-        }
+            case 'websocket-message-received': {
+              const eventData =
+                data as NetworkActivityEventMap['websocket-message-received'];
+              set((state) => {
+                const socketId = `ws-${eventData.socketId}`;
+                const currentMessages =
+                  state.websocketMessages.get(socketId) || [];
 
-        case 'sse-message': {
-          const eventData = data as NetworkActivityEventMap['sse-message'];
-          set((state) => {
-            const entry = state.networkEntries.get(eventData.requestId);
-            if (!entry || entry.type !== 'sse') return state;
+                const message: WebSocketMessage = {
+                  id: getId(`${socketId}-message`),
+                  direction: 'received',
+                  data: eventData.data,
+                  messageType: eventData.messageType,
+                  timestamp: eventData.timestamp,
+                };
 
-            const sseEntry = entry as SSENetworkEntry;
-            const newMessage: SSEMessage = {
-              id: getId(`${eventData.requestId}-message`),
-              type: eventData.payload.type,
-              data: eventData.payload.data,
-              timestamp: eventData.timestamp,
-            };
+                const newMessages = new Map(state.websocketMessages);
+                newMessages.set(
+                  socketId,
+                  [...currentMessages, message].slice(
+                    -MAX_WEBSOCKET_MESSAGES_PER_CONNECTION
+                  )
+                );
 
-            const updatedEntry: SSENetworkEntry = {
-              ...sseEntry,
-              messages: [...sseEntry.messages, newMessage].slice(
-                -MAX_SSE_MESSAGES_PER_CONNECTION
+                return { websocketMessages: newMessages };
+              });
+              break;
+            }
+
+            case 'websocket-error': {
+              const eventData =
+                data as NetworkActivityEventMap['websocket-error'];
+              set((state) => {
+                const entry = state.networkEntries.get(
+                  `ws-${eventData.socketId}`
+                );
+                if (!entry || entry.type !== 'websocket') return state;
+
+                const wsEntry = entry as WebSocketNetworkEntry;
+                const updatedEntry: WebSocketNetworkEntry = {
+                  ...wsEntry,
+                  status: 'error',
+                  error: eventData.error,
+                };
+
+                const newEntries = new Map(state.networkEntries);
+                newEntries.set(entry.id, updatedEntry);
+                return { networkEntries: newEntries };
+              });
+              break;
+            }
+
+            case 'websocket-connection-status-changed': {
+              const eventData =
+                data as NetworkActivityEventMap['websocket-connection-status-changed'];
+              set((state) => {
+                const entry = state.networkEntries.get(
+                  `ws-${eventData.socketId}`
+                );
+                if (!entry || entry.type !== 'websocket') return state;
+
+                const wsEntry = entry as WebSocketNetworkEntry;
+                const updatedEntry: WebSocketNetworkEntry = {
+                  ...wsEntry,
+                  status: eventData.status,
+                };
+
+                const newEntries = new Map(state.networkEntries);
+                newEntries.set(entry.id, updatedEntry);
+                return { networkEntries: newEntries };
+              });
+              break;
+            }
+
+            case 'sse-open': {
+              const eventData = data as NetworkActivityEventMap['sse-open'];
+              set((state) => {
+                const entry = state.networkEntries.get(eventData.requestId);
+                if (!entry || entry.type !== 'http') return state;
+
+                // Transform the existing HTTP entry to SSE
+                const httpEntry = entry as HttpNetworkEntry;
+                const sseEntry: SSENetworkEntry = {
+                  ...httpEntry,
+                  type: 'sse', // Change type from 'http' to 'sse'
+                  status: 'open', // Update status
+                  messages: [], // Add SSE-specific field
+                  response: eventData.response,
+                };
+
+                const newEntries = new Map(state.networkEntries);
+                newEntries.set(eventData.requestId, sseEntry);
+                return { networkEntries: newEntries };
+              });
+              break;
+            }
+
+            case 'sse-message': {
+              const eventData = data as NetworkActivityEventMap['sse-message'];
+              set((state) => {
+                const entry = state.networkEntries.get(eventData.requestId);
+                if (!entry || entry.type !== 'sse') return state;
+
+                const sseEntry = entry as SSENetworkEntry;
+                const newMessage: SSEMessage = {
+                  id: getId(`${eventData.requestId}-message`),
+                  type: eventData.payload.type,
+                  data: eventData.payload.data,
+                  timestamp: eventData.timestamp,
+                };
+
+                const updatedEntry: SSENetworkEntry = {
+                  ...sseEntry,
+                  messages: [...sseEntry.messages, newMessage].slice(
+                    -MAX_SSE_MESSAGES_PER_CONNECTION
+                  ),
+                };
+
+                const newEntries = new Map(state.networkEntries);
+                newEntries.set(eventData.requestId, updatedEntry);
+                return { networkEntries: newEntries };
+              });
+              break;
+            }
+
+            case 'sse-error': {
+              const eventData = data as NetworkActivityEventMap['sse-error'];
+              set((state) => {
+                const entry = state.networkEntries.get(eventData.requestId);
+                if (!entry || entry.type !== 'sse') return state;
+
+                const sseEntry = entry as SSENetworkEntry;
+                const updatedEntry: SSENetworkEntry = {
+                  ...sseEntry,
+                  status: 'error',
+                  error: eventData.error.message,
+                };
+
+                const newEntries = new Map(state.networkEntries);
+                newEntries.set(eventData.requestId, updatedEntry);
+                return { networkEntries: newEntries };
+              });
+              break;
+            }
+
+            case 'sse-close': {
+              const eventData = data as NetworkActivityEventMap['sse-close'];
+              set((state) => {
+                const entry = state.networkEntries.get(eventData.requestId);
+                if (!entry || entry.type !== 'sse') return state;
+
+                const sseEntry = entry as SSENetworkEntry;
+                const updatedEntry: SSENetworkEntry = {
+                  ...sseEntry,
+                  status: 'closed',
+                  duration: eventData.timestamp - sseEntry.timestamp,
+                };
+
+                const newEntries = new Map(state.networkEntries);
+                newEntries.set(eventData.requestId, updatedEntry);
+                return { networkEntries: newEntries };
+              });
+              break;
+            }
+          }
+        },
+
+        // Client management
+        client: {
+          setupClient: (client: NetworkActivityDevToolsClient) => {
+            const { handleEvent } = get();
+
+            // Subscribe to all events using the unified handler
+            const unsubscribeFunctions = [
+              client.onMessage('request-sent', (data) =>
+                handleEvent('request-sent', data)
               ),
-            };
+              client.onMessage('response-received', (data) =>
+                handleEvent('response-received', data)
+              ),
+              client.onMessage('request-completed', (data) =>
+                handleEvent('request-completed', data)
+              ),
+              client.onMessage('request-failed', (data) =>
+                handleEvent('request-failed', data)
+              ),
+              client.onMessage('response-body', (data) =>
+                handleEvent('response-body', data)
+              ),
+              client.onMessage('websocket-connect', (data) =>
+                handleEvent('websocket-connect', data)
+              ),
+              client.onMessage('websocket-open', (data) =>
+                handleEvent('websocket-open', data)
+              ),
+              client.onMessage('websocket-close', (data) =>
+                handleEvent('websocket-close', data)
+              ),
+              client.onMessage('websocket-message-sent', (data) =>
+                handleEvent('websocket-message-sent', data)
+              ),
+              client.onMessage('websocket-message-received', (data) =>
+                handleEvent('websocket-message-received', data)
+              ),
+              client.onMessage('websocket-error', (data) =>
+                handleEvent('websocket-error', data)
+              ),
+              client.onMessage('websocket-connection-status-changed', (data) =>
+                handleEvent('websocket-connection-status-changed', data)
+              ),
+              client.onMessage('sse-open', (data) =>
+                handleEvent('sse-open', data)
+              ),
+              client.onMessage('sse-message', (data) =>
+                handleEvent('sse-message', data)
+              ),
+              client.onMessage('sse-error', (data) =>
+                handleEvent('sse-error', data)
+              ),
+              client.onMessage('sse-close', (data) =>
+                handleEvent('sse-close', data)
+              ),
+            ];
 
-            const newEntries = new Map(state.networkEntries);
-            newEntries.set(eventData.requestId, updatedEntry);
-            return { networkEntries: newEntries };
-          });
-          break;
-        }
+            // Store unsubscribe functions in the state for cleanup
+            set({
+              _unsubscribeFunctions: unsubscribeFunctions,
+              _client: client,
+            });
+          },
 
-        case 'sse-error': {
-          const eventData = data as NetworkActivityEventMap['sse-error'];
-          set((state) => {
-            const entry = state.networkEntries.get(eventData.requestId);
-            if (!entry || entry.type !== 'sse') return state;
+          cleanupClient: () => {
+            const { _unsubscribeFunctions, _client } = get();
 
-            const sseEntry = entry as SSENetworkEntry;
-            const updatedEntry: SSENetworkEntry = {
-              ...sseEntry,
-              status: 'error',
-              error: eventData.error.message,
-            };
+            if (_unsubscribeFunctions) {
+              _unsubscribeFunctions.forEach(
+                (unsubscribe: { remove: () => void }) => unsubscribe.remove()
+              );
+            }
 
-            const newEntries = new Map(state.networkEntries);
-            newEntries.set(eventData.requestId, updatedEntry);
-            return { networkEntries: newEntries };
-          });
-          break;
-        }
+            if (_client) {
+              _client.send('network-disable', {});
+            }
 
-        case 'sse-close': {
-          const eventData = data as NetworkActivityEventMap['sse-close'];
-          set((state) => {
-            const entry = state.networkEntries.get(eventData.requestId);
-            if (!entry || entry.type !== 'sse') return state;
-
-            const sseEntry = entry as SSENetworkEntry;
-            const updatedEntry: SSENetworkEntry = {
-              ...sseEntry,
-              status: 'closed',
-              duration: eventData.timestamp - sseEntry.timestamp,
-            };
-
-            const newEntries = new Map(state.networkEntries);
-            newEntries.set(eventData.requestId, updatedEntry);
-            return { networkEntries: newEntries };
-          });
-          break;
-        }
+            set({
+              _unsubscribeFunctions: undefined,
+              _client: undefined,
+            });
+          },
+        },
+      }),
+      {
+        name: 'rozenite-network-activity-storage',
+        storage: createJSONStorage(() => localStorage, {
+          replacer: (key, value) => {
+            if (value instanceof Map) {
+              return {
+                _type: 'map',
+                value: Array.from(value.entries()),
+              };
+            }
+            return value;
+          },
+          reviver: (key, value) => {
+            if (
+              typeof value === 'object' &&
+              value !== null &&
+              value._type === 'map'
+            ) {
+              return new Map(value.value);
+            }
+            return value;
+          },
+        }),
+        partialize: (state) => ({ overrides: state.overrides }), // Persist only the overrides
       }
-    },
-
-    // Client management
-    client: {
-      setupClient: (client: NetworkActivityDevToolsClient) => {
-        const { handleEvent } = get();
-
-        // Subscribe to all events using the unified handler
-        const unsubscribeFunctions = [
-          client.onMessage('request-sent', (data) =>
-            handleEvent('request-sent', data)
-          ),
-          client.onMessage('response-received', (data) =>
-            handleEvent('response-received', data)
-          ),
-          client.onMessage('request-completed', (data) =>
-            handleEvent('request-completed', data)
-          ),
-          client.onMessage('request-failed', (data) =>
-            handleEvent('request-failed', data)
-          ),
-          client.onMessage('response-body', (data) =>
-            handleEvent('response-body', data)
-          ),
-          client.onMessage('websocket-connect', (data) =>
-            handleEvent('websocket-connect', data)
-          ),
-          client.onMessage('websocket-open', (data) =>
-            handleEvent('websocket-open', data)
-          ),
-          client.onMessage('websocket-close', (data) =>
-            handleEvent('websocket-close', data)
-          ),
-          client.onMessage('websocket-message-sent', (data) =>
-            handleEvent('websocket-message-sent', data)
-          ),
-          client.onMessage('websocket-message-received', (data) =>
-            handleEvent('websocket-message-received', data)
-          ),
-          client.onMessage('websocket-error', (data) =>
-            handleEvent('websocket-error', data)
-          ),
-          client.onMessage('websocket-connection-status-changed', (data) =>
-            handleEvent('websocket-connection-status-changed', data)
-          ),
-          client.onMessage('sse-open', (data) => handleEvent('sse-open', data)),
-          client.onMessage('sse-message', (data) =>
-            handleEvent('sse-message', data)
-          ),
-          client.onMessage('sse-error', (data) =>
-            handleEvent('sse-error', data)
-          ),
-          client.onMessage('sse-close', (data) =>
-            handleEvent('sse-close', data)
-          ),
-        ];
-
-        // Store unsubscribe functions in the state for cleanup
-        set({
-          _unsubscribeFunctions: unsubscribeFunctions,
-          _client: client,
-        });
-      },
-
-      cleanupClient: () => {
-        const { _unsubscribeFunctions, _client } = get();
-
-        if (_unsubscribeFunctions) {
-          _unsubscribeFunctions.forEach((unsubscribe: { remove: () => void }) =>
-            unsubscribe.remove()
-          );
-        }
-
-        if (_client) {
-          _client.send('network-disable', {});
-        }
-
-        set({
-          _unsubscribeFunctions: undefined,
-          _client: undefined,
-        });
-      },
-    },
-  }));
+    )
+  );
 
 export const store = createNetworkActivityStore();

--- a/packages/network-activity-plugin/src/ui/tabs/ResponseTab.tsx
+++ b/packages/network-activity-plugin/src/ui/tabs/ResponseTab.tsx
@@ -1,19 +1,30 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { ScrollArea } from '../components/ScrollArea';
 import { JsonTree } from '../components/JsonTree';
 import { HttpNetworkEntry } from '../state/model';
 import { Section } from '../components/Section';
 import { KeyValueGrid } from '../components/KeyValueGrid';
 import { CodeBlock } from '../components/CodeBlock';
+import { useNetworkActivityActions, useOverrides } from '../state/hooks';
+import { OverrideActions } from '../components/OverrideActions';
+import { CodeEditor } from '../components/CodeEditor';
 
 export type ResponseTabProps = {
   selectedRequest: HttpNetworkEntry;
   onRequestResponseBody: (requestId: string) => void;
 };
 
-const renderResponseBodySection = (children: React.ReactNode) => {
+type ResponseBodySectionProps = {
+  action?: React.ReactNode;
+  children: React.ReactNode;
+};
+
+const RenderResponseBodySection = ({
+  children,
+  action,
+}: ResponseBodySectionProps) => {
   return (
-    <Section title="Response Body" collapsible={false}>
+    <Section title="Response Body" collapsible={false} action={action}>
       <div className="space-y-4">{children}</div>
     </Section>
   );
@@ -24,6 +35,14 @@ export const ResponseTab = ({
   onRequestResponseBody,
 }: ResponseTabProps) => {
   const onRequestResponseBodyRef = useRef(onRequestResponseBody);
+  const actions = useNetworkActivityActions();
+  const overrides = useOverrides();
+  const [savedOverride, setSavedOverride] = useState<string | null>(() => {
+    const override = overrides.get(selectedRequest.request.url);
+    return override?.body ?? null;
+  });
+  const [editedData, setEditedData] = useState<string | null>(savedOverride);
+  const responseEditorRef = useRef<HTMLPreElement>(null);
 
   useEffect(() => {
     onRequestResponseBodyRef.current = onRequestResponseBody;
@@ -36,6 +55,22 @@ export const ResponseTab = ({
   }, [selectedRequest.id]);
 
   const responseBody = selectedRequest.response?.body;
+
+  const saveOverride = () => {
+    if (editedData === null) return;
+
+    const newOverrideData = editedData;
+    setSavedOverride(newOverrideData);
+    actions.addOverride(selectedRequest.request.url, {
+      body: newOverrideData,
+    });
+  };
+
+  const clearOverride = () => {
+    setSavedOverride(null);
+    setEditedData(null);
+    actions.clearOverride(selectedRequest.request.url);
+  };
 
   const renderResponseBody = () => {
     if (!responseBody || responseBody.data === null) {
@@ -60,6 +95,32 @@ export const ResponseTab = ({
       />
     );
 
+    const overrideActions = (
+      <OverrideActions
+        currentData={editedData}
+        initialData={savedOverride}
+        onOverride={() => {
+          setSavedOverride(data);
+          setEditedData(data);
+        }}
+        onSaveOverride={saveOverride}
+        onClear={clearOverride}
+      />
+    );
+
+    if (savedOverride !== null) {
+      return (
+        <RenderResponseBodySection action={overrideActions}>
+          {contentTypeGrid}
+          <CodeEditor
+            data={savedOverride}
+            ref={responseEditorRef}
+            onInput={(e) => setEditedData(e.currentTarget.innerText)}
+          />
+        </RenderResponseBodySection>
+      );
+    }
+
     if (type.startsWith('application/json')) {
       let bodyContent;
 
@@ -82,11 +143,11 @@ export const ResponseTab = ({
         );
       }
 
-      return renderResponseBodySection(
-        <>
+      return (
+        <RenderResponseBodySection action={overrideActions}>
           {contentTypeGrid}
           {bodyContent}
-        </>
+        </RenderResponseBodySection>
       );
     }
 
@@ -95,21 +156,21 @@ export const ResponseTab = ({
       type.startsWith('application/xml') ||
       type.startsWith('application/javascript')
     ) {
-      return renderResponseBodySection(
-        <>
+      return (
+        <RenderResponseBodySection action={overrideActions}>
           {contentTypeGrid}
           <CodeBlock>{data}</CodeBlock>
-        </>
+        </RenderResponseBodySection>
       );
     }
 
-    return renderResponseBodySection(
-      <>
+    return (
+      <RenderResponseBodySection>
         {contentTypeGrid}
         <div className="text-sm text-gray-400">
           Binary content not shown - {data.length} bytes
         </div>
-      </>
+      </RenderResponseBodySection>
     );
   };
 

--- a/packages/network-activity-plugin/src/ui/views/InspectorView.tsx
+++ b/packages/network-activity-plugin/src/ui/views/InspectorView.tsx
@@ -8,6 +8,7 @@ import {
   useNetworkActivityClientManagement,
   useHasSelectedRequest,
   useNetworkActivityActions,
+  useOverrides,
 } from '../state/hooks';
 
 export type InspectorViewProps = {
@@ -18,6 +19,7 @@ export const InspectorView = ({ client }: InspectorViewProps) => {
   const actions = useNetworkActivityActions();
   const clientManagement = useNetworkActivityClientManagement();
   const hasSelectedRequest = useHasSelectedRequest();
+  const overrides = useOverrides();
   const [filter, setFilter] = useState<FilterState>({
     text: '',
     types: new Set(['http', 'websocket', 'sse']),
@@ -30,6 +32,10 @@ export const InspectorView = ({ client }: InspectorViewProps) => {
 
     clientManagement.setupClient(client);
     actions.setRecording(true);
+
+    client.send('set-overrides', {
+      overrides: Array.from(overrides.entries()),
+    });
 
     return () => {
       actions.setRecording(false);


### PR DESCRIPTION
## Override and mock network responses

This feature is inspired by [Chrome DevTools overrides](https://developer.chrome.com/docs/devtools/overrides). It allows developers to edit the response and see how their app behaves, without changing the backend. Currently, it’s possible to override the response body and status.

> With local overrides, you can unblock your workflow by prototyping and testing changes and fixes without waiting for the backend, third-parties, or APIs to support them.

Demo:

https://github.com/user-attachments/assets/8570713e-5ab2-45c7-a355-6de00dd8a94d

## How it works
The DevTools and the app both store the overrides. Every time a response is overridden, the DevTools send it to the app. The overrides list is persisted in the DevTools’ local storage, so it survives app reloads. On the DevTools side, it’s stored in Zustand store; in the app, it’s stored in a registry. If a request has an override, the response body and status are monkey-patched during XMLHttpRequest interception. On load, the DevTools send all overrides stored in local storage to the app, keeping the data in sync.
