### PR TITLE
docs: insert @react-native-nitro-geolocation/rozenite-plugin in the plugins list

### DIFF
--- a/plugin-directory.json
+++ b/plugin-directory.json
@@ -34,5 +34,9 @@
   {
     "npmUrl": "https://www.npmjs.com/package/@ilteoood/zorro",
     "githubUrl": "https://github.com/ilteoood/zorro"
+  },
+  {
+    "npmUrl": "https://www.npmjs.com/package/@react-native-nitro-geolocation/rozenite-plugin",
+    "githubUrl": "https://github.com/jingjing2222/react-native-nitro-geolocation/tree/main/packages/rozenite-devtools-plugin"
   }
 ]


### PR DESCRIPTION
## Description

insert @react-native-nitro-geolocation/rozenite-plugin in the plugins list

![DevTools Plugin Demo](https://raw.githubusercontent.com/jingjing2222/react-native-nitro-geolocation/main/devtools.gif)
