### PR TITLE
docs: Update EDIT_ROOT_URL to point to src directory

### DIFF
--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -1,7 +1,7 @@
 import { withCallstackPreset } from '@callstack/rspress-preset';
 import { pluginDirectoryPlugin } from './plugins/plugin-directory';
 
-const EDIT_ROOT_URL = `https://github.com/callstackincubator/rozenite/tree/main/website`;
+const EDIT_ROOT_URL = `https://github.com/callstackincubator/rozenite/tree/main/website/src`;
 
 export default withCallstackPreset(
   {


### PR DESCRIPTION
Fix broken "Edit this page in Github" links on docs website

Fixes #139 

<img width="1294" height="442" alt="CleanShot 2025-11-12 at 13 47 14@2x" src="https://github.com/user-attachments/assets/8e3b4edf-ecc8-4ce3-98e3-d0eff332a714" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update `EDIT_ROOT_URL` in `website/rspress.config.ts` to point to `website/src` for correct "Edit this page" links.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0080735b89e16b94167fc313bf28132d8c5eb558. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->