### PR TITLE
docs: add getting-started link before plugin installation instructions

### DIFF
--- a/website/src/docs/official-plugins/expo-atlas.mdx
+++ b/website/src/docs/official-plugins/expo-atlas.mdx
@@ -18,6 +18,8 @@ Expo Atlas is a bundle analyzer and visualizer that helps you understand and opt
 
 ## Installation
 
+Make sure to go through the [Getting Started guide](/docs/getting-started) before installing the plugin.
+
 Install the Expo Atlas plugin as a development dependency using your preferred package manager:
 
 <PackageManagerTabs command="install -D @rozenite/expo-atlas-plugin" />

--- a/website/src/docs/official-plugins/mmkv.mdx
+++ b/website/src/docs/official-plugins/mmkv.mdx
@@ -21,6 +21,8 @@ The MMKV plugin is a powerful debugging tool that helps you inspect and manage M
 
 ## Installation
 
+Make sure to go through the [Getting Started guide](/docs/getting-started) before installing the plugin.
+
 Install the MMKV plugin and its peer dependencies:
 
 <PackageManagerTabs command="install -D @rozenite/mmkv-plugin react-native-mmkv" />

--- a/website/src/docs/official-plugins/network-activity.mdx
+++ b/website/src/docs/official-plugins/network-activity.mdx
@@ -22,6 +22,8 @@ The Network Activity plugin will only capture network traffic coming from the Ja
 
 ## Installation
 
+Make sure to go through the [Getting Started guide](/docs/getting-started) before installing the plugin
+
 Install the Network Activity plugin as a development dependency using your preferred package manager:
 
 <PackageManagerTabs command="install -D @rozenite/network-activity-plugin" />

--- a/website/src/docs/official-plugins/performance-monitor.mdx
+++ b/website/src/docs/official-plugins/performance-monitor.mdx
@@ -20,6 +20,8 @@ The Performance Monitor plugin is a powerful debugging tool that helps you monit
 
 ## Installation
 
+Make sure to go through the [Getting Started guide](/docs/getting-started) before installing the plugin.
+
 Install the Performance Monitor plugin and its peer dependencies:
 
 <PackageManagerTabs command="install -D @rozenite/performance-monitor-plugin react-native-performance" />

--- a/website/src/docs/official-plugins/react-navigation.mdx
+++ b/website/src/docs/official-plugins/react-navigation.mdx
@@ -19,6 +19,8 @@ The React Navigation plugin is a powerful debugging tool that helps you inspect 
 
 ## Installation
 
+Make sure to go through the [Getting Started guide](/docs/getting-started) before installing the plugin.
+
 Install the React Navigation plugin as a development dependency:
 
 <PackageManagerTabs command="install -D @rozenite/react-navigation-plugin" />

--- a/website/src/docs/official-plugins/redux-devtools.mdx
+++ b/website/src/docs/official-plugins/redux-devtools.mdx
@@ -20,6 +20,8 @@ Time travel debugging and action dispatch features will be added in future relea
 
 ## Installation
 
+Make sure to go through the [Getting Started guide](/docs/getting-started) before installing the plugin.
+
 ### Install dependencies
 
 Install the Redux DevTools plugin and its peer dependencies as development dependencies:

--- a/website/src/docs/official-plugins/tanstack-query.mdx
+++ b/website/src/docs/official-plugins/tanstack-query.mdx
@@ -19,6 +19,8 @@ TanStack Query (formerly React Query) is a powerful data synchronization library
 
 ## Installation
 
+Make sure to go through the [Getting Started guide](/docs/getting-started) before installing the plugin,
+
 Install the TanStack Query plugin as a development dependency using your preferred package manager:
 
 <PackageManagerTabs command="install -D @rozenite/tanstack-query-plugin" />


### PR DESCRIPTION
Added a note to ensure users read the Getting Started guide before installation of each plugin.

Fixes #138 

<img width="1514" height="296" alt="CleanShot 2025-11-12 at 13 48 21@2x" src="https://github.com/user-attachments/assets/2588577f-df77-4679-ac65-eb5e041cff5f" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a pre-install note linking to the Getting Started guide across official plugin docs.
> 
> - **Docs**:
>   - Add a pre-install note linking to the Getting Started guide before installation sections in `website/src/docs/official-plugins/{expo-atlas,mmkv,network-activity,performance-monitor,react-navigation,redux-devtools,tanstack-query}.mdx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dcfd66c38817205a92326b68ea249fc4556584d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->