### PR TITLE
feat(sqlite-plugin): export SQL and bridge helpers for custom adapters

### DIFF
--- a/.changeset/sqlite-plugin-export-sql-bridge-helpers.md
+++ b/.changeset/sqlite-plugin-export-sql-bridge-helpers.md
@@ -1,0 +1,5 @@
+---
+'@rozenite/sqlite-plugin': minor
+---
+
+`classifySqlStatement`, `normalizeSingleStatementSql`, `splitSqlStatements`, `statementReturnsRows`, `decodeSqliteBridgeValue`, and `formatSqliteError` are now exported from `@rozenite/sqlite-plugin`. These are the building blocks you need when writing a custom SQLite adapter — to parse and classify SQL before execution, and to decode values coming back over the native bridge.

--- a/packages/sqlite-plugin/react-native.ts
+++ b/packages/sqlite-plugin/react-native.ts
@@ -18,6 +18,7 @@ export type {
   CreateExpoSqliteAdapterOptions,
   ExpoSqliteLike,
 } from './src/react-native/adapters/expo-sqlite';
+export type { SqlStatementSegment } from './src/shared/sql';
 
 type CreateSqliteAdapter =
   typeof import('./src/react-native/adapters').createSqliteAdapter;
@@ -27,6 +28,12 @@ type CreateExpoSqliteAdapter =
 export let createSqliteAdapter: CreateSqliteAdapter;
 export let createExpoSqliteAdapter: CreateExpoSqliteAdapter;
 export let useRozeniteSqlitePlugin: typeof import('./src/react-native/useRozeniteSqlitePlugin').useRozeniteSqlitePlugin;
+export let classifySqlStatement: typeof import('./src/shared/sql').classifySqlStatement;
+export let normalizeSingleStatementSql: typeof import('./src/shared/sql').normalizeSingleStatementSql;
+export let splitSqlStatements: typeof import('./src/shared/sql').splitSqlStatements;
+export let statementReturnsRows: typeof import('./src/shared/sql').statementReturnsRows;
+export let decodeSqliteBridgeValue: typeof import('./src/shared/bridge-values').decodeSqliteBridgeValue;
+export let formatSqliteError: typeof import('./src/shared/bridge-values').formatSqliteError;
 
 const isDev = process.env.NODE_ENV !== 'production';
 const isWeb =
@@ -40,6 +47,14 @@ if (isDev && !isWeb && !isServer) {
     require('./src/react-native/adapters').createExpoSqliteAdapter;
   useRozeniteSqlitePlugin =
     require('./src/react-native/useRozeniteSqlitePlugin').useRozeniteSqlitePlugin;
+  classifySqlStatement = require('./src/shared/sql').classifySqlStatement;
+  normalizeSingleStatementSql =
+    require('./src/shared/sql').normalizeSingleStatementSql;
+  splitSqlStatements = require('./src/shared/sql').splitSqlStatements;
+  statementReturnsRows = require('./src/shared/sql').statementReturnsRows;
+  decodeSqliteBridgeValue =
+    require('./src/shared/bridge-values').decodeSqliteBridgeValue;
+  formatSqliteError = require('./src/shared/bridge-values').formatSqliteError;
 } else {
   createSqliteAdapter = (options) => ({
     id: options.adapterId ?? 'sqlite',
@@ -52,4 +67,10 @@ if (isDev && !isWeb && !isServer) {
     databases: [],
   });
   useRozeniteSqlitePlugin = () => null;
+  classifySqlStatement = () => 'other';
+  normalizeSingleStatementSql = (sql) => sql;
+  splitSqlStatements = () => [];
+  statementReturnsRows = (_type): _type is never => false;
+  decodeSqliteBridgeValue = (value) => value;
+  formatSqliteError = () => 'Unknown SQLite error.';
 }


### PR DESCRIPTION
## Why

When building a custom SQLite adapter for Rozenite (e.g. a driver not covered by the built-in Expo SQLite adapter), developers need to parse, classify, and normalise SQL statements themselves — and decode bridge-encoded values returned over the JS/native boundary. The relevant utilities already exist in `shared/sql` and `shared/bridge-values`, but they were not exported from the package, forcing consumers to either duplicate the logic or reach into internal paths.

## What

Exports the following helpers from the `react-native` entry-point of `sqlite-plugin`:

**`shared/sql`**
- `SqlStatementSegment` (type)
- `classifySqlStatement`
- `normalizeSingleStatementSql`
- `splitSqlStatements`
- `statementReturnsRows`

**`shared/bridge-values`**
- `decodeSqliteBridgeValue`
- `formatSqliteError`

## Approach

An earlier attempt at this was made in #226, which tried to generate a new dedicated entry-point for these helpers. That approach turned out to be flaky, so for the time being the same pattern used for all other exported functions is applied here: `let` declarations assigned via inline `require()` calls that Metro can statically analyse, with passive no-op mocks assigned in the `else` branch for production/web/SSR builds. This ensures the helpers are completely tree-shaken out of production bundles.