### PR TITLE
fix(vite-plugin): normalize rolled-up declaration refs

### DIFF
--- a/packages/mmkv-plugin/src/react-native/useMMKVDevTools.ts
+++ b/packages/mmkv-plugin/src/react-native/useMMKVDevTools.ts
@@ -4,7 +4,7 @@ import { MMKVEventMap } from '../shared/messaging';
 import { getMMKVView } from './mmkv-view';
 import { useMMKVAgentTools } from './useMMKVAgentTools';
 import { normalizeStoragesConfigProperty } from './utils';
-import type { MMKV } from 'react-native-mmkv';
+import type { MMKV } from './utils';
 
 export type MMKVDevToolsOptions = {
   /**

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -40,6 +40,7 @@
   },
   "scripts": {
     "build": "vite build",
+    "test": "vitest run",
     "typecheck": "tsc -p tsconfig.lib.json --noEmit",
     "lint": "eslint ."
   },

--- a/packages/vite-plugin/src/bundle-dts.ts
+++ b/packages/vite-plugin/src/bundle-dts.ts
@@ -8,6 +8,35 @@ import {
 
 type Target = 'react-native' | 'metro' | 'sdk';
 
+export const normalizeRolledUpDeclarations = (content: string) => {
+  const valueDeclarationNames = new Set<string>();
+
+  content.replace(
+    /^\s*declare\s+(?:const|let|var|function)\s+([A-Za-z_$][\w$]*)\b/gm,
+    (_, name: string) => {
+      valueDeclarationNames.add(name);
+      return _;
+    },
+  );
+
+  const normalizeTypeReference = (name: string) =>
+    valueDeclarationNames.has(name) ? `typeof ${name}` : name;
+
+  return content
+    .replace(
+      /^(\s*(?:export\s+)?declare\s+(?:const|let|var)\s+[A-Za-z_$][\w$]*\s*:\s*)([A-Za-z_$][\w$]*)(\s*;)$/gm,
+      (_, prefix: string, name: string, suffix: string) => {
+        return `${prefix}${normalizeTypeReference(name)}${suffix}`;
+      },
+    )
+    .replace(
+      /^(\s*(?:export\s+)?declare\s+type\s+[A-Za-z_$][\w$]*\s*=\s*)([A-Za-z_$][\w$]*)(\s*;)$/gm,
+      (_, prefix: string, name: string, suffix: string) => {
+        return `${prefix}${normalizeTypeReference(name)}${suffix}`;
+      },
+    );
+};
+
 export const bundleTargetDeclarations = async (
   projectRoot: string,
   target: Target,
@@ -85,5 +114,12 @@ export const bundleTargetDeclarations = async (
   }
   await fs.rm(entryPath, { force: true });
   await fs.rename(tempOutputPath, publicEntryPath);
+  const bundledContent = await fs.readFile(publicEntryPath, 'utf8');
+  const normalizedContent = normalizeRolledUpDeclarations(bundledContent);
+
+  if (normalizedContent !== bundledContent) {
+    await fs.writeFile(publicEntryPath, normalizedContent);
+  }
+
   await fs.rm(srcDeclarationsPath, { recursive: true, force: true });
 };

--- a/packages/vite-plugin/tests/bundle-dts.test.ts
+++ b/packages/vite-plugin/tests/bundle-dts.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeRolledUpDeclarations } from '../src/bundle-dts.js';
+
+describe('normalizeRolledUpDeclarations', () => {
+  it('rewrites exported value references to typeof', () => {
+    const input = `
+export declare let useNetworkActivityDevTools: useNetworkActivityDevTools_2;
+declare const useNetworkActivityDevTools_2: (config?: NetworkActivityDevToolsConfig) => unknown;
+`;
+
+    expect(normalizeRolledUpDeclarations(input)).toContain(
+      'export declare let useNetworkActivityDevTools: typeof useNetworkActivityDevTools_2;',
+    );
+  });
+
+  it('rewrites type aliases that point at declared values', () => {
+    const input = `
+declare type UseNetworkActivityDevTools = useNetworkActivityDevTools_2;
+declare const useNetworkActivityDevTools_2: (config?: NetworkActivityDevToolsConfig) => unknown;
+`;
+
+    expect(normalizeRolledUpDeclarations(input)).toContain(
+      'declare type UseNetworkActivityDevTools = typeof useNetworkActivityDevTools_2;',
+    );
+  });
+
+  it('leaves proper type aliases unchanged', () => {
+    const input = `
+declare type NetworkActivityDevToolsConfig = {
+  enabled?: boolean;
+};
+declare type UseNetworkActivityDevTools = NetworkActivityDevToolsConfig;
+`;
+
+    expect(normalizeRolledUpDeclarations(input)).toBe(input);
+  });
+});


### PR DESCRIPTION
## Summary
Rozenite users can end up with broken published plugin typings where some React Native exports lose their real function signatures and fall back to `any` in TypeScript consumers. This change fixes the declaration output produced by the Vite plugin so those published plugin APIs resolve to correct types again, and it aligns the MMKV plugin's storage input typing with the v3/v4 compatibility the plugin already supports.

## Context
This change hardens the Vite declaration bundling step so rolled-up plugin `.d.ts` files keep valid `typeof` references when API Extractor rewrites lazy React Native exports through generated value names. It also adds a regression test around the normalization logic so future declaration bundling changes keep producing consumable plugin types across packages.

The MMKV plugin change switches its React Native hook options to use the shared compatibility MMKV type instead of the narrower `react-native-mmkv` import. That keeps the playground and consumers on MMKV v4 type-safe without changing runtime behavior.

## Proposed Testing Scenario
Build and typecheck the workspace. Then inspect a React Native plugin package that exposes lazy exports, such as the network activity plugin, and confirm that its generated `dist/react-native/index.d.ts` uses `typeof` for generated helper references and that importing those APIs in a TypeScript consumer resolves to concrete function signatures instead of falling back to `any`.

In the playground app, confirm that `useMMKVDevTools({ storages: mmkvStorages })` typechecks when the app depends on `react-native-mmkv@4`.