### PR TITLE
fix(network-activity-plugin): support RFC 6839 json responses

### DIFF
--- a/.changeset/green-countries-trade.md
+++ b/.changeset/green-countries-trade.md
@@ -1,0 +1,5 @@
+---
+'@rozenite/network-activity-plugin': patch
+---
+
+Rozenite now treats `application/*+json` responses as JSON in Network Activity, so vendor-specific JSON payloads render correctly instead of falling back to plain text.

--- a/packages/network-activity-plugin/src/react-native/http/http-utils.ts
+++ b/packages/network-activity-plugin/src/react-native/http/http-utils.ts
@@ -7,6 +7,7 @@ import {
 } from '../../shared/client';
 import { safeStringify } from '../../utils/safeStringify';
 import { getStringSizeInBytes } from '../../utils/getStringSizeInBytes';
+import { isJsonContentType } from '../../utils/getContentTypeMimeType';
 import {
   isBlob,
   isArrayBuffer,
@@ -129,7 +130,7 @@ export const getResponseBody = async (
 
     if (
       contentType.startsWith('text/') ||
-      contentType.startsWith('application/json')
+      isJsonContentType(contentType)
     ) {
       // It looks like a text blob, let's read it and forward it to the client.
       return new Promise((resolve) => {
@@ -195,7 +196,7 @@ export const setupRequestOverride = (
       Object.defineProperty(request, 'responseText', { writable: true });
 
       const contentType = getContentType(request);
-      if (contentType === 'application/json') {
+      if (isJsonContentType(contentType)) {
         request.responseType = 'json';
       } else if (contentType === 'text/plain') {
         request.responseType = 'text';

--- a/packages/network-activity-plugin/src/ui/tabs/ResponseTab.tsx
+++ b/packages/network-activity-plugin/src/ui/tabs/ResponseTab.tsx
@@ -10,6 +10,7 @@ import { RequestOverride } from '../../shared/client';
 import { OverrideResponse } from '../components/OverrideResponse';
 import { Button } from '../components/Button';
 import { Pencil } from 'lucide-react';
+import { isJsonContentType } from '../../utils/getContentTypeMimeType';
 
 export type ResponseTabProps = {
   selectedRequest: HttpNetworkEntry;
@@ -110,7 +111,7 @@ export const ResponseTab = ({
       );
     }
 
-    if (type.startsWith('application/json')) {
+    if (isJsonContentType(type)) {
       let bodyContent;
 
       try {

--- a/packages/network-activity-plugin/src/utils/__tests__/getContentTypeMimeType.test.ts
+++ b/packages/network-activity-plugin/src/utils/__tests__/getContentTypeMimeType.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getContentTypeMime,
+  isJsonContentType,
+} from '../getContentTypeMimeType';
+
+describe('getContentTypeMimeType', () => {
+  it('recognizes application/json content types with parameters', () => {
+    expect(isJsonContentType('application/json; charset=utf-8')).toBe(true);
+  });
+
+  it('recognizes RFC 6839 +json content types', () => {
+    expect(isJsonContentType('application/vnd.geo+json; charset=utf-8')).toBe(
+      true,
+    );
+    expect(isJsonContentType('Application/LD+JSON')).toBe(true);
+  });
+
+  it('rejects non-json content types', () => {
+    expect(isJsonContentType('text/plain')).toBe(false);
+    expect(isJsonContentType(undefined)).toBe(false);
+  });
+
+  it('keeps the extracted mime type display-friendly', () => {
+    expect(
+      getContentTypeMime({
+        'content-type': 'Application/LD+JSON; charset=utf-8',
+      }),
+    ).toBe('Application/LD+JSON');
+  });
+});

--- a/packages/network-activity-plugin/src/utils/getContentTypeMimeType.ts
+++ b/packages/network-activity-plugin/src/utils/getContentTypeMimeType.ts
@@ -1,6 +1,10 @@
 import { HttpHeaders } from '../shared/client';
 import { getHttpHeader } from './getHttpHeader';
 
+export function normalizeContentType(contentType: string) {
+  return contentType.split(';')[0].trim().toLowerCase();
+}
+
 export function getContentTypeMime(headers: HttpHeaders) {
   const contentType = getHttpHeader(headers, 'content-type');
 
@@ -14,4 +18,14 @@ export function getContentTypeMime(headers: HttpHeaders) {
   const actualValue = Array.isArray(value) ? value[0] : value;
 
   return actualValue.split(';')[0].trim();
+}
+
+export function isJsonContentType(contentType: string | null | undefined) {
+  if (!contentType) {
+    return false;
+  }
+
+  const mimeType = normalizeContentType(contentType);
+
+  return mimeType === 'application/json' || mimeType.endsWith('+json');
 }


### PR DESCRIPTION
## Summary
- recognize RFC 6839 `+json` content types alongside `application/json` in the network activity plugin
- use the same JSON content-type detection when extracting response bodies, rendering the Response tab, and applying response overrides
- add coverage for `application/*+json` handling so Rozenite users can inspect JSON responses correctly instead of seeing an empty body

## Testing
- pnpm exec vitest run packages/network-activity-plugin/src/utils/__tests__/getContentTypeMimeType.test.ts packages/network-activity-plugin/src/react-native/nitro-fetch/__tests__/nitro-network-inspector.test.ts packages/network-activity-plugin/src/react-native/agent/__tests__/network-activity-agent-state.test.ts
- pnpm --filter @rozenite/network-activity-plugin typecheck

Closes #239.