### PR TITLE
fix(middleware): restore scoped agent routes

### DIFF
--- a/.changeset/five-apes-breathe.md
+++ b/.changeset/five-apes-breathe.md
@@ -1,0 +1,6 @@
+---
+'@rozenite/middleware': patch
+---
+
+Fix scoped Rozenite middleware so agent setup requests still resolve after the
+outer `/rozenite` prefix is stripped by Metro integrations.

--- a/packages/middleware/src/__tests__/middleware.test.ts
+++ b/packages/middleware/src/__tests__/middleware.test.ts
@@ -73,6 +73,15 @@ const runRequest = async (
 };
 
 describe('middleware request normalization', () => {
+  it('restores stripped agent routes for scoped integrations', () => {
+    expect(getNormalizedRequestUrl('/agent/targets')).toBe(
+      '/rozenite/agent/targets',
+    );
+    expect(getNormalizedRequestUrl('/agent/sessions/device-1')).toBe(
+      '/rozenite/agent/sessions/device-1',
+    );
+  });
+
   it('preserves agent routes under /rozenite', () => {
     expect(getNormalizedRequestUrl('/rozenite/agent/targets')).toBe(
       '/rozenite/agent/targets',
@@ -93,6 +102,27 @@ describe('middleware request normalization', () => {
 });
 
 describe('scoped middleware', () => {
+  it('keeps agent setup working when the outer prefix is stripped first', async () => {
+    const middleware = createScopedMiddleware('/rozenite', (req, res, next) => {
+      if (
+        req.url &&
+        getNormalizedRequestUrl(req.url) === '/rozenite/agent/targets'
+      ) {
+        res.end('agent targets');
+        return;
+      }
+
+      next();
+    });
+
+    const response = await runRequest(middleware, '/rozenite/agent/targets');
+
+    expect(response).toEqual({
+      status: 200,
+      body: 'agent targets',
+    });
+  });
+
   it('delegates only requests within the configured prefix', async () => {
     const handler = vi.fn<MiddlewareHandler>((req, res) => {
       res.end(req.url);

--- a/packages/middleware/src/middleware.ts
+++ b/packages/middleware/src/middleware.ts
@@ -18,6 +18,10 @@ export type MiddlewareConfig = {
 };
 
 export const getNormalizedRequestUrl = (url: string): string => {
+  if (url === '/agent' || url.startsWith('/agent/')) {
+    return `/rozenite${url}`;
+  }
+
   if (url === '/rozenite' || url.startsWith('/rozenite/')) {
     if (url === '/rozenite/agent' || url.startsWith('/rozenite/agent/')) {
       return url;


### PR DESCRIPTION
## Summary
- restore `/rozenite/agent/*` handling when scoped Metro or Re.Pack integrations strip the outer `/rozenite` prefix before delegating to `@rozenite/middleware`
- keep existing `/rozenite/*` UI routing behavior intact so both the Rozenite UI and Rozenite for Agents continue to work
- add middleware tests for the stripped agent-route case and a changeset for `@rozenite/middleware`

## Testing
- pnpm --filter @rozenite/middleware test
- pnpm --filter @rozenite/middleware typecheck
- pnpm changeset status