### PR TITLE
feat(plugin-bridge): add RPC bridge

### DIFF
--- a/.nx/version-plans/version-plan-1766951301102.md
+++ b/.nx/version-plans/version-plan-1766951301102.md
@@ -1,0 +1,5 @@
+---
+"@rozenite/plugin-bridge": minor
+---
+
+Introduced `createRozeniteRPCBridge` for symmetrical bi-directional RPC communication between App and DevTools. This enables type-safe, contract-first method calls across the bridge.

--- a/packages/plugin-bridge/README.md
+++ b/packages/plugin-bridge/README.md
@@ -148,7 +148,8 @@ async function setupAppBridge() {
       send: (msg) => client.send('rpc', msg),
       onMessage: (listener) => client.onMessage('rpc', listener),
     },
-    localHandlers
+    localHandlers,
+    { timeout: 30000 } // Optional: Timeout in ms (default: 60000)
   );
 
   // Call remote method

--- a/packages/plugin-bridge/src/index.ts
+++ b/packages/plugin-bridge/src/index.ts
@@ -6,3 +6,4 @@ export { getRozeniteDevToolsClient } from './client';
 export { UnsupportedPlatformError } from './errors';
 export { createRozeniteRPCBridge } from './rpc';
 export type { Transport as RozeniteRPCTransport } from './rpc';
+export type { RPCBridgeOptions } from './rpc';

--- a/packages/plugin-bridge/src/index.ts
+++ b/packages/plugin-bridge/src/index.ts
@@ -4,3 +4,5 @@ export type { Subscription } from './types';
 export type { UseRozeniteDevToolsClientOptions } from './useRozeniteDevToolsClient';
 export { getRozeniteDevToolsClient } from './client';
 export { UnsupportedPlatformError } from './errors';
+export { createRozeniteRPCBridge } from './rpc';
+export type { Transport as RozeniteRPCTransport } from './rpc';

