### PR TITLE
docs: insert rozenite-graphql-client-devtool & rozenite-assets-viewer in the plugins list

### DIFF
--- a/plugin-directory.json
+++ b/plugin-directory.json
@@ -42,5 +42,9 @@
   {
     "npmUrl": "https://www.npmjs.com/package/rozenite-graphql-client-devtool",
     "githubUrl": "https://github.com/CodeByRahulSaini/rozenite-graphql-client-devtool"
+  },
+  {
+    "npmUrl": "https://www.npmjs.com/package/rozenite-assets-viewer",
+    "githubUrl": "https://github.com/CodeByRahulSaini/rozenite-assets-viewer"
   }
 ]


### PR DESCRIPTION
## Description

Please insert rozenite-graphql-client-devtool in plugins list. 


> This plugin provides a comprehensive debugging interface for monitoring and inspecting GraphQL operations in React Native applications. It supports multiple GraphQL clients through a flexible adapter pattern and offers real-time operation tracking, cache inspection, and schema exploration.
 
 
 
![preview-ezgif com-video-to-webp-converter (3)](https://github.com/user-attachments/assets/c59a3149-1910-4019-9590-305cb16b3b6f)

 

