### PR TITLE
fix(redux-devtools-plugin): asyncIterator not defined

### DIFF
--- a/.nx/version-plans/version-plan-1761752669919.md
+++ b/.nx/version-plans/version-plan-1761752669919.md
@@ -1,0 +1,5 @@
+---
+'@rozenite/redux-devtools-plugin': prerelease
+---
+
+Fixed a race condition that occurred in certain scenarios by inlining the require call to the redux-devtools/remote package.

--- a/packages/redux-devtools-plugin/src/runtime.ts
+++ b/packages/redux-devtools-plugin/src/runtime.ts
@@ -1,9 +1,12 @@
 import { Platform } from 'react-native';
 import getDevServer from 'react-native/Libraries/Core/Devtools/getDevServer';
 import { REDUX_DEVTOOLS_PORT } from './constants';
+import type { devToolsEnhancer } from '@redux-devtools/remote';
 
-// @ts-expect-error - Symbol.asyncIterator is not defined in the global scope, but required by the redux-devtools/remote package (no static import is allowed).
+// @ts-expect-error - Symbol.asyncIterator is not defined in the global scope, but required by the redux-devtools/remote package.
 Symbol.asyncIterator ??= Symbol.for('Symbol.asyncIterator');
+
+type StoreEnhancer = ReturnType<typeof devToolsEnhancer>;
 
 const getDeviceId = (): string => {
   if (Platform.OS === 'android') {
@@ -22,7 +25,7 @@ const getHostname = (): string => {
   return devServer.url.split('://')[1].split(':')[0];
 };
 
-export const rozeniteDevToolsEnhancer = (): ReturnType<typeof import('@redux-devtools/remote').devToolsEnhancer> => {
+export const rozeniteDevToolsEnhancer = (): StoreEnhancer => {
   return require('@redux-devtools/remote').devToolsEnhancer({
     name: getDeviceId(),
     hostname: getHostname(),

--- a/website/src/docs/official-plugins/redux-devtools.mdx
+++ b/website/src/docs/official-plugins/redux-devtools.mdx
@@ -105,7 +105,8 @@ The Redux DevTools plugin currently displays Redux stores from all connected dev
 
 ### Physical Devices
 
-When using an emulator, everything is automatic, but when running on a physical device, adb reverse is required on port 8765.
+Redux DevTools work out of the box with Android emulators, but when using a physical device, you need to tunnel an additional port using the adb reverse command.
+
 ```sh
 adb reverse tcp:8765 tcp:8765
 ```


### PR DESCRIPTION
As found out in this [issue](https://github.com/callstackincubator/rozenite/issues/126#issuecomment-3416711486), adding documentation on the Redux DevTool plugin for a physical device + Hermes when we cannot select the device in the inspector's selector, either because:
1. Data on port 8765 is not proxied because of a missing adb reverse
2. Potential Hermes bug with `asyncIterator` in Redux DevTools
3. Move the init of `asyncIterator` before its usage in the import of `redux-devtools/remote`