--- a/packages/plugin-bridge/src/rpc.test.ts
+++ b/packages/plugin-bridge/src/rpc.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createRozeniteRPCBridge } from './rpc';
+import type { RozeniteRPCTransport } from './index';
+
+describe('createRozeniteRPCBridge', () => {
+  const createMockTransport = () => {
+    let listener: (message: unknown) => void = () => {};
+    return {
+      send: vi.fn(),
+      onMessage: vi.fn((l) => {
+        listener = l;
+      }),
+      // Helper to simulate receiving a message
+      emit: (message: unknown) => listener(message),
+    };
+  };
+
+  type Local = {
+    add(a: number, b: number): Promise<number>;
+    getError(): Promise<void>;
+  };
+
+  type Remote = {
+    multiply(a: number, b: number): Promise<number>;
+  };
+
+  it('should call remote methods via proxy and receive results', async () => {
+    const transport = createMockTransport();
+    const localHandlers: Local = {
+      add: async (a, b) => a + b,
+      getError: async () => {
+        throw new Error('Local error');
+      },
+    };
+
+    const bridge = createRozeniteRPCBridge<Local, Remote>(
+      transport as unknown as RozeniteRPCTransport,
+      localHandlers
+    );
+
+    // Call remote method
+    const promise = bridge.multiply(2, 3);
+
+    // Verify request was sent
+    expect(transport.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jsonrpc: '2.0',
+        method: 'multiply',
+        params: [2, 3],
+        id: expect.any(String),
+      })
+    );
+
+    // Simulate response
+    const lastCall = transport.send.mock.calls[0][0] as any;
+    transport.emit({
+      jsonrpc: '2.0',
+      id: lastCall.id,
+      result: 6,
+    });
+
+    const result = await promise;
+    expect(result).toBe(6);
+  });
+
+  it('should handle incoming requests and send responses', async () => {
+    const transport = createMockTransport();
+    const localHandlers: Local = {
+      add: async (a, b) => a + b,
+      getError: async () => {
+        throw new Error('Local error');
+      },
+    };
+
+    createRozeniteRPCBridge<Local, Remote>(
+      transport as unknown as RozeniteRPCTransport,
+      localHandlers
+    );
+
+    // Simulate incoming request
+    transport.emit({
+      jsonrpc: '2.0',
+      id: '123',
+      method: 'add',
+      params: [10, 20],
+    });
+
+    // Wait for promise resolution in handler
+    await vi.waitFor(() => {
+      expect(transport.send).toHaveBeenCalledWith({
+        jsonrpc: '2.0',
+        id: '123',
+        result: 30,
+      });
+    });
+  });
+
+  it('should handle errors across the bridge', async () => {
+    const transport = createMockTransport();
+    const localHandlers: Local = {
+      add: async (a, b) => a + b,
+      getError: async () => {
+        throw new Error('Remote crash');
+      },
+    };
+
+    const bridge = createRozeniteRPCBridge<Local, Remote>(
+      transport as unknown as RozeniteRPCTransport,
+      localHandlers
+    );
+
+    // Test remote error (received from other side)
+    const promise = bridge.multiply(5, 5);
+    const lastCall = transport.send.mock.calls[0][0] as any;
+    
+    transport.emit({
+      jsonrpc: '2.0',
+      id: lastCall.id,
+      error: { message: 'Method failed' },
+    });
+
+    await expect(promise).rejects.toThrow('Method failed');
+
+    // Test local error (sent to other side)
+    transport.emit({
+      jsonrpc: '2.0',
+      id: '456',
+      method: 'getError',
+      params: [],
+    });
+
+    await vi.waitFor(() => {
+      expect(transport.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          jsonrpc: '2.0',
+          id: '456',
+          error: expect.objectContaining({
+            message: 'Remote crash',
+          }),
+        })
+      );
+    });
+  });
+
+  it('should ignore non-RPC messages', async () => {
+    const transport = createMockTransport();
+    const localHandlers = {
+      ping: vi.fn(),
+    };
+
+    createRozeniteRPCBridge(
+      transport as unknown as RozeniteRPCTransport,
+      localHandlers
+    );
+
+    // Send invalid message
+    transport.emit({ type: 'not-rpc', data: {} });
+    
+    expect(localHandlers.ping).not.toHaveBeenCalled();
+    expect(transport.send).not.toHaveBeenCalled();
+  });
+});

