### PR TITLE
feat: SQLite agent tools, web-ready storage, and Rozenite for Web docs

### DIFF
--- a/.changeset/sqlite-agent-tools.md
+++ b/.changeset/sqlite-agent-tools.md
@@ -1,0 +1,5 @@
+---
+'@rozenite/sqlite-plugin': minor
+---
+
+Add agent tool support to the SQLite plugin. LLM agents can now use `list-databases` to discover registered databases and `execute-sql` to run any SQL — including multi-statement scripts — against a specific database.

--- a/.changeset/sqlite-plugin-web.md
+++ b/.changeset/sqlite-plugin-web.md
@@ -1,5 +1,0 @@
----
-'@rozenite/sqlite-plugin': minor
----
-
-The SQLite plugin now loads in **development on web** (React Native for Web) instead of staying disabled. Use it when `expo-sqlite` is configured for web (Expo’s WASM and header setup); behavior matches your registered databases in the browser dev session.

--- a/.changeset/sqlite-plugin-web.md
+++ b/.changeset/sqlite-plugin-web.md
@@ -1,0 +1,5 @@
+---
+'@rozenite/sqlite-plugin': minor
+---
+
+The SQLite plugin now loads in **development on web** (React Native for Web) instead of staying disabled. Use it when `expo-sqlite` is configured for web (Expo’s WASM and header setup); behavior matches your registered databases in the browser dev session.

--- a/.changeset/storage-plugin-web.md
+++ b/.changeset/storage-plugin-web.md
@@ -1,0 +1,5 @@
+---
+'@rozenite/storage-plugin': minor
+---
+
+The Storage plugin now runs in **development on web** (React Native for Web) when using Rozenite for Web. AsyncStorage and Expo SecureStore adapters work as on native; **MMKV** stays unavailable in the browser, so the MMKV adapter resolves to an **empty inspector** (same as production) without loading `react-native-mmkv` in your web bundle.

--- a/apps/playground/metro.config.js
+++ b/apps/playground/metro.config.js
@@ -25,6 +25,18 @@ config.resolver.nodeModulesPaths = [
   path.resolve(workspaceRoot, 'node_modules'),
 ];
 
