### PR TITLE
Add GrowthBook plugin to community plugins

### DIFF
--- a/plugin-directory.json
+++ b/plugin-directory.json
@@ -70,5 +70,9 @@
   {
     "npmUrl": "https://www.npmjs.com/package/rozenite-assets-viewer",
     "githubUrl": "https://github.com/CodeByRahulSaini/rozenite-assets-viewer"
+  },
+  {
+    "npmUrl": "https://www.npmjs.com/package/rozenite-growthbook-plugin",
+    "githubUrl": "https://github.com/valeriobelli/rozenite-growthbook-plugin"
   }
 ]


### PR DESCRIPTION
## Description

This plugin adds the integration to manage GrowthBook client, similarly to the [Chrome counterpart](https://chromewebstore.google.com/detail/growthbook-devtools/opemhndcehfgipokneipaafbglcecjia).

![demo](https://github.com/user-attachments/assets/0034452e-6bae-4290-b50a-ac6231d883df)