--- a/packages/plugin-bridge/src/rpc.test.ts
+++ b/packages/plugin-bridge/src/rpc.test.ts
@@ -4,7 +4,10 @@ import type { RozeniteRPCTransport } from './index';
 
 describe('createRozeniteRPCBridge', () => {
   const createMockTransport = () => {
-    let listener: (message: unknown) => void = () => {};
+    let listener: (message: unknown) => void = () => {
+      // Empty listener to avoid warnings
+    };
+    
     return {
       send: vi.fn(),
       onMessage: vi.fn((l) => {

--- a/packages/plugin-bridge/src/rpc.test.ts
+++ b/packages/plugin-bridge/src/rpc.test.ts
@@ -159,4 +159,26 @@ describe('createRozeniteRPCBridge', () => {
     expect(localHandlers.ping).not.toHaveBeenCalled();
     expect(transport.send).not.toHaveBeenCalled();
   });
+
+  it('should timeout if no response is received', async () => {
+    const transport = createMockTransport();
+    const localHandlers = {};
+
+    vi.useFakeTimers();
+
+    const bridge = createRozeniteRPCBridge<typeof localHandlers, Remote>(
+      transport as unknown as RozeniteRPCTransport,
+      localHandlers,
+      { timeout: 1000 }
+    );
+
+    const promise = bridge.multiply(1, 2);
+
+    // Fast-forward time
+    vi.advanceTimersByTime(1001);
+
+    await expect(promise).rejects.toThrow('RPC Timeout: Request multiply timed out after 1000ms');
+
+    vi.useRealTimers();
+  });
 });

--- a/packages/plugin-bridge/src/rpc.ts
+++ b/packages/plugin-bridge/src/rpc.ts
@@ -1,0 +1,191 @@
+import { Subscription } from './types';
+
+export type Transport = {
+  send(message: unknown): void;
+  onMessage(listener: (message: unknown) => void): Subscription | void;
+};
+
+export type RPCRequest = {
+  jsonrpc: '2.0';
+  id: string;
+  method: string;
+  params: unknown[];
+};
+
+export type RPCResponseSuccess = {
+  jsonrpc: '2.0';
+  id: string;
+  result: unknown;
+};
+
+export type RPCResponseError = {
+  jsonrpc: '2.0';
+  id: string;
+  error: {
+    message: string;
+    code?: number;
+    data?: unknown;
+  };
+};
+
+export type RPCResponse = RPCResponseSuccess | RPCResponseError;
+
+type PendingPromise = {
+  resolve: (value: unknown) => void;
+  reject: (reason?: unknown) => void;
+};
+
+// Error serialization helper
+function serializeError(error: unknown) {
+  if (error instanceof Error) {
+    return {
+      message: error.message,
+      data: { 
+        stack: error.stack, 
+        name: error.name,
+        // Copy other properties
+        ...Object.getOwnPropertyNames(error).reduce((acc, key) => {
+            // @ts-ignore
+            acc[key] = error[key];
+            return acc;
+        }, {} as Record<string, unknown>)
+      },
+    };
+  }
+  return {
+    message: String(error),
+  };
+}
+
+// Simple ID generator
+function generateId(): string {
+  return Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
+}
+
+function isRPCRequest(message: any): message is RPCRequest {
+  return (
+    typeof message === 'object' &&
+    message !== null &&
+    message.jsonrpc === '2.0' &&
+    typeof message.method === 'string' &&
+    typeof message.id === 'string' &&
+    Array.isArray(message.params)
+  );
+}
+
+function isRPCResponse(message: any): message is RPCResponse {
+  return (
+    typeof message === 'object' &&
+    message !== null &&
+    message.jsonrpc === '2.0' &&
+    typeof message.id === 'string' &&
+    ('result' in message || 'error' in message)
+  );
+}
+
+/**
+ * Creates a Symmetrical Bi-Directional RPC Bridge.
+ * 
+ * @param transport - The transport layer to send/receive messages.
+ * @param localHandlers - The implementation of the local methods exposed to the other side.
+ * @returns A Proxy object representing the remote interface.
+ */
+export function createRozeniteRPCBridge<LocalHandlers extends object, RemoteInterface extends object>(
+  transport: Transport,
+  localHandlers: LocalHandlers
+): RemoteInterface {
+  const pendingPromises = new Map<string, PendingPromise>();
+
+  // Message Handler
+  transport.onMessage((message: unknown) => {
+    if (isRPCRequest(message)) {
+      // It's a request: Execute local handler
+      const { id, method, params } = message;
+      // @ts-ignore
+      const handler = localHandlers[method];
+
+      if (typeof handler === 'function') {
+        try {
+          const result = handler(...params);
+          // Handle sync and async results
+          Promise.resolve(result)
+            .then((res) => {
+              const response: RPCResponseSuccess = {
+                jsonrpc: '2.0',
+                id,
+                result: res,
+              };
+              transport.send(response);
+            })
+            .catch((err) => {
+              const response: RPCResponseError = {
+                jsonrpc: '2.0',
+                id,
+                error: serializeError(err),
+              };
+              transport.send(response);
+            });
+        } catch (err) {
+           const response: RPCResponseError = {
+             jsonrpc: '2.0',
+             id,
+             error: serializeError(err),
+           };
+           transport.send(response);
+        }
+      } else {
+        // Method not found
+        const response: RPCResponseError = {
+          jsonrpc: '2.0',
+          id,
+          error: { message: `Method ${method} not found` },
+        };
+        transport.send(response);
+      }
+    } else if (isRPCResponse(message)) {
+      // It's a response: Resolve/Reject pending promise
+      const { id } = message;
+      const pending = pendingPromises.get(id);
+      if (pending) {
+        pendingPromises.delete(id);
+        if ('error' in message && message.error) {
+           // Reconstruct error
+           const errData = (message as RPCResponseError).error;
+           const error = new Error(errData.message);
+           if (errData.data && typeof errData.data === 'object') {
+             Object.assign(error, errData.data);
+           }
+           pending.reject(error);
+        } else {
+          pending.resolve((message as RPCResponseSuccess).result);
+        }
+      }
+    }
+    // Ignore other messages (opt-in approach)
+  });
+
+  // Proxy Mechanism
+  return new Proxy({} as RemoteInterface, {
+    get: (target, prop) => {
+      if (typeof prop === 'string') {
+        // Return a function that sends the RPC request
+        return (...args: unknown[]) => {
+          return new Promise((resolve, reject) => {
+            const id = generateId();
+            pendingPromises.set(id, { resolve, reject });
+
+            const request: RPCRequest = {
+              jsonrpc: '2.0',
+              id,
+              method: prop,
+              params: args,
+            };
+
+            transport.send(request);
+          });
+        };
+      }
+      return Reflect.get(target, prop);
+    },
+  });
+}

--- a/packages/plugin-bridge/src/rpc.ts
+++ b/packages/plugin-bridge/src/rpc.ts
@@ -55,7 +55,7 @@ function serializeError(error: unknown) {
         name: error.name,
         // Copy other properties
         ...Object.getOwnPropertyNames(error).reduce((acc, key) => {
-            // @ts-ignore
+            // @ts-expect-error - error is an instance of Error
             acc[key] = error[key];
             return acc;
         }, {} as Record<string, unknown>)
@@ -114,7 +114,7 @@ export function createRozeniteRPCBridge<LocalHandlers extends object, RemoteInte
     if (isRPCRequest(message)) {
       // It's a request: Execute local handler
       const { id, method, params } = message;
-      // @ts-ignore
+      // @ts-expect-error - method is a string
       const handler = localHandlers[method];
 
       if (typeof handler === 'function') {

--- a/packages/plugin-bridge/vite.config.ts
+++ b/packages/plugin-bridge/vite.config.ts
@@ -12,6 +12,10 @@ export default defineConfig({
   root: __dirname,
   cacheDir: '../../node_modules/.vite/communication',
   base: './',
+  test: {
+    globals: true,
+    environment: 'node',
+  },
   build: {
     lib: {
       entry: resolve(__dirname, 'src/index.ts'),

--- a/website/src/docs/plugin-development/plugin-development.md
+++ b/website/src/docs/plugin-development/plugin-development.md
@@ -231,7 +231,8 @@ export default function setupPlugin(client: DevToolsPluginClient) {
       send: (msg) => client.send('rpc', msg),
       onMessage: (listener) => client.onMessage('rpc', listener),
     },
-    localHandlers
+    localHandlers,
+    { timeout: 30000 } // Optional: Timeout in ms (default: 60000)
   );
 
   // You can now call methods on the DevTools side


### PR DESCRIPTION
## Description

<!-- Provide a general summary of your changes -->
The RPC bridge allows both sides to expose methods and call remote methods using a single shared channel. It uses JSON-RPC 2.0 protocol and ES6 Proxy to provide natural method calling syntax like await devTools.refresh(). Errors are automatically serialized and propagated. The implementation is opt-in, allowing coexistence with existing event-based communication patterns.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
None

## Context

<!-- Why this feature was implemented in this particular way? -->
<!-- Is there anything reviewer needs to know before conducting code review? -->
Previously, communication between apps and DevTools used an event-based messaging pattern where each side sent messages and listened for responses. While this was type-safe, it required manual promise management, call ID tracking, and custom request-response handling for each interaction. The RPC bridge provides a method-calling abstraction that automatically handles request-response pairing, promise management, and error propagation. This reduces boilerplate code and provides a more natural API for bidirectional method calls while maintaining backward compatibility with existing event-based communication.

## Testing

<!-- Please describe how you tested your changes -->
Unit tests using Vitest cover remote method calls, incoming request handling, error propagation in both directions, and opt-in compatibility with non-RPC messages. Tests use a mock transport layer to verify the full request and response cycle, including error serialization and promise management.