+// Add wasm asset support
+config.resolver.assetExts.push('wasm');
+
+// Add COEP and COOP headers to support SharedArrayBuffer
+config.server.enhanceMiddleware = (middleware) => {
+  return (req, res, next) => {
+    res.setHeader('Cross-Origin-Embedder-Policy', 'credentialless');
+    res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+    return middleware(req, res, next);
+  };
+};
+
 module.exports = composeMetroConfigTransformers([
   withRozenite,
   {

--- a/apps/playground/src/app/App.web.tsx
+++ b/apps/playground/src/app/App.web.tsx
@@ -1,113 +1,35 @@
-import { useState } from 'react';
+import { SafeAreaView, ScrollView, StyleSheet, Text } from 'react-native';
 import {
-  ActivityIndicator,
-  Pressable,
-  SafeAreaView,
-  ScrollView,
-  StyleSheet,
-  Text,
-  View,
-} from 'react-native';
-import { api, type Post, type User } from './utils/network-activity/api';
+  ControlsPluginSection,
+  OverlayPluginSection,
+  PerformanceMonitorPluginSection,
+  ReactNavigationPluginSection,
+  ReduxDevToolsPluginSection,
+  SqlitePluginSection,
+  StoragePluginSection,
+  TanStackQueryPluginSection,
+} from './WebPluginSections';
 
 export default function App() {
-  const [users, setUsers] = useState<User[]>([]);
-  const [post, setPost] = useState<Post | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
-
-  const loadUsers = async () => {
-    setLoading(true);
-    setError(null);
-
-    try {
-      setUsers(await api.getUsers());
-    } catch (nextError) {
-      setError(
-        nextError instanceof Error ? nextError.message : 'Failed to load users',
-      );
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const createTestPost = async () => {
-    setLoading(true);
-    setError(null);
-
-    try {
-      setPost(
-        await api.createPost({
-          title: 'Webpack web smoke test',
-          body: 'Testing the React Native Web webpack setup.',
-          userId: 1,
-        }),
-      );
-    } catch (nextError) {
-      setError(
-        nextError instanceof Error
-          ? nextError.message
-          : 'Failed to create post',
-      );
-    } finally {
-      setLoading(false);
-    }
-  };
-
   return (
     <SafeAreaView style={styles.safeArea}>
       <ScrollView contentContainerStyle={styles.content}>
-        <Text style={styles.eyebrow}>React Native Web</Text>
-        <Text style={styles.title}>Playground webpack smoke test</Text>
+        <Text style={styles.eyebrow}>Rozenite for Web</Text>
         <Text style={styles.description}>
-          This uses `webpack` plus `react-native-web` against the existing
-          `src/main.tsx` entry.
+          Requirements: install the Rozenite Chrome extension, add
+          `@rozenite/web`, wrap your web bundler config with `withRozeniteWeb`,
+          and load `require('@rozenite/web')` in your web entry point. Then run
+          the app in development on a Chromium-based browser.
         </Text>
 
-        <View style={styles.actions}>
-          <Pressable onPress={loadUsers} style={styles.primaryButton}>
-            <Text style={styles.primaryButtonText}>Load users</Text>
-          </Pressable>
-          <Pressable onPress={createTestPost} style={styles.secondaryButton}>
-            <Text style={styles.secondaryButtonText}>Create test post</Text>
-          </Pressable>
-        </View>
-
-        {loading ? (
-          <View style={styles.card}>
-            <ActivityIndicator color="#8b5cf6" />
-            <Text style={styles.muted}>Running request...</Text>
-          </View>
-        ) : null}
-
-        {error ? (
-          <View style={styles.errorCard}>
-            <Text style={styles.errorTitle}>Request failed</Text>
-            <Text style={styles.errorText}>{error}</Text>
-          </View>
-        ) : null}
-
-        {post ? (
-          <View style={styles.card}>
-            <Text style={styles.sectionTitle}>Latest created post</Text>
-            <Text style={styles.cardTitle}>{post.title}</Text>
-            <Text style={styles.cardText}>{post.body}</Text>
-          </View>
-        ) : null}
-
-        <View style={styles.card}>
-          <Text style={styles.sectionTitle}>Fetched users</Text>
-          {users.length === 0 ? (
-            <Text style={styles.muted}>No users loaded yet.</Text>
-          ) : (
-            users.map((user) => (
-              <View key={user.id} style={styles.userRow}>
-                <Text style={styles.cardTitle}>{user.name}</Text>
-                <Text style={styles.cardText}>{user.email}</Text>
-              </View>
-            ))
-          )}
-        </View>
+        <StoragePluginSection />
+        <ReactNavigationPluginSection />
+        <ControlsPluginSection />
+        <OverlayPluginSection />
+        <PerformanceMonitorPluginSection />
+        <ReduxDevToolsPluginSection />
+        <SqlitePluginSection />
+        <TanStackQueryPluginSection />
       </ScrollView>
     </SafeAreaView>
   );
@@ -125,6 +47,7 @@ const styles = StyleSheet.create({
     width: '100%',
     maxWidth: 880,
     alignSelf: 'center',
+    paddingBottom: 48,
   },
   eyebrow: {
     color: '#8b5cf6',
@@ -133,95 +56,10 @@ const styles = StyleSheet.create({
     textTransform: 'uppercase',
     letterSpacing: 1,
   },
-  title: {
-    color: '#f8fafc',
-    fontSize: 36,
-    fontWeight: '800',
-  },
   description: {
     color: '#cbd5e1',
     fontSize: 16,
     lineHeight: 24,
-    maxWidth: 640,
-  },
-  actions: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: 12,
-  },
-  primaryButton: {
-    backgroundColor: '#8b5cf6',
-    borderRadius: 999,
-    paddingHorizontal: 18,
-    paddingVertical: 12,
-  },
-  secondaryButton: {
-    backgroundColor: '#111827',
-    borderRadius: 999,
-    borderWidth: 1,
-    borderColor: '#334155',
-    paddingHorizontal: 18,
-    paddingVertical: 12,
-  },
-  primaryButtonText: {
-    color: '#ffffff',
-    fontSize: 15,
-    fontWeight: '700',
-  },
-  secondaryButtonText: {
-    color: '#e2e8f0',
-    fontSize: 15,
-    fontWeight: '700',
-  },
-  card: {
-    backgroundColor: '#111827',
-    borderRadius: 20,
-    borderWidth: 1,
-    borderColor: '#1f2937',
-    gap: 10,
-    padding: 20,
-  },
-  errorCard: {
-    backgroundColor: '#3f1d2e',
-    borderRadius: 20,
-    borderWidth: 1,
-    borderColor: '#7f1d1d',
-    gap: 8,
-    padding: 20,
-  },
-  sectionTitle: {
-    color: '#f8fafc',
-    fontSize: 18,
-    fontWeight: '700',
-  },
-  errorTitle: {
-    color: '#fecaca',
-    fontSize: 18,
-    fontWeight: '700',
-  },
-  errorText: {
-    color: '#fee2e2',
-    fontSize: 14,
-    lineHeight: 20,
-  },
-  cardTitle: {
-    color: '#f8fafc',
-    fontSize: 16,
-    fontWeight: '600',
-  },
-  cardText: {
-    color: '#cbd5e1',
-    fontSize: 14,
-    lineHeight: 20,
-  },
-  muted: {
-    color: '#94a3b8',
-    fontSize: 14,
-  },
-  userRow: {
-    gap: 4,
-    borderTopWidth: 1,
-    borderTopColor: '#1f2937',
-    paddingTop: 12,
+    maxWidth: 720,
   },
 });

--- a/apps/playground/src/app/App.web.tsx
+++ b/apps/playground/src/app/App.web.tsx
@@ -18,7 +18,7 @@ export default function App() {
         <Text style={styles.description}>
           Requirements: install the Rozenite Chrome extension, add
           `@rozenite/web`, wrap your web bundler config with `withRozeniteWeb`,
-          and load `require('@rozenite/web')` in your web entry point. Then run
+          and load `require(&apos;@rozenite/web&apos;)` in your web entry point. Then run
           the app in development on a Chromium-based browser.
         </Text>
 

--- a/apps/playground/src/app/WebPluginSections.tsx
+++ b/apps/playground/src/app/WebPluginSections.tsx
@@ -1,0 +1,226 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { QueryClient } from '@tanstack/react-query';
+import { useRozeniteControlsPlugin } from '@rozenite/controls-plugin';
+import { RozeniteOverlay } from '@rozenite/overlay-plugin';
+import { usePerformanceMonitorDevTools } from '@rozenite/performance-monitor-plugin';
+import { useReactNavigationDevTools } from '@rozenite/react-navigation-plugin';
+import {
+  rozeniteDevToolsEnhancer,
+  useReduxDevToolsAgentTools,
+} from '@rozenite/redux-devtools-plugin';
+import { useRozeniteStoragePlugin } from '@rozenite/storage-plugin';
+import { useTanStackQueryDevTools } from '@rozenite/tanstack-query-plugin';
+import { useEffect, useRef, type ReactNode } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { usePlaygroundControlsSections } from './hooks/usePlaygroundControlsSections';
+import { storagePluginAdapters } from './storage-plugin-adapters';
+
+const tanstackQueryClient = new QueryClient();
+
+const reduxStore = configureStore({
+  reducer: (state = { count: 0 }, action: { type: string }) => {
+    if (action.type === 'web/increment') {
+      return { count: state.count + 1 };
+    }
+
+    return state;
+  },
+  enhancers: (getDefaultEnhancers) =>
+    getDefaultEnhancers().concat(
+      rozeniteDevToolsEnhancer({
+        name: 'playground-web-counter',
+        maxAge: 100,
+      }),
+    ),
+});
+
+type PluginCardProps = {
+  title: string;
+  packageName: string;
+  description: string;
+  notes?: string[];
+  children?: ReactNode;
+};
+
+const PluginCard = ({
+  title,
+  packageName,
+  description,
+  notes,
+  children,
+}: PluginCardProps) => {
+  return (
+    <View style={styles.card}>
+      <Text style={styles.sectionTitle}>{title}</Text>
+      <Text style={styles.packageName}>{packageName}</Text>
+      <Text style={styles.cardText}>{description}</Text>
+      {notes?.map((note) => (
+        <Text key={note} style={styles.note}>
+          {note}
+        </Text>
+      ))}
+      {children}
+    </View>
+  );
+};
+
+export const StoragePluginSection = () => {
+  useRozeniteStoragePlugin({
+    storages: storagePluginAdapters,
+  });
+
+  return (
+    <PluginCard
+      title="Storage"
+      packageName="@rozenite/storage-plugin"
+      description="Unified storage inspection for adapters you register. On web, Async Storage and Expo Secure Store paths are active; the MMKV adapter stays inert because MMKV does not run in the browser."
+      notes={[
+        'Use Async Storage or Expo Secure Store adapters in web playground code; MMKV remains native-only.',
+      ]}
+    />
+  );
+};
+
+export const ReactNavigationPluginSection = () => {
+  const navigationRef = useRef<any>(null);
+
+  useReactNavigationDevTools({
+    ref: navigationRef,
+  });
+
+  return (
+    <PluginCard
+      title="React Navigation"
+      packageName="@rozenite/react-navigation-plugin"
+      description="Inspect navigation state, actions, and deep links from DevTools when your web app uses React Navigation."
+      notes={[
+        'The hook is configured with a navigation ref in this web entry so the plugin can attach when a navigation container is present.',
+      ]}
+    />
+  );
+};
+
+export const ControlsPluginSection = () => {
+  const sections = usePlaygroundControlsSections();
+
+  useRozeniteControlsPlugin({
+    sections,
+  });
+
+  return (
+    <PluginCard
+      title="Controls"
+      packageName="@rozenite/controls-plugin"
+      description="Surface toggles, inputs, and actions from your app into DevTools for quick manual testing while the web bundle is running."
+    />
+  );
+};
+
+export const OverlayPluginSection = () => {
+  return (
+    <PluginCard
+      title="Overlay"
+      packageName="@rozenite/overlay-plugin"
+      description="Alignment grids and image comparison overlays driven from DevTools; works with React Native Web views in development."
+      notes={['Mounting RozeniteOverlay enables the plugin runtime bridge.']}
+    >
+      <RozeniteOverlay />
+    </PluginCard>
+  );
+};
+
+export const PerformanceMonitorPluginSection = () => {
+  usePerformanceMonitorDevTools();
+
+  return (
+    <PluginCard
+      title="Performance monitor"
+      packageName="@rozenite/performance-monitor-plugin"
+      description="Streams marks, measures, and metrics to DevTools via the same bridge used on native when react-native-performance is available in your web build."
+    />
+  );
+};
+
+export const ReduxDevToolsPluginSection = () => {
+  useReduxDevToolsAgentTools();
+
+  useEffect(() => {
+    reduxStore.dispatch({ type: 'web/increment' });
+  }, []);
+
+  return (
+    <PluginCard
+      title="Redux DevTools"
+      packageName="@rozenite/redux-devtools-plugin"
+      description="Connect Redux stores to Rozenite with the Redux enhancer so time-travel and state inspection work in the browser target."
+      notes={['A dedicated demo store is created with rozeniteDevToolsEnhancer.']}
+    />
+  );
+};
+
+/**
+ * SQLite plugin is intentionally not wired on web: expo-sqlite has upstream
+ * issues in browser builds. Use the native playground for SQLite + Rozenite.
+ */
+export const SqlitePluginSection = () => {
+  return (
+    <PluginCard
+      title="SQLite"
+      packageName="@rozenite/sqlite-plugin"
+      description="The SQLite plugin is disabled in this web entry because of upstream bugs in expo-sqlite on web. Use the iOS or Android playground to exercise the SQLite plugin with Rozenite."
+      notes={['`useRozeniteSqlitePlugin` and expo-sqlite are not loaded on web.']}
+    />
+  );
+};
+
+export const TanStackQueryPluginSection = () => {
+  useTanStackQueryDevTools(tanstackQueryClient);
+
+  useEffect(() => {
+    tanstackQueryClient.setQueryData(['web-plugin-section', 'demo'], {
+      initializedAt: new Date().toISOString(),
+      status: 'ready',
+    });
+  }, []);
+
+  return (
+    <PluginCard
+      title="TanStack Query"
+      packageName="@rozenite/tanstack-query-plugin"
+      description="Inspect TanStack Query caches, queries, and mutations from DevTools with the same hook integration as on native."
+    />
+  );
+};
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: '#111827',
+    borderRadius: 20,
+    borderWidth: 1,
+    borderColor: '#1f2937',
+    gap: 8,
+    padding: 20,
+  },
+  sectionTitle: {
+    color: '#f8fafc',
+    fontSize: 18,
+    fontWeight: '700',
+  },
+  packageName: {
+    color: '#a78bfa',
+    fontSize: 13,
+    fontWeight: '600',
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+  },
+  cardText: {
+    color: '#cbd5e1',
+    fontSize: 14,
+    lineHeight: 22,
+  },
+  note: {
+    color: '#94a3b8',
+    fontSize: 13,
+    lineHeight: 20,
+    marginTop: 4,
+  },
+});

--- a/packages/sqlite-plugin/README.md
+++ b/packages/sqlite-plugin/README.md
@@ -52,6 +52,10 @@ function App() {
 }
 ```
 
+## Web (React Native for Web)
+
+With [Rozenite for Web](https://rozenite.dev/docs/rozenite-for-web), this plugin runs in the browser in development when `expo-sqlite` is set up for web. Follow Expo’s **Web setup** for `expo-sqlite` (WASM support in Metro, and COEP/COOP or related headers for `SharedArrayBuffer` where required). Web support in Expo is documented as alpha; see the [Expo SQLite docs](https://docs.expo.dev/versions/latest/sdk/sqlite/).
+
 ## Custom adapters
 
 You can support any SQLite-like library by normalizing its statement execution API:

--- a/packages/sqlite-plugin/README.md
+++ b/packages/sqlite-plugin/README.md
@@ -52,10 +52,6 @@ function App() {
 }
 ```
 
-## Web (React Native for Web)
-
-With [Rozenite for Web](https://rozenite.dev/docs/rozenite-for-web), this plugin runs in the browser in development when `expo-sqlite` is set up for web. Follow Expo’s **Web setup** for `expo-sqlite` (WASM support in Metro, and COEP/COOP or related headers for `SharedArrayBuffer` where required). Web support in Expo is documented as alpha; see the [Expo SQLite docs](https://docs.expo.dev/versions/latest/sdk/sqlite/).
-
 ## Custom adapters
 
 You can support any SQLite-like library by normalizing its statement execution API:

--- a/packages/sqlite-plugin/package.json
+++ b/packages/sqlite-plugin/package.json
@@ -22,6 +22,7 @@
     "test": "vitest --run"
   },
   "dependencies": {
+    "@rozenite/agent-bridge": "workspace:*",
     "@rozenite/plugin-bridge": "workspace:*"
   },
   "devDependencies": {

--- a/packages/sqlite-plugin/react-native.ts
+++ b/packages/sqlite-plugin/react-native.ts
@@ -28,9 +28,9 @@ export let createSqliteAdapter: CreateSqliteAdapter;
 export let createExpoSqliteAdapter: CreateExpoSqliteAdapter;
 export let useRozeniteSqlitePlugin: typeof import('./src/react-native/useRozeniteSqlitePlugin').useRozeniteSqlitePlugin;
 
+const isDev = process.env.NODE_ENV !== 'production';
 const isWeb =
   typeof window !== 'undefined' && window.navigator.product !== 'ReactNative';
-const isDev = process.env.NODE_ENV !== 'production';
 const isServer = typeof window === 'undefined';
 
 if (isDev && !isWeb && !isServer) {

--- a/packages/sqlite-plugin/src/react-native/useRozeniteSqlitePlugin.ts
+++ b/packages/sqlite-plugin/src/react-native/useRozeniteSqlitePlugin.ts
@@ -10,6 +10,7 @@ import type {
   SqliteStatementInput,
 } from '../shared/types';
 import { createSqliteDatabaseViews } from './sqlite-view';
+import { useSqliteAgentTools } from './useSqliteAgentTools';
 
 export type RozeniteSqlitePluginOptions = {
   adapters: SqliteAdapter[];
@@ -27,6 +28,8 @@ export const useRozeniteSqlitePlugin = ({
   adapters,
 }: RozeniteSqlitePluginOptions) => {
   const views = useMemo(() => createSqliteDatabaseViews(adapters), [adapters]);
+
+  useSqliteAgentTools(views);
   const client = useRozeniteDevToolsClient<SqliteEventMap>({
     pluginId: PLUGIN_ID,
   });

--- a/packages/sqlite-plugin/src/react-native/useSqliteAgentTools.ts
+++ b/packages/sqlite-plugin/src/react-native/useSqliteAgentTools.ts
@@ -1,0 +1,152 @@
+import { useCallback } from 'react';
+import { useRozenitePluginAgentTool, type AgentTool } from '@rozenite/agent-bridge';
+import { formatSqliteError } from '../shared/bridge-values';
+import { normalizeSingleStatementSql, splitSqlStatements } from '../shared/sql';
+import type { SqliteExecuteStatementsError } from '../shared/types';
+import type { SqliteDatabaseView } from './sqlite-view';
+
+type ExecuteSqlInput = {
+  databaseId: string;
+  sql: string;
+};
+
+const pluginId = '@rozenite/sqlite-plugin';
+
+const listDatabasesTool: AgentTool = {
+  name: 'list-databases',
+  description: 'List all registered SQLite databases.',
+  inputSchema: { type: 'object', properties: {} },
+};
+
+const executeSqlTool: AgentTool = {
+  name: 'execute-sql',
+  description:
+    'Execute one or more SQL statements against a database. Supports SELECT, INSERT, UPDATE, DELETE, PRAGMA, DDL, and multi-statement scripts. Returns per-statement results including rows, columns, and metadata. Statements are executed in order and stop on first error.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      databaseId: {
+        type: 'string',
+        description: 'Database ID from list-databases.',
+      },
+      sql: {
+        type: 'string',
+        description:
+          'SQL to execute. May contain multiple semicolon-separated statements.',
+      },
+    },
+    required: ['databaseId', 'sql'],
+  },
+};
+
+const isExecuteStatementsError = (
+  error: unknown,
+): error is SqliteExecuteStatementsError =>
+  error instanceof Error &&
+  ('completedResults' in error || 'failedStatementIndex' in error);
+
+export const useSqliteAgentTools = (views: SqliteDatabaseView[]) => {
+  const resolveDatabase = useCallback(
+    (databaseId: string) => {
+      const database = views.find((view) => view.id === databaseId);
+
+      if (!database) {
+        const available = views.map((v) => v.id).join(', ');
+        throw new Error(
+          `Unknown databaseId "${databaseId}". Available: ${available || '(none)'}`,
+        );
+      }
+
+      return database;
+    },
+    [views],
+  );
+
+  useRozenitePluginAgentTool({
+    pluginId,
+    tool: listDatabasesTool,
+    handler: () => ({
+      databases: views.map(({ id, name, adapterId, adapterName }) => ({
+        id,
+        name,
+        adapterId,
+        adapterName,
+      })),
+    }),
+  });
+
+  useRozenitePluginAgentTool<ExecuteSqlInput>({
+    pluginId,
+    tool: executeSqlTool,
+    handler: async ({ databaseId, sql }) => {
+      const database = resolveDatabase(databaseId);
+      const statementSegments = splitSqlStatements(sql);
+
+      if (statementSegments.length === 0) {
+        throw new Error('SQL cannot be empty.');
+      }
+
+      const statementInputs = statementSegments.map((segment) => ({
+        sql: normalizeSingleStatementSql(segment.text),
+      }));
+
+      try {
+        const results = await database.executeStatements(statementInputs);
+
+        return {
+          databaseId,
+          totalStatementCount: statementSegments.length,
+          failedStatementIndex: null,
+          statements: statementSegments.map((_, index) => {
+            const result = results[index]!;
+            return {
+              index,
+              sql: statementInputs[index]!.sql,
+              rows: result.rows,
+              columns: result.columns,
+              metadata: result.metadata,
+            };
+          }),
+        };
+      } catch (error) {
+        if (!isExecuteStatementsError(error)) {
+          throw new Error(formatSqliteError(error));
+        }
+
+        const failedStatementIndex = Math.max(
+          0,
+          Math.min(
+            typeof error.failedStatementIndex === 'number'
+              ? error.failedStatementIndex
+              : (error.completedResults?.length ?? 0),
+            statementSegments.length - 1,
+          ),
+        );
+        const completedResults = (error.completedResults ?? []).slice(
+          0,
+          failedStatementIndex,
+        );
+
+        return {
+          databaseId,
+          totalStatementCount: statementSegments.length,
+          failedStatementIndex,
+          statements: [
+            ...completedResults.map((result, index) => ({
+              index,
+              sql: statementInputs[index]!.sql,
+              rows: result.rows,
+              columns: result.columns,
+              metadata: result.metadata,
+            })),
+            {
+              index: failedStatementIndex,
+              sql: statementInputs[failedStatementIndex]!.sql,
+              error: formatSqliteError(error),
+            },
+          ],
+        };
+      }
+    },
+  });
+};

--- a/packages/storage-plugin/README.md
+++ b/packages/storage-plugin/README.md
@@ -69,6 +69,12 @@ createAsyncStorageAdapter({
 
 `createExpoAsyncStorageAdapter` is still exported as a backward-compatible alias.
 
+## Web (React Native for Web)
+
+When you use [Rozenite for Web](https://rozenite.dev/docs/rozenite-for-web) in development, this plugin loads in the browser like on native. **AsyncStorage** and **Expo SecureStore** adapters work on web when the underlying libraries do.
+
+**MMKV** is not available in typical web bundles. In development on web, `createMMKVStorageAdapter` returns an adapter with **empty `storages`** (same behavior as production builds), so you can keep shared setup code without importing `react-native-mmkv` in the web bundle.
+
 ## Notes
 
 - Unsupported value types are disabled in UI create/edit flows.

--- a/packages/storage-plugin/react-native.ts
+++ b/packages/storage-plugin/react-native.ts
@@ -30,28 +30,17 @@ const isWeb =
 const isDev = process.env.NODE_ENV !== 'production';
 const isServer = typeof window === 'undefined';
 
-if (isDev && !isWeb && !isServer) {
-  createAsyncStorageAdapter =
-    require('./src/react-native/adapters').createAsyncStorageAdapter;
-  createExpoAsyncStorageAdapter =
-    require('./src/react-native/adapters').createExpoAsyncStorageAdapter;
-  createExpoSecureStorageAdapter =
-    require('./src/react-native/adapters').createExpoSecureStorageAdapter;
-  createMMKVStorageAdapter =
-    require('./src/react-native/adapters').createMMKVStorageAdapter;
-  useRozeniteStoragePlugin =
-    require('./src/react-native/useRozeniteStoragePlugin').useRozeniteStoragePlugin;
-} else {
-  const createNoopStorageAdapter = (
-    options: { adapterId?: string; adapterName?: string } | undefined,
-    defaultId: string,
-    defaultName: string
-  ) => ({
-    id: options?.adapterId ?? defaultId,
-    name: options?.adapterName ?? defaultName,
-    storages: [],
-  });
+const createNoopStorageAdapter = (
+  options: { adapterId?: string; adapterName?: string } | undefined,
+  defaultId: string,
+  defaultName: string
+) => ({
+  id: options?.adapterId ?? defaultId,
+  name: options?.adapterName ?? defaultName,
+  storages: [],
+});
 
+if (!isDev || isServer) {
   createAsyncStorageAdapter = ((
     options: { adapterId?: string; adapterName?: string }
   ) =>
@@ -74,4 +63,27 @@ if (isDev && !isWeb && !isServer) {
     options: { adapterId?: string; adapterName?: string }
   ) => createNoopStorageAdapter(options, 'mmkv', 'MMKV')) as typeof createMMKVStorageAdapter;
   useRozeniteStoragePlugin = () => null;
+} else if (isWeb) {
+  const asyncStorageModule = require('./src/react-native/adapters/async-storage');
+  const secureStorageModule = require('./src/react-native/adapters/secure-storage');
+
+  createAsyncStorageAdapter = asyncStorageModule.createAsyncStorageAdapter;
+  createExpoAsyncStorageAdapter = asyncStorageModule.createExpoAsyncStorageAdapter;
+  createExpoSecureStorageAdapter = secureStorageModule.createExpoSecureStorageAdapter;
+  createMMKVStorageAdapter = ((
+    options: { adapterId?: string; adapterName?: string }
+  ) => createNoopStorageAdapter(options, 'mmkv', 'MMKV')) as typeof createMMKVStorageAdapter;
+  useRozeniteStoragePlugin =
+    require('./src/react-native/useRozeniteStoragePlugin').useRozeniteStoragePlugin;
+} else {
+  createAsyncStorageAdapter =
+    require('./src/react-native/adapters').createAsyncStorageAdapter;
+  createExpoAsyncStorageAdapter =
+    require('./src/react-native/adapters').createExpoAsyncStorageAdapter;
+  createExpoSecureStorageAdapter =
+    require('./src/react-native/adapters').createExpoSecureStorageAdapter;
+  createMMKVStorageAdapter =
+    require('./src/react-native/adapters').createMMKVStorageAdapter;
+  useRozeniteStoragePlugin =
+    require('./src/react-native/useRozeniteStoragePlugin').useRozeniteStoragePlugin;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -652,7 +652,7 @@ importers:
         version: 7.7.0
       vitest:
         specifier: ^4.0.18
-        version: 4.1.0(@types/node@22.17.0)(@vitest/ui@3.2.4(vitest@3.2.4))(jiti@2.6.1)(jsdom@22.1.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.1.0(@types/node@22.17.0)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@22.1.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.8.1)
 
   packages/mmkv-plugin:
     dependencies:
@@ -1201,6 +1201,9 @@ importers:
 
   packages/sqlite-plugin:
     dependencies:
+      '@rozenite/agent-bridge':
+        specifier: workspace:*
+        version: link:../agent-bridge
       '@rozenite/plugin-bridge':
         specifier: workspace:*
         version: link:../plugin-bridge
@@ -20032,7 +20035,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@18.16.9)(@vitest/ui@3.2.4)(jiti@2.4.2)(jsdom@22.1.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.8.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.17.0)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@22.1.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.8.1)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -28431,7 +28434,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.1.0(@types/node@22.17.0)(@vitest/ui@3.2.4(vitest@3.2.4))(jiti@2.6.1)(jsdom@22.1.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.8.1):
+  vitest@4.1.0(@types/node@22.17.0)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@22.1.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.8.1):
     dependencies:
       '@vitest/expect': 4.1.0
       '@vitest/mocker': 4.1.0(vite@7.3.1(@types/node@22.17.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.8.1))

--- a/website/src/docs/official-plugins/controls.mdx
+++ b/website/src/docs/official-plugins/controls.mdx
@@ -98,6 +98,10 @@ function App() {
 }
 ```
 
+## Web (React Native for Web)
+
+With [Rozenite for Web](/docs/rozenite-for-web), this plugin is available when you debug your React Native web app.
+
 ## Usage
 
 Once configured, the Controls plugin appears in your React Native DevTools sidebar as `Controls`.

--- a/website/src/docs/official-plugins/overlay.mdx
+++ b/website/src/docs/official-plugins/overlay.mdx
@@ -40,6 +40,10 @@ function App() {
 }
 ```
 
+## Web (React Native for Web)
+
+With [Rozenite for Web](/docs/rozenite-for-web), this plugin is available when you debug your React Native web app.
+
 ## Usage
 
 Once configured, the Overlay plugin will automatically appear in your React Native DevTools sidebar as "Overlay". Click on it to access the overlay controls:

--- a/website/src/docs/official-plugins/performance-monitor.mdx
+++ b/website/src/docs/official-plugins/performance-monitor.mdx
@@ -39,6 +39,10 @@ function App() {
 }
 ```
 
+## Web (React Native for Web)
+
+With [Rozenite for Web](/docs/rozenite-for-web), this plugin is available when you debug your React Native web app.
+
 ## Usage
 
 Once configured, the Performance Monitor plugin will automatically appear in your React Native DevTools sidebar as "Performance Monitor". Click on it to access:

--- a/website/src/docs/official-plugins/react-navigation.mdx
+++ b/website/src/docs/official-plugins/react-navigation.mdx
@@ -64,6 +64,10 @@ function App() {
 }
 ```
 
+## Web (React Native for Web)
+
+With [Rozenite for Web](/docs/rozenite-for-web), this plugin is available when you debug your React Native web app.
+
 ## Usage
 
 Once configured, the React Navigation plugin will automatically appear in your React Native DevTools sidebar as "React Navigation". Click on it to access two main features:

--- a/website/src/docs/official-plugins/redux-devtools.mdx
+++ b/website/src/docs/official-plugins/redux-devtools.mdx
@@ -81,6 +81,10 @@ export const store = init({
 export default store;
 ```
 
+## Web (React Native for Web)
+
+With [Rozenite for Web](/docs/rozenite-for-web), this plugin is available when you debug your React Native web app.
+
 ## Usage
 
 Once configured, the Redux DevTools plugin will automatically appear in your React Native DevTools sidebar as "Redux DevTools".

--- a/website/src/docs/official-plugins/sqlite.mdx
+++ b/website/src/docs/official-plugins/sqlite.mdx
@@ -58,6 +58,15 @@ function App() {
 - Run SQL scripts and inspect normalized metadata for each executed statement.
 - Preview result cells with structured JSON and blob-like payload support.
 
+## Agent Integration
+
+This plugin exposes agent tools under the `@rozenite/sqlite-plugin` domain for LLM workflows. No additional setup is required — tools are registered automatically when `useRozeniteSqlitePlugin` is called.
+
+- `list-databases` — list all registered databases with their adapter info
+- `execute-sql` — execute one or more semicolon-separated SQL statements against a database; returns per-statement rows, columns, and metadata, with `failedStatementIndex` pointing to the first failure in a batch
+
+Use `list-databases` first to discover available database IDs, then pass the ID to `execute-sql`. A single `execute-sql` call handles everything: reads, writes, DDL, PRAGMAs, and multi-statement scripts.
+
 ## Adapter: Expo SQLite
 
 ```ts title="App.tsx"

--- a/website/src/docs/official-plugins/storage.mdx
+++ b/website/src/docs/official-plugins/storage.mdx
@@ -48,6 +48,12 @@ function App() {
 }
 ```
 
+## Web (React Native for Web)
+
+With [Rozenite for Web](/docs/rozenite-for-web), this plugin is available when you debug your React Native web app.
+
+On web, the inspector shows entries from Async Storage and Expo Secure Store adapters you configure for the browser.
+
 ## Adapter: MMKV
 
 ```ts title="App.tsx"

--- a/website/src/docs/official-plugins/tanstack-query.mdx
+++ b/website/src/docs/official-plugins/tanstack-query.mdx
@@ -54,6 +54,10 @@ function App() {
 }
 ```
 
+## Web (React Native for Web)
+
+With [Rozenite for Web](/docs/rozenite-for-web), this plugin is available when you debug your React Native web app.
+
 ## Usage
 
 Once configured, the TanStack Query plugin will automatically appear in your React Native DevTools sidebar as "TanStack Query".


### PR DESCRIPTION
## Summary

This PR adds SQLite agent tooling, improves how official plugins behave on web, refreshes documentation for [Rozenite for Web](https://rozenite.dev/docs/rozenite-for-web), and replaces the playground webpack web screen with plugin-focused sections.

### SQLite plugin
- **Agents:** LLM workflows can list registered databases and run SQL (including multi-statement scripts) via new agent tools wired from `useRozeniteSqlitePlugin`.
- **Web:** The SQLite plugin runtime is **not** loaded in browser builds for now, because of upstream `expo-sqlite` issues on web. Documentation states that SQLite in DevTools is for iOS and Android until upstream stabilizes.

### Storage plugin
- **Web:** In development, Async Storage and Expo Secure Store adapters work in the inspector on web; the MMKV adapter stays an empty inspector on web because MMKV does not run in the browser.

### Playground (web)
- The webpack web entry no longer uses the JSONPlaceholder smoke test. It lists supported plugins and wires the corresponding hooks (controls, overlay, performance monitor, React Navigation, Redux, TanStack Query, etc.). SQLite is shown as disabled on web only.
- Metro config adds WASM asset resolution and COEP/COOP headers where needed for web SQLite experiments elsewhere.

### Documentation
- Official plugin pages note Rozenite for Web where the plugin runs in the browser in development.
- SQLite docs describe agent tools and the current web limitation.

## Test plan
- [x] `pnpm` typecheck / lint for touched packages as appropriate
- [x] Native playground: SQLite and Storage plugins behave as before
- [x] Web playground: plugin sections render; SQLite section explains disabled state