### PR TITLE
fix(require-profiler-plugin): preserve Expo SSR run-module regex

### DIFF
--- a/apps/playground/metro.config.js
+++ b/apps/playground/metro.config.js
@@ -8,11 +8,10 @@ const {
 const {
   withRozeniteRequireProfiler,
 } = require('@rozenite/require-profiler-plugin/metro');
-const {
-  withRozeniteWeb,
-} = require('@rozenite/web/metro');
+const { withRozeniteWeb } = require('@rozenite/web/metro');
 const path = require('node:path');
 
+/** @type {import('expo/metro-config').MetroConfig} */
 const config = getDefaultConfig(__dirname);
 
 const projectRoot = __dirname;
@@ -24,6 +23,23 @@ config.resolver.nodeModulesPaths = [
   path.resolve(projectRoot, 'node_modules'),
   path.resolve(workspaceRoot, 'node_modules'),
 ];
+config.resolver.assetExts.push('wasm');
+
+const previousEnhanceMiddleware = config.server?.enhanceMiddleware;
+
+config.server = {
+  ...config.server,
+  enhanceMiddleware: (middleware) => {
+    const previousMiddleware =
+      previousEnhanceMiddleware?.(middleware) ?? middleware;
+
+    return (req, res, next) => {
+      res.setHeader('Cross-Origin-Embedder-Policy', 'credentialless');
+      res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+      previousMiddleware(req, res, next);
+    };
+  },
+};
 
 module.exports = composeMetroConfigTransformers([
   withRozenite,

--- a/packages/require-profiler-plugin/src/metro/index.ts
+++ b/packages/require-profiler-plugin/src/metro/index.ts
@@ -37,7 +37,7 @@ export const withRozeniteRequireProfiler = createMetroConfigTransformer(
         ],
         getRunModuleStatement: (...opts) => {
           const statement = existingGetRunModuleStatement(...opts);
-          return `typeof __patchSystrace === "function" && __patchSystrace();${statement}`;
+          return `typeof __patchSystrace === "function" && __patchSystrace();\n${statement}`;
         },
       },
     };


### PR DESCRIPTION
## Summary
- preserve Expo SSR static rendering compatibility in the require profiler Metro hook
- keep Metro's final `__r(...);` call on its own line so Expo's SSR wrapper regex still matches it
- update the playground Metro config with the server middleware and `wasm` asset handling used for the Expo server-side setup

## Problem
The require profiler prefixes Metro's run-module statement in `getRunModuleStatement()`.

Expo SSR later rewrites bundled output with a regex that only matches lines shaped exactly like:

`__r(...);`

When the profiler returned:

`typeof __patchSystrace === \"function\" && __patchSystrace();__r(...);`

that regex stopped matching. As a result, Expo SSR did not rewrite the final run-module line, the SSR-evaluated module returned the wrong shape, and `bundleStaticHtml()` could end up with `getStaticContent` not being a function.

## Fix
- insert a newline between the profiler prefix and the original Metro run statement so the final `__r(...);` remains on its own line
- restore the playground Metro config needed for the Expo web server setup, including COEP/COOP middleware composition and `wasm` asset support