### PR TITLE
feat(sqlite-plugin): add adapter-helpers subpath export

### DIFF
--- a/packages/sqlite-plugin/package.json
+++ b/packages/sqlite-plugin/package.json
@@ -76,6 +76,11 @@
       "import": "./dist/react-native/index.js",
       "require": "./dist/react-native/index.cjs"
     },
+    "./adapter-helpers": {
+      "types": "./dist/react-native/adapter-helpers.d.ts",
+      "import": "./dist/react-native/adapter-helpers.js",
+      "require": "./dist/react-native/adapter-helpers.cjs"
+    },
     "./package.json": "./package.json"
   },
   "publishConfig": {

--- a/packages/sqlite-plugin/src/react-native/adapter-helpers.ts
+++ b/packages/sqlite-plugin/src/react-native/adapter-helpers.ts
@@ -1,0 +1,11 @@
+/**
+ * Shared SQL + bridge helpers for custom adapters (e.g. non-Expo SQLite drivers).
+ */
+export type { SqlStatementSegment } from '../shared/sql';
+export {
+  classifySqlStatement,
+  normalizeSingleStatementSql,
+  splitSqlStatements,
+  statementReturnsRows,
+} from '../shared/sql';
+export { decodeSqliteBridgeValue, formatSqliteError } from '../shared/bridge-values';

--- a/packages/sqlite-plugin/vite.config.ts
+++ b/packages/sqlite-plugin/vite.config.ts
@@ -1,10 +1,51 @@
 /// <reference types='vitest' />
+import path from 'node:path';
 import { defineConfig } from 'vite';
 import { rozenitePlugin } from '@rozenite/vite-plugin';
 
+const sqliteAdapterHelpersSubpathPlugin = {
+  name: 'sqlite-plugin-adapter-helpers-subpath',
+  enforce: 'post' as const,
+  config(config: import('vite').UserConfig) {
+    const root = __dirname;
+    config.build ??= {};
+    const currentEntry = config.build.lib?.entry;
+    const normalizedEntry =
+      typeof currentEntry === 'string'
+        ? { index: currentEntry }
+        : (currentEntry ?? {});
+
+    config.build.lib = {
+      ...config.build.lib,
+      entry: {
+        ...normalizedEntry,
+        'adapter-helpers': path.resolve(
+          root,
+          'src/react-native/adapter-helpers.ts',
+        ),
+      },
+    };
+    config.build.rollupOptions ??= {};
+    const currentOutput = config.build.rollupOptions.output;
+    const applyEntryNaming = (output: import('rollup').OutputOptions) => ({
+      ...output,
+      entryFileNames:
+        output.format === 'cjs'
+          ? 'react-native/[name].cjs'
+          : 'react-native/[name].js',
+    });
+
+    if (Array.isArray(currentOutput)) {
+      config.build.rollupOptions.output = currentOutput.map(applyEntryNaming);
+    } else if (currentOutput) {
+      config.build.rollupOptions.output = applyEntryNaming(currentOutput);
+    }
+  },
+};
+
 export default defineConfig({
   root: __dirname,
-  plugins: [rozenitePlugin()],
+  plugins: [rozenitePlugin(), sqliteAdapterHelpersSubpathPlugin],
   test: {
     passWithNoTests: true,
   },


### PR DESCRIPTION
### Summary

We’re integrating Rozenite SQLite inspector with non-Expo SQLite drivers (e.g. react-native-nitro-sqlite). The plugin already has shared SQL normalization / statement classification / bridge decode / error formatting helpers, but they were not available on a stable public subpath.

This PR exposes those helpers via a dedicated subpath:

- `@rozenite/sqlite-plugin/adapter-helpers`

This keeps helper code out of the main package entry and avoids leaking it into production builds that only use the core plugin APIs.

### Implementation notes

- Added `src/react-native/adapter-helpers.ts` to re-export existing shared helpers from `src/shared/sql` and `src/shared/bridge-values`.
- Added `./adapter-helpers` to `packages/sqlite-plugin/package.json` exports.
- Added a second RN build entry in `vite.config.ts` so dist emits:
  - `dist/react-native/adapter-helpers.js`
  - `dist/react-native/adapter-helpers.cjs`
  - `dist/react-native/adapter-helpers.d.ts`

### Question for maintainers

We also have a small adapter that wires react-native-nitro-sqlite into `createSqliteAdapter`, using these same helpers. Are you open to follow-up PRs that add additional first-party adapters (e.g. Nitro)?

---

Thanks for reviewing.
