### PR TITLE
ci: improve release workflow branch handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
     env:
       RELEASE_MODE: ${{ github.event.inputs.mode }}
       RELEASE_REF: ${{ github.event.inputs.ref }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GIT_AUTHOR_NAME: actions-bot
       GIT_AUTHOR_EMAIL: actions-bot@users.noreply.github.com
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,17 +11,13 @@ on:
           - stable
           - rc
           - canary
-      ref:
-        description: Git ref to checkout
-        required: true
-        type: string
 
 permissions:
   contents: write
   id-token: write
 
 concurrency:
-  group: release-${{ github.event.inputs.mode }}-${{ github.event.inputs.ref }}
+  group: release-${{ github.event.inputs.mode }}-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:
@@ -30,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RELEASE_MODE: ${{ github.event.inputs.mode }}
-      RELEASE_REF: ${{ github.event.inputs.ref }}
+      RELEASE_REF: ${{ github.ref_name }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GIT_AUTHOR_NAME: actions-bot
       GIT_AUTHOR_EMAIL: actions-bot@users.noreply.github.com
@@ -38,7 +34,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.event.inputs.ref }}
           fetch-depth: 0
 
       - name: Configure git identity

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -37,9 +37,9 @@ Prereleases also run manually with `.github/workflows/release.yml`.
 
 ### RC releases
 
-Use `release/<minor>` or `release/<version>` branches, for example `release/1.7` or `release/2.0`.
+Use `release/v<version>` branches, for example `release/v1.7` or `release/v2.0.0`.
 
-`rc` mode is intentionally restricted to `release/*` branches and will fail on `main`.
+`rc` mode is intentionally restricted to `release/v<version>` branches and will fail on `main`.
 
 First `rc` run on a release branch:
 

--- a/scripts/release/release.mjs
+++ b/scripts/release/release.mjs
@@ -25,6 +25,10 @@ function normalizeRef(ref) {
   return ref.replace(/^refs\/heads\//, '').trim();
 }
 
+function isReleaseBranch(ref) {
+  return /^release\/v\d+\.\d+(?:\.\d+)?$/.test(ref);
+}
+
 function run(command, args, options = {}) {
   execFileSync(command, args, {
     stdio: 'inherit',
@@ -92,7 +96,7 @@ function updateLockfile() {
   run('pnpm', ['install', '--lockfile-only']);
 }
 
-function commitVersionChanges(message) {
+function commitVersionChanges() {
   run('git', [
     'add',
     '.changeset',
@@ -108,7 +112,7 @@ function commitVersionChanges(message) {
     fail('no release files were staged for commit');
   }
 
-  run('git', ['commit', '-m', message]);
+  run('git', ['commit', '-m', `chore: release v${readVersion()}`]);
 }
 
 function pushBranch() {
@@ -166,7 +170,7 @@ function runStableRelease() {
 
   run('pnpm', ['changeset', 'version']);
   updateLockfile();
-  commitVersionChanges('Version packages for stable release');
+  commitVersionChanges();
   pushBranch();
   run('pnpm', ['release:check']);
   run('pnpm', ['release:build']);
@@ -179,8 +183,10 @@ function runRcRelease() {
     fail(`rc releases must not run from ${stableBranch}`);
   }
 
-  if (!branch.startsWith('release/')) {
-    fail(`rc releases must run from a release/* branch, received ${branch}`);
+  if (!isReleaseBranch(branch)) {
+    fail(
+      `rc releases must run from a release/v<version> branch, received ${branch}`,
+    );
   }
 
   ensureRemoteBranch();
@@ -192,7 +198,7 @@ function runRcRelease() {
 
   run('pnpm', ['changeset', 'version']);
   updateLockfile();
-  commitVersionChanges('Version packages for rc release');
+  commitVersionChanges();
   pushBranch();
   run('pnpm', ['release:check']);
   run('pnpm', ['release:build']);


### PR DESCRIPTION
## Summary
- remove the manual `ref` input from the release workflow and use the branch the workflow is run from
- align the release script and docs with the workflow-driven branch selection
- keep the release automation scoped to the current branch while preserving existing release modes