### PR TITLE
fix(network-activity-plugin): isolate react-native-nitro-fetch into separate bundle chunk

### DIFF
--- a/.changeset/nitro-fetch-optional-dep-chunk.md
+++ b/.changeset/nitro-fetch-optional-dep-chunk.md
@@ -1,0 +1,5 @@
+---
+"@rozenite/network-activity-plugin": patch
+---
+
+Fix `react-native-nitro-fetch` not being resolved correctly in Metro by isolating the optional dependency import into its own bundle chunk. This ensures the network inspector works reliably even when `react-native-nitro-fetch` is not installed.

--- a/packages/network-activity-plugin/src/react-native/nitro-fetch/get-nitro-module.ts
+++ b/packages/network-activity-plugin/src/react-native/nitro-fetch/get-nitro-module.ts
@@ -1,0 +1,9 @@
+import type { NitroModule } from './nitro-network-inspector';
+
+export const getNitroModule = (): NitroModule | null => {
+  try {
+    return require('react-native-nitro-fetch') as NitroModule;
+  } catch {
+    return null;
+  }
+};

--- a/packages/network-activity-plugin/src/react-native/nitro-fetch/nitro-network-inspector.ts
+++ b/packages/network-activity-plugin/src/react-native/nitro-fetch/nitro-network-inspector.ts
@@ -7,6 +7,7 @@ import type {
 } from '../../shared/client';
 import type { WebSocketEventMap } from '../../shared/websocket-events';
 import type { Inspector } from '../inspector';
+import { getNitroModule as loadNitroModule } from './get-nitro-module';
 
 type NitroHttpHeader = {
   key: string;
@@ -62,7 +63,7 @@ type NitroWebSocketEntry = {
 
 type NitroInspectorEntry = NitroHttpEntry | NitroWebSocketEntry;
 
-type NitroModule = {
+export type NitroModule = {
   NetworkInspector: {
     enable: () => void;
     disable: () => void;
@@ -106,14 +107,6 @@ export const NITRO_NETWORK_EVENTS: (keyof NitroNetworkEventMap)[] = [
   'websocket-message-received',
   'websocket-error',
 ];
-
-const loadNitroModule = (): NitroModule | null => {
-  try {
-    return require('react-native-nitro-fetch') as NitroModule;
-  } catch {
-    return null;
-  }
-};
 
 const timestampOrigin =
   typeof performance !== 'undefined' &&

--- a/packages/network-activity-plugin/vite.config.ts
+++ b/packages/network-activity-plugin/vite.config.ts
@@ -27,6 +27,10 @@ export default defineConfig({
             return 'event-source';
           }
 
+          if (id.includes('get-nitro-module.ts')) {
+            return 'get-nitro-module';
+          }
+
           return undefined;
         },
       },


### PR DESCRIPTION
## Problem

Metro has a known issue ([facebook/metro#836](https://github.com/facebook/metro/issues/836)) where optional `require()` calls fail to resolve correctly even when wrapped in `try/catch`. This caused `react-native-nitro-fetch` — an optional dependency — to break bundling in some Metro configurations.

## Solution

Follows the same pattern already in place for `react-native-sse` / `event-source.ts`:

- Extract the `require('react-native-nitro-fetch')` call from `nitro-network-inspector.ts` into a dedicated `get-nitro-module.ts` file.
- Add `get-nitro-module.ts` to Vite's `manualChunks` so Rollup emits it as a separate bundle chunk.

Metro loads each chunk independently, which sidesteps the optional-dependency resolution bug.

## Changes

- `src/react-native/nitro-fetch/get-nitro-module.ts` — new file with the isolated `getNitroModule` getter
- `nitro-network-inspector.ts` — removes `loadNitroModule`, imports from the new file; exports `NitroModule` type
- `vite.config.ts` — adds `get-nitro-module.ts` to `manualChunks`
- `.changeset/nitro-fetch-optional-dep-chunk.md` — patch changeset