### PR TITLE
feat(storage-plugin): add storage-level JSON import/export

### DIFF
--- a/.changeset/quiet-snakes-export.md
+++ b/.changeset/quiet-snakes-export.md
@@ -1,0 +1,7 @@
+---
+'@rozenite/storage-plugin': minor
+---
+
+Add storage-level JSON import/export to the storage plugin.
+
+You can now export the currently selected storage to a versioned JSON snapshot and import a snapshot back as an upsert. Import validates the file before writing and rejects entries whose types are not supported by the target storage. See the storage plugin docs for the schema and behavior.

--- a/packages/storage-plugin/README.md
+++ b/packages/storage-plugin/README.md
@@ -103,3 +103,4 @@ When you use [Rozenite for Web](https://rozenite.dev/docs/rozenite-for-web) in d
 - Type support is enforced in UI, runtime and Agent tools.
 - Storages without subscriptions automatically use internal polling updates.
 - Per-storage blacklists are supported through adapter configuration.
+- Storage snapshots can be exported to and imported from a versioned JSON file from the panel. See the [storage plugin docs](https://www.rozenite.dev/docs/official-plugins/storage) for the schema and behavior.

--- a/packages/storage-plugin/src/react-native/__tests__/import.test.ts
+++ b/packages/storage-plugin/src/react-native/__tests__/import.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it, vi } from 'vitest';
+import { handleImportEntries, type ImportEmittedEvent } from '../import';
+import type { StorageView } from '../storage-view';
+import { getStorageViewId } from '../../shared/types';
+import type { StorageEntry, StorageTarget } from '../../shared/types';
+import type { StorageImportEntriesEvent } from '../../shared/messaging';
+
+const target: StorageTarget = { adapterId: 'mmkv', storageId: 'user' };
+
+const buildView = (overrides?: Partial<StorageView>): StorageView => {
+  const unexpected = (method: string) =>
+    vi.fn(() => {
+      throw new Error(`Unexpected call to ${method}`);
+    });
+
+  return {
+    id: getStorageViewId(target),
+    target,
+    adapterName: 'MMKV',
+    storageName: 'user',
+    capabilities: {
+      supportedTypes: ['string', 'number', 'boolean', 'buffer'],
+    },
+    get: unexpected('get'),
+    set: vi.fn(async () => {}),
+    delete: unexpected('delete'),
+    getAllKeys: unexpected('getAllKeys'),
+    getAllEntries: unexpected('getAllEntries'),
+    watch: unexpected('watch'),
+    ...overrides,
+  };
+};
+
+const buildEntries = (count: number): StorageEntry[] =>
+  Array.from({ length: count }, (_, index) => ({
+    key: `k${index}`,
+    type: 'string' as const,
+    value: `v${index}`,
+  }));
+
+describe('handleImportEntries', () => {
+  it('emits a set-entry echo per write followed by a success import-result', async () => {
+    const view = buildView();
+    const entries = buildEntries(5);
+    const event: StorageImportEntriesEvent = {
+      type: 'import-entries',
+      target,
+      entries,
+    };
+    const emitted: ImportEmittedEvent[] = [];
+
+    await handleImportEntries([view], event, (out) => emitted.push(out));
+
+    expect(view.set).toHaveBeenCalledTimes(5);
+
+    expect(emitted).toHaveLength(6);
+    expect(emitted.slice(0, 5)).toEqual(
+      entries.map((entry) => ({
+        type: 'set-entry',
+        target,
+        entry,
+      })),
+    );
+    expect(emitted[5]).toEqual({
+      type: 'import-result',
+      target,
+      ok: true,
+      written: 5,
+      total: 5,
+    });
+  });
+
+  it('stops at the first write that throws and reports the failed key', async () => {
+    const failingKey = 'k2';
+    const view = buildView({
+      set: vi.fn(async (entry: StorageEntry) => {
+        if (entry.key === failingKey) {
+          throw new Error('boom');
+        }
+      }),
+    });
+    const entries = buildEntries(5);
+    const event: StorageImportEntriesEvent = {
+      type: 'import-entries',
+      target,
+      entries,
+    };
+    const emitted: ImportEmittedEvent[] = [];
+
+    await handleImportEntries([view], event, (out) => emitted.push(out));
+
+    // 2 set-entry echoes (k0, k1), then the failure result. No echoes for k2+.
+    expect(view.set).toHaveBeenCalledTimes(3);
+    expect(emitted).toHaveLength(3);
+    expect(emitted[0]).toMatchObject({ type: 'set-entry', entry: entries[0] });
+    expect(emitted[1]).toMatchObject({ type: 'set-entry', entry: entries[1] });
+    expect(emitted[2]).toEqual({
+      type: 'import-result',
+      target,
+      ok: false,
+      written: 2,
+      total: 5,
+      failedKey: failingKey,
+      error: 'boom',
+    });
+  });
+
+  it('coerces non-Error throws to a string error message', async () => {
+    const view = buildView({
+      set: vi.fn(async () => {
+        throw 'plain string failure';
+      }),
+    });
+    const event: StorageImportEntriesEvent = {
+      type: 'import-entries',
+      target,
+      entries: buildEntries(1),
+    };
+    const emitted: ImportEmittedEvent[] = [];
+
+    await handleImportEntries([view], event, (out) => emitted.push(out));
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toMatchObject({
+      type: 'import-result',
+      ok: false,
+      error: 'plain string failure',
+    });
+  });
+
+  it('emits an unknown-target import-result without calling set', async () => {
+    const view = buildView();
+    const unknownTarget: StorageTarget = {
+      adapterId: 'async-storage',
+      storageId: 'default',
+    };
+    const entries = buildEntries(3);
+    const event: StorageImportEntriesEvent = {
+      type: 'import-entries',
+      target: unknownTarget,
+      entries,
+    };
+    const emitted: ImportEmittedEvent[] = [];
+
+    await handleImportEntries([view], event, (out) => emitted.push(out));
+
+    expect(view.set).not.toHaveBeenCalled();
+    expect(emitted).toEqual([
+      {
+        type: 'import-result',
+        target: unknownTarget,
+        ok: false,
+        written: 0,
+        total: 3,
+        error: 'Target storage not found',
+      },
+    ]);
+  });
+
+  it('handles empty entries as a successful no-op', async () => {
+    const view = buildView();
+    const event: StorageImportEntriesEvent = {
+      type: 'import-entries',
+      target,
+      entries: [],
+    };
+    const emitted: ImportEmittedEvent[] = [];
+
+    await handleImportEntries([view], event, (out) => emitted.push(out));
+
+    expect(view.set).not.toHaveBeenCalled();
+    expect(emitted).toEqual([
+      {
+        type: 'import-result',
+        target,
+        ok: true,
+        written: 0,
+        total: 0,
+      },
+    ]);
+  });
+});

--- a/packages/storage-plugin/src/react-native/import.ts
+++ b/packages/storage-plugin/src/react-native/import.ts
@@ -1,0 +1,67 @@
+import type {
+  StorageImportEntriesEvent,
+  StorageImportResultEvent,
+  StorageSetEntryEvent,
+} from '../shared/messaging';
+import type { StorageView } from './storage-view';
+
+export type ImportEmittedEvent =
+  | StorageSetEntryEvent
+  | StorageImportResultEvent;
+
+export const handleImportEntries = async (
+  views: StorageView[],
+  event: StorageImportEntriesEvent,
+  emit: (out: ImportEmittedEvent) => void,
+): Promise<void> => {
+  const view = views.find(
+    (candidate) =>
+      candidate.target.adapterId === event.target.adapterId &&
+      candidate.target.storageId === event.target.storageId,
+  );
+
+  if (!view) {
+    emit({
+      type: 'import-result',
+      target: event.target,
+      ok: false,
+      written: 0,
+      total: event.entries.length,
+      error: 'Target storage not found',
+    });
+    return;
+  }
+
+  for (let i = 0; i < event.entries.length; i++) {
+    const entry = event.entries[i];
+
+    try {
+      await view.set(entry);
+    } catch (error) {
+      emit({
+        type: 'import-result',
+        target: event.target,
+        ok: false,
+        written: i,
+        total: event.entries.length,
+        failedKey: entry.key,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return;
+    }
+
+    emit({
+      type: 'set-entry',
+      target: event.target,
+      entry,
+    });
+  }
+
+  emit({
+    type: 'import-result',
+    target: event.target,
+    ok: true,
+    written: event.entries.length,
+    total: event.entries.length,
+  });
+};

--- a/packages/storage-plugin/src/react-native/storage-view.ts
+++ b/packages/storage-plugin/src/react-native/storage-view.ts
@@ -49,14 +49,14 @@ const shouldFilterKey = (storage: StorageNode, key: string) => {
 const checkTypeSupport = (
   capabilities: StorageCapabilities,
   type: StorageEntryType,
-  target: StorageTarget
+  target: StorageTarget,
 ) => {
   if (supportsType(capabilities, type)) {
     return;
   }
 
   throw new Error(
-    `Type "${type}" is not supported by storage "${target.storageId}" in adapter "${target.adapterId}".`
+    `Type "${type}" is not supported by storage "${target.storageId}" in adapter "${target.adapterId}".`,
   );
 };
 
@@ -100,6 +100,7 @@ export type StorageView = {
   adapterName: string;
   storageName: string;
   capabilities: StorageCapabilities;
+  blacklist?: RegExp;
   get: (key: string) => Promise<StorageEntry | undefined>;
   set: (entry: StorageEntry) => Promise<void>;
   delete: (key: string) => Promise<void>;
@@ -112,7 +113,7 @@ export type StorageView = {
 };
 
 const buildSnapshotMap = async (
-  getAllEntries: () => Promise<StorageEntry[]>
+  getAllEntries: () => Promise<StorageEntry[]>,
 ): Promise<StorageSnapshotMap> => {
   const entries = await getAllEntries();
   return toSnapshotMap(entries);
@@ -124,7 +125,7 @@ const diffSnapshots = (
   handlers: {
     onSet: (entry: StorageEntry) => void;
     onDelete: (key: string) => void;
-  }
+  },
 ) => {
   next.forEach((nextEntry, key) => {
     const previousEntry = previous.get(key);
@@ -151,7 +152,7 @@ const createPollingSubscription = async (
   handlers: {
     onSet: (entry: StorageEntry) => void;
     onDelete: (key: string) => void;
-  }
+  },
 ): Promise<StorageSubscription> => {
   let previousSnapshot = await buildSnapshotMap(getAllEntries);
 
@@ -174,7 +175,7 @@ const createPollingSubscription = async (
 
 export const createStorageView = (
   adapter: StorageAdapter,
-  storageNode: StorageNode
+  storageNode: StorageNode,
 ): StorageView => {
   const storage = storageNode.storage;
   const target: StorageTarget = {
@@ -195,7 +196,7 @@ export const createStorageView = (
     const visibleEntries = await Promise.all(
       keys
         .filter((key) => !shouldFilterKey(storageNode, key))
-        .map((key) => getEntry(storage, key))
+        .map((key) => getEntry(storage, key)),
     );
 
     return visibleEntries.filter((entry): entry is StorageEntry => !!entry);
@@ -207,6 +208,7 @@ export const createStorageView = (
     adapterName: adapter.name,
     storageName: storageNode.name,
     capabilities: storageNode.capabilities,
+    blacklist: storageNode.blacklist,
     get,
     set: async (entry) => {
       checkTypeSupport(storageNode.capabilities, entry.type, target);
@@ -245,5 +247,7 @@ export const createStorageView = (
 
 export const createStorageViews = (storages: StorageAdapter[]) =>
   storages.flatMap((adapter) =>
-    adapter.storages.map((storageNode) => createStorageView(adapter, storageNode))
+    adapter.storages.map((storageNode) =>
+      createStorageView(adapter, storageNode),
+    ),
   );

--- a/packages/storage-plugin/src/react-native/useRozeniteStoragePlugin.ts
+++ b/packages/storage-plugin/src/react-native/useRozeniteStoragePlugin.ts
@@ -4,9 +4,11 @@ import type {
   StorageDeleteEntryEvent,
   StorageEventMap,
   StorageGetSnapshotEvent,
+  StorageImportEntriesEvent,
   StorageSetEntryEvent,
 } from '../shared/messaging';
 import type { StorageAdapter } from '../shared/types';
+import { handleImportEntries } from './import';
 import { createStorageViews } from './storage-view';
 import { useStorageAgentTools } from './useStorageAgentTools';
 
@@ -31,7 +33,9 @@ export const useRozeniteStoragePlugin = ({
     }
 
     const pushSnapshot = async (viewId?: string) => {
-      const selectedViews = viewId ? views.filter((view) => view.id === viewId) : views;
+      const selectedViews = viewId
+        ? views.filter((view) => view.id === viewId)
+        : views;
 
       for (const view of selectedViews) {
         try {
@@ -47,7 +51,7 @@ export const useRozeniteStoragePlugin = ({
         } catch (error) {
           console.warn(
             `[Rozenite] Storage Plugin: Failed to snapshot ${view.target.adapterId}/${view.target.storageId}.`,
-            error
+            error,
           );
         }
       }
@@ -88,48 +92,51 @@ export const useRozeniteStoragePlugin = ({
         } catch (error) {
           console.warn(
             `[Rozenite] Storage Plugin: Failed to attach watcher for ${view.target.adapterId}/${view.target.storageId}.`,
-            error
-          );
-        }
-      })
-    );
-
-    const messageSubscriptions = [
-      client.onMessage('set-entry', async ({ target, entry }: StorageSetEntryEvent) => {
-        const view = views.find(
-          (candidate) =>
-            candidate.target.adapterId === target.adapterId &&
-            candidate.target.storageId === target.storageId
-        );
-
-        if (!view) {
-          console.warn(
-            `[Rozenite] Storage Plugin: Storage target not found for ${target.adapterId}/${target.storageId}`
-          );
-          return;
-        }
-
-        try {
-          await view.set(entry);
-        } catch (error) {
-          console.warn(
-            `[Rozenite] Storage Plugin: Failed to set entry in ${target.adapterId}/${target.storageId}.`,
-            error
+            error,
           );
         }
       }),
+    );
+
+    const messageSubscriptions = [
+      client.onMessage(
+        'set-entry',
+        async ({ target, entry }: StorageSetEntryEvent) => {
+          const view = views.find(
+            (candidate) =>
+              candidate.target.adapterId === target.adapterId &&
+              candidate.target.storageId === target.storageId,
+          );
+
+          if (!view) {
+            console.warn(
+              `[Rozenite] Storage Plugin: Storage target not found for ${target.adapterId}/${target.storageId}`,
+            );
+            return;
+          }
+
+          try {
+            await view.set(entry);
+          } catch (error) {
+            console.warn(
+              `[Rozenite] Storage Plugin: Failed to set entry in ${target.adapterId}/${target.storageId}.`,
+              error,
+            );
+          }
+        },
+      ),
       client.onMessage(
         'delete-entry',
         async ({ target, key }: StorageDeleteEntryEvent) => {
           const view = views.find(
             (candidate) =>
               candidate.target.adapterId === target.adapterId &&
-              candidate.target.storageId === target.storageId
+              candidate.target.storageId === target.storageId,
           );
 
           if (!view) {
             console.warn(
-              `[Rozenite] Storage Plugin: Storage target not found for ${target.adapterId}/${target.storageId}`
+              `[Rozenite] Storage Plugin: Storage target not found for ${target.adapterId}/${target.storageId}`,
             );
             return;
           }
@@ -139,19 +146,34 @@ export const useRozeniteStoragePlugin = ({
           } catch (error) {
             console.warn(
               `[Rozenite] Storage Plugin: Failed to delete entry in ${target.adapterId}/${target.storageId}.`,
-              error
+              error,
             );
           }
-        }
+        },
       ),
-      client.onMessage('get-snapshot', async ({ target }: StorageGetSnapshotEvent) => {
-        if (target === 'all') {
-          await pushSnapshot();
-          return;
-        }
+      client.onMessage(
+        'get-snapshot',
+        async ({ target }: StorageGetSnapshotEvent) => {
+          if (target === 'all') {
+            await pushSnapshot();
+            return;
+          }
 
-        await pushSnapshot(`${target.adapterId}:${target.storageId}`);
-      }),
+          await pushSnapshot(`${target.adapterId}:${target.storageId}`);
+        },
+      ),
+      client.onMessage(
+        'import-entries',
+        async (event: StorageImportEntriesEvent) => {
+          await handleImportEntries(views, event, (out) => {
+            if (out.type === 'set-entry') {
+              client.send('set-entry', out);
+            } else {
+              client.send('import-result', out);
+            }
+          });
+        },
+      ),
     ];
 
     return () => {

--- a/packages/storage-plugin/src/react-native/useRozeniteStoragePlugin.ts
+++ b/packages/storage-plugin/src/react-native/useRozeniteStoragePlugin.ts
@@ -46,6 +46,9 @@ export const useRozeniteStoragePlugin = ({
             adapterName: view.adapterName,
             storageName: view.storageName,
             capabilities: view.capabilities,
+            blacklist: view.blacklist
+              ? { source: view.blacklist.source, flags: view.blacklist.flags }
+              : undefined,
             entries,
           });
         } catch (error) {

--- a/packages/storage-plugin/src/shared/__tests__/snapshot.test.ts
+++ b/packages/storage-plugin/src/shared/__tests__/snapshot.test.ts
@@ -1,0 +1,361 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildSnapshot,
+  computePreview,
+  parseSnapshot,
+  type StorageSnapshotV1,
+} from '../snapshot';
+import type {
+  StorageCapabilities,
+  StorageEntry,
+  StorageTarget,
+} from '../types';
+
+const validSnapshot = (
+  overrides: Partial<StorageSnapshotV1> = {},
+): StorageSnapshotV1 => ({
+  version: 1,
+  plugin: '@rozenite/storage-plugin',
+  createdAt: '2026-05-11T12:00:00.000Z',
+  storage: {
+    adapterId: 'mmkv',
+    storageId: 'user',
+    adapterName: 'MMKV',
+    storageName: 'user',
+    capabilities: { supportedTypes: ['string', 'number', 'boolean', 'buffer'] },
+  },
+  entries: [
+    { key: 'token', type: 'string', value: 'abc' },
+    { key: 'launchCount', type: 'number', value: 3 },
+    { key: 'seenOnboarding', type: 'boolean', value: true },
+    { key: 'blob', type: 'buffer', value: [1, 2, 255] },
+  ],
+  ...overrides,
+});
+
+describe('parseSnapshot', () => {
+  it('accepts a valid snapshot covering all entry types', () => {
+    const result = parseSnapshot(validSnapshot());
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.snapshot).toEqual(validSnapshot());
+    }
+  });
+
+  it('accepts a snapshot with an empty entries array', () => {
+    const result = parseSnapshot(validSnapshot({ entries: [] }));
+    expect(result.ok).toBe(true);
+  });
+
+  it('ignores unknown top-level fields (forward-tolerant)', () => {
+    const input = { ...validSnapshot(), extraField: 'ignored' };
+    const result = parseSnapshot(input);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.snapshot).not.toHaveProperty('extraField');
+    }
+  });
+
+  describe('top-level rejections', () => {
+    it.each([
+      ['null', null],
+      ['array', []],
+      ['string', 'hi'],
+      ['number', 1],
+    ])('rejects non-object root (%s)', (_label, raw) => {
+      const result = parseSnapshot(raw);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.path).toBe('$');
+      }
+    });
+
+    it('rejects when version is missing', () => {
+      const snapshot = validSnapshot() as Record<string, unknown>;
+      delete snapshot.version;
+      const result = parseSnapshot(snapshot);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error.path).toBe('version');
+    });
+
+    it.each([0, 2, '1', null])('rejects unsupported version: %s', (version) => {
+      const result = parseSnapshot({ ...validSnapshot(), version });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.path).toBe('version');
+        expect(result.error.message).toMatch(/version/i);
+      }
+    });
+
+    it('rejects when plugin is not a string', () => {
+      const result = parseSnapshot({ ...validSnapshot(), plugin: 42 });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error.path).toBe('plugin');
+    });
+
+    it('rejects when createdAt is not a string', () => {
+      const result = parseSnapshot({ ...validSnapshot(), createdAt: 0 });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error.path).toBe('createdAt');
+    });
+
+    it('rejects when storage is missing', () => {
+      const snapshot = validSnapshot() as Record<string, unknown>;
+      delete snapshot.storage;
+      const result = parseSnapshot(snapshot);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error.path).toBe('storage');
+    });
+
+    it('rejects when entries is not an array', () => {
+      const result = parseSnapshot({ ...validSnapshot(), entries: 'nope' });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error.path).toBe('entries');
+    });
+
+    it('rejects when capabilities.supportedTypes has an invalid type', () => {
+      const snapshot = validSnapshot();
+      const input = {
+        ...snapshot,
+        storage: {
+          ...snapshot.storage,
+          capabilities: { supportedTypes: ['string', 'date'] },
+        },
+      };
+      const result = parseSnapshot(input);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.path).toBe(
+          'storage.capabilities.supportedTypes[1]',
+        );
+      }
+    });
+  });
+
+  describe('per-entry rejections', () => {
+    const withEntry = (entry: unknown) =>
+      parseSnapshot({ ...validSnapshot(), entries: [entry] });
+
+    it('rejects entry missing key', () => {
+      const result = withEntry({ type: 'string', value: 'x' });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error.path).toBe('entries[0].key');
+    });
+
+    it('rejects entry with unknown type', () => {
+      const result = withEntry({ key: 'k', type: 'date', value: 'x' });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error.path).toBe('entries[0].type');
+    });
+
+    it('rejects string type with non-string value', () => {
+      const result = withEntry({ key: 'k', type: 'string', value: 42 });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error.path).toBe('entries[0].value');
+    });
+
+    it('rejects number type with non-number value', () => {
+      const result = withEntry({ key: 'k', type: 'number', value: '42' });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error.path).toBe('entries[0].value');
+    });
+
+    it.each([NaN, Infinity, -Infinity])(
+      'rejects number type with non-finite value (%s)',
+      (value) => {
+        const result = withEntry({ key: 'k', type: 'number', value });
+        expect(result.ok).toBe(false);
+        if (!result.ok) expect(result.error.path).toBe('entries[0].value');
+      },
+    );
+
+    it('rejects boolean type with non-boolean value', () => {
+      const result = withEntry({ key: 'k', type: 'boolean', value: 'true' });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error.path).toBe('entries[0].value');
+    });
+
+    it('rejects buffer type with non-array value', () => {
+      const result = withEntry({ key: 'k', type: 'buffer', value: 'data' });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error.path).toBe('entries[0].value');
+    });
+
+    it.each([
+      ['byte > 255', [1, 2, 256]],
+      ['byte < 0', [1, -1]],
+      ['non-integer byte', [1, 1.5]],
+      ['NaN byte', [1, NaN]],
+      ['non-number byte', [1, 'x']],
+    ])('rejects buffer with invalid byte (%s)', (_label, value) => {
+      const result = withEntry({ key: 'k', type: 'buffer', value });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.path).toMatch(/^entries\[0\]\.value\[\d+\]$/);
+      }
+    });
+
+    it('produces a path-precise error for a nested failure', () => {
+      const result = parseSnapshot({
+        ...validSnapshot(),
+        entries: [
+          { key: 'a', type: 'string', value: 'ok' },
+          { key: 'b', type: 'string', value: 'ok' },
+          { key: 'c', type: 'string', value: 'ok' },
+          { key: 'd', type: 'number', value: 'wrong' },
+        ],
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error.path).toBe('entries[3].value');
+    });
+  });
+});
+
+describe('buildSnapshot', () => {
+  it('produces a v1-shaped snapshot with the plugin id and an ISO createdAt', () => {
+    const target: StorageTarget = { adapterId: 'mmkv', storageId: 'user' };
+    const capabilities: StorageCapabilities = {
+      supportedTypes: ['string', 'number'],
+    };
+    const entries: StorageEntry[] = [
+      { key: 'token', type: 'string', value: 'abc' },
+    ];
+
+    const result = buildSnapshot({
+      target,
+      adapterName: 'MMKV',
+      storageName: 'user',
+      capabilities,
+      entries,
+    });
+
+    expect(result.version).toBe(1);
+    expect(result.plugin).toBe('@rozenite/storage-plugin');
+    expect(() => new Date(result.createdAt).toISOString()).not.toThrow();
+    expect(result.storage).toEqual({
+      adapterId: 'mmkv',
+      storageId: 'user',
+      adapterName: 'MMKV',
+      storageName: 'user',
+      capabilities,
+    });
+    expect(result.entries).toBe(entries);
+  });
+});
+
+describe('computePreview', () => {
+  const target: StorageTarget = { adapterId: 'mmkv', storageId: 'user' };
+  const allTypes: StorageCapabilities = {
+    supportedTypes: ['string', 'number', 'boolean', 'buffer'],
+  };
+  const noBlacklist = () => false;
+
+  it('splits entries into new vs overwrite', () => {
+    const snapshot = validSnapshot({
+      entries: [
+        { key: 'existing', type: 'string', value: 'a' },
+        { key: 'fresh', type: 'string', value: 'b' },
+      ],
+    });
+    const preview = computePreview(snapshot, {
+      target,
+      capabilities: allTypes,
+      entryKeys: new Set(['existing']),
+      isBlacklisted: noBlacklist,
+    });
+    expect(preview.newKeys).toEqual(['fresh']);
+    expect(preview.overwriteKeys).toEqual(['existing']);
+  });
+
+  it('surfaces blacklisted keys in skippedKeys', () => {
+    const snapshot = validSnapshot({
+      entries: [
+        { key: 'visible', type: 'string', value: 'a' },
+        { key: '__internal', type: 'string', value: 'b' },
+      ],
+    });
+    const preview = computePreview(snapshot, {
+      target,
+      capabilities: allTypes,
+      entryKeys: new Set(),
+      isBlacklisted: (key) => key.startsWith('__'),
+    });
+    expect(preview.skippedKeys).toEqual([
+      { key: '__internal', reason: 'blacklist' },
+    ]);
+    expect(preview.newKeys).toEqual(['visible']);
+  });
+
+  it('surfaces unsupported types', () => {
+    const stringOnly: StorageCapabilities = { supportedTypes: ['string'] };
+    const snapshot = validSnapshot({
+      entries: [
+        { key: 'ok', type: 'string', value: 'a' },
+        { key: 'bad', type: 'buffer', value: [1, 2] },
+      ],
+    });
+    const preview = computePreview(snapshot, {
+      target,
+      capabilities: stringOnly,
+      entryKeys: new Set(),
+      isBlacklisted: noBlacklist,
+    });
+    expect(preview.unsupportedTypes).toEqual([{ key: 'bad', type: 'buffer' }]);
+    expect(preview.newKeys).toEqual(['ok']);
+  });
+
+  it('prioritises unsupportedTypes over blacklist over overwrite/new', () => {
+    const stringOnly: StorageCapabilities = { supportedTypes: ['string'] };
+    const snapshot = validSnapshot({
+      entries: [
+        { key: '__blocked', type: 'buffer', value: [1] }, // unsupported wins
+        { key: '__skipped', type: 'string', value: 'a' }, // blacklist
+        { key: 'existing', type: 'string', value: 'b' },
+        { key: 'fresh', type: 'string', value: 'c' },
+      ],
+    });
+    const preview = computePreview(snapshot, {
+      target,
+      capabilities: stringOnly,
+      entryKeys: new Set(['existing']),
+      isBlacklisted: (key) => key.startsWith('__'),
+    });
+    expect(preview.unsupportedTypes).toEqual([
+      { key: '__blocked', type: 'buffer' },
+    ]);
+    expect(preview.skippedKeys).toEqual([
+      { key: '__skipped', reason: 'blacklist' },
+    ]);
+    expect(preview.overwriteKeys).toEqual(['existing']);
+    expect(preview.newKeys).toEqual(['fresh']);
+  });
+
+  it('flags metadataMismatch when adapter or storage IDs differ', () => {
+    const snapshot = validSnapshot({
+      storage: {
+        adapterId: 'async-storage',
+        storageId: 'default',
+        adapterName: 'AsyncStorage',
+        storageName: 'default',
+        capabilities: allTypes,
+      },
+    });
+    const preview = computePreview(snapshot, {
+      target,
+      capabilities: allTypes,
+      entryKeys: new Set(),
+      isBlacklisted: noBlacklist,
+    });
+    expect(preview.metadataMismatch).toBe(true);
+  });
+
+  it('reports metadataMismatch=false for matching target', () => {
+    const preview = computePreview(validSnapshot(), {
+      target,
+      capabilities: allTypes,
+      entryKeys: new Set(),
+      isBlacklisted: noBlacklist,
+    });
+    expect(preview.metadataMismatch).toBe(false);
+  });
+});

--- a/packages/storage-plugin/src/shared/messaging.ts
+++ b/packages/storage-plugin/src/shared/messaging.ts
@@ -1,11 +1,17 @@
 import type { StorageCapabilities, StorageEntry, StorageTarget } from './types';
 
+export type SerializedBlacklist = {
+  source: string;
+  flags: string;
+};
+
 export type StorageSnapshotEvent = {
   type: 'snapshot';
   target: StorageTarget;
   adapterName: string;
   storageName: string;
   capabilities: StorageCapabilities;
+  blacklist?: SerializedBlacklist;
   entries: StorageEntry[];
 };
 

--- a/packages/storage-plugin/src/shared/messaging.ts
+++ b/packages/storage-plugin/src/shared/messaging.ts
@@ -26,11 +26,29 @@ export type StorageGetSnapshotEvent = {
   target: StorageTarget | 'all';
 };
 
+export type StorageImportEntriesEvent = {
+  type: 'import-entries';
+  target: StorageTarget;
+  entries: StorageEntry[];
+};
+
+export type StorageImportResultEvent = {
+  type: 'import-result';
+  target: StorageTarget;
+  ok: boolean;
+  written: number;
+  total: number;
+  failedKey?: string;
+  error?: string;
+};
+
 export type StorageEvent =
   | StorageSnapshotEvent
   | StorageSetEntryEvent
   | StorageDeleteEntryEvent
-  | StorageGetSnapshotEvent;
+  | StorageGetSnapshotEvent
+  | StorageImportEntriesEvent
+  | StorageImportResultEvent;
 
 export type StorageEventMap = {
   [K in StorageEvent['type']]: Extract<StorageEvent, { type: K }>;

--- a/packages/storage-plugin/src/shared/snapshot.ts
+++ b/packages/storage-plugin/src/shared/snapshot.ts
@@ -1,0 +1,276 @@
+import {
+  DEFAULT_SUPPORTED_TYPES,
+  supportsType,
+  type StorageCapabilities,
+  type StorageEntry,
+  type StorageEntryType,
+  type StorageTarget,
+} from './types';
+
+const PLUGIN_ID = '@rozenite/storage-plugin';
+const SUPPORTED_VERSION = 1;
+
+export type StorageSnapshotV1 = {
+  version: 1;
+  plugin: string;
+  createdAt: string;
+  storage: {
+    adapterId: string;
+    storageId: string;
+    adapterName: string;
+    storageName: string;
+    capabilities: StorageCapabilities;
+  };
+  entries: StorageEntry[];
+};
+
+export type ParseError = { path: string; message: string };
+
+export type ParseResult =
+  | { ok: true; snapshot: StorageSnapshotV1 }
+  | { ok: false; error: ParseError };
+
+class ParseException extends Error {
+  constructor(
+    public path: string,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+const describe = (value: unknown): string => {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'array';
+  return typeof value;
+};
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const expectObject = (
+  value: unknown,
+  path: string,
+): Record<string, unknown> => {
+  if (!isPlainObject(value)) {
+    throw new ParseException(path, `Expected object, got ${describe(value)}`);
+  }
+  return value;
+};
+
+const expectString = (value: unknown, path: string): string => {
+  if (typeof value !== 'string') {
+    throw new ParseException(path, `Expected string, got ${describe(value)}`);
+  }
+  return value;
+};
+
+const expectArray = (value: unknown, path: string): unknown[] => {
+  if (!Array.isArray(value)) {
+    throw new ParseException(path, `Expected array, got ${describe(value)}`);
+  }
+  return value;
+};
+
+const expectEntryType = (value: unknown, path: string): StorageEntryType => {
+  if (
+    typeof value !== 'string' ||
+    !DEFAULT_SUPPORTED_TYPES.includes(value as StorageEntryType)
+  ) {
+    throw new ParseException(
+      path,
+      `Expected one of ${DEFAULT_SUPPORTED_TYPES.join(', ')}, got ${describe(value)}`,
+    );
+  }
+  return value as StorageEntryType;
+};
+
+const parseCapabilities = (raw: unknown, path: string): StorageCapabilities => {
+  const obj = expectObject(raw, path);
+  const supported = expectArray(obj.supportedTypes, `${path}.supportedTypes`);
+  const supportedTypes = supported.map((type, index) =>
+    expectEntryType(type, `${path}.supportedTypes[${index}]`),
+  );
+  return { supportedTypes };
+};
+
+const parseStorageMeta = (raw: unknown): StorageSnapshotV1['storage'] => {
+  const obj = expectObject(raw, 'storage');
+  return {
+    adapterId: expectString(obj.adapterId, 'storage.adapterId'),
+    storageId: expectString(obj.storageId, 'storage.storageId'),
+    adapterName: expectString(obj.adapterName, 'storage.adapterName'),
+    storageName: expectString(obj.storageName, 'storage.storageName'),
+    capabilities: parseCapabilities(obj.capabilities, 'storage.capabilities'),
+  };
+};
+
+const parseEntry = (raw: unknown, path: string): StorageEntry => {
+  const obj = expectObject(raw, path);
+  const key = expectString(obj.key, `${path}.key`);
+  const type = expectEntryType(obj.type, `${path}.type`);
+  const valuePath = `${path}.value`;
+
+  switch (type) {
+    case 'string': {
+      const value = obj.value;
+      if (typeof value !== 'string') {
+        throw new ParseException(
+          valuePath,
+          `Expected string for type "string", got ${describe(value)}`,
+        );
+      }
+      return { key, type: 'string', value };
+    }
+    case 'number': {
+      const value = obj.value;
+      if (typeof value !== 'number' || !Number.isFinite(value)) {
+        throw new ParseException(
+          valuePath,
+          `Expected finite number for type "number", got ${describe(value)}`,
+        );
+      }
+      return { key, type: 'number', value };
+    }
+    case 'boolean': {
+      const value = obj.value;
+      if (typeof value !== 'boolean') {
+        throw new ParseException(
+          valuePath,
+          `Expected boolean for type "boolean", got ${describe(value)}`,
+        );
+      }
+      return { key, type: 'boolean', value };
+    }
+    case 'buffer': {
+      const value = obj.value;
+      if (!Array.isArray(value)) {
+        throw new ParseException(
+          valuePath,
+          `Expected number[] for type "buffer", got ${describe(value)}`,
+        );
+      }
+      const bytes = value.map((byte, index) => {
+        if (
+          typeof byte !== 'number' ||
+          !Number.isInteger(byte) ||
+          byte < 0 ||
+          byte > 255
+        ) {
+          throw new ParseException(
+            `${valuePath}[${index}]`,
+            `Expected uint8 (integer 0-255), got ${describe(byte)}`,
+          );
+        }
+        return byte;
+      });
+      return { key, type: 'buffer', value: bytes };
+    }
+  }
+};
+
+export const parseSnapshot = (raw: unknown): ParseResult => {
+  try {
+    const root = expectObject(raw, '$');
+    const version = root.version;
+    if (version !== SUPPORTED_VERSION) {
+      throw new ParseException(
+        'version',
+        `Unsupported snapshot version: ${describe(version)} (this build supports version ${SUPPORTED_VERSION})`,
+      );
+    }
+    const plugin = expectString(root.plugin, 'plugin');
+    const createdAt = expectString(root.createdAt, 'createdAt');
+    const storage = parseStorageMeta(root.storage);
+    const rawEntries = expectArray(root.entries, 'entries');
+    const entries = rawEntries.map((entry, index) =>
+      parseEntry(entry, `entries[${index}]`),
+    );
+    return {
+      ok: true,
+      snapshot: {
+        version: SUPPORTED_VERSION,
+        plugin,
+        createdAt,
+        storage,
+        entries,
+      },
+    };
+  } catch (error) {
+    if (error instanceof ParseException) {
+      return { ok: false, error: { path: error.path, message: error.message } };
+    }
+    throw error;
+  }
+};
+
+export const buildSnapshot = (args: {
+  target: StorageTarget;
+  adapterName: string;
+  storageName: string;
+  capabilities: StorageCapabilities;
+  entries: StorageEntry[];
+}): StorageSnapshotV1 => ({
+  version: 1,
+  plugin: PLUGIN_ID,
+  createdAt: new Date().toISOString(),
+  storage: {
+    adapterId: args.target.adapterId,
+    storageId: args.target.storageId,
+    adapterName: args.adapterName,
+    storageName: args.storageName,
+    capabilities: args.capabilities,
+  },
+  entries: args.entries,
+});
+
+export type ImportPreview = {
+  newKeys: string[];
+  overwriteKeys: string[];
+  skippedKeys: { key: string; reason: 'blacklist' }[];
+  unsupportedTypes: { key: string; type: StorageEntryType }[];
+  metadataMismatch: boolean;
+};
+
+export const computePreview = (
+  snapshot: StorageSnapshotV1,
+  current: {
+    target: StorageTarget;
+    capabilities: StorageCapabilities;
+    entryKeys: Set<string>;
+    isBlacklisted: (key: string) => boolean;
+  },
+): ImportPreview => {
+  const newKeys: string[] = [];
+  const overwriteKeys: string[] = [];
+  const skippedKeys: { key: string; reason: 'blacklist' }[] = [];
+  const unsupportedTypes: { key: string; type: StorageEntryType }[] = [];
+
+  for (const entry of snapshot.entries) {
+    if (!supportsType(current.capabilities, entry.type)) {
+      unsupportedTypes.push({ key: entry.key, type: entry.type });
+      continue;
+    }
+    if (current.isBlacklisted(entry.key)) {
+      skippedKeys.push({ key: entry.key, reason: 'blacklist' });
+      continue;
+    }
+    if (current.entryKeys.has(entry.key)) {
+      overwriteKeys.push(entry.key);
+    } else {
+      newKeys.push(entry.key);
+    }
+  }
+
+  const metadataMismatch =
+    snapshot.storage.adapterId !== current.target.adapterId ||
+    snapshot.storage.storageId !== current.target.storageId;
+
+  return {
+    newKeys,
+    overwriteKeys,
+    skippedKeys,
+    unsupportedTypes,
+    metadataMismatch,
+  };
+};

--- a/packages/storage-plugin/src/ui/import-dialog.tsx
+++ b/packages/storage-plugin/src/ui/import-dialog.tsx
@@ -1,0 +1,261 @@
+import { AlertTriangle, CheckCircle2, Loader2, X, XCircle } from 'lucide-react';
+import type { StorageEntry, StorageTarget } from '../shared/types';
+import type { ImportPreview, StorageSnapshotV1 } from '../shared/snapshot';
+
+export type ImportFlightState =
+  | {
+      phase: 'preview';
+      target: StorageTarget;
+      targetLabel: string;
+      snapshot: StorageSnapshotV1;
+      preview: ImportPreview;
+      entriesToWrite: StorageEntry[];
+    }
+  | {
+      phase: 'importing';
+      target: StorageTarget;
+      total: number;
+      written: number;
+    }
+  | {
+      phase: 'result';
+      ok: true;
+      written: number;
+    }
+  | {
+      phase: 'result';
+      ok: false;
+      written: number;
+      total: number;
+      failedKey?: string;
+      error: string;
+    };
+
+export type ImportDialogProps = {
+  state: ImportFlightState | null;
+  onApply: () => void;
+  onCancel: () => void;
+  onClose: () => void;
+};
+
+const KeyList = ({ title, items }: { title: string; items: string[] }) => {
+  if (items.length === 0) return null;
+  return (
+    <div>
+      <div className="text-xs font-medium text-gray-300">
+        {title} ({items.length})
+      </div>
+      <div className="mt-1 max-h-24 overflow-auto rounded bg-gray-900 px-2 py-1 font-mono text-xs text-gray-200">
+        {items.slice(0, 50).join(', ')}
+        {items.length > 50 ? `, +${items.length - 50} more` : ''}
+      </div>
+    </div>
+  );
+};
+
+const PreviewBody = ({
+  state,
+  onApply,
+  onCancel,
+}: {
+  state: Extract<ImportFlightState, { phase: 'preview' }>;
+  onApply: () => void;
+  onCancel: () => void;
+}) => {
+  const { snapshot, preview, entriesToWrite, targetLabel } = state;
+  const hasUnsupported = preview.unsupportedTypes.length > 0;
+  const sourceLabel = `${snapshot.storage.adapterName} / ${snapshot.storage.storageName}`;
+
+  return (
+    <>
+      <div className="space-y-3">
+        {preview.metadataMismatch && (
+          <div className="flex items-start gap-2 rounded border border-yellow-700 bg-yellow-900/30 p-2 text-xs text-yellow-200">
+            <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+            <div>
+              This file was exported from <strong>{sourceLabel}</strong>. You
+              are importing into <strong>{targetLabel}</strong>.
+            </div>
+          </div>
+        )}
+
+        {hasUnsupported && (
+          <div className="flex items-start gap-2 rounded border border-red-700 bg-red-900/30 p-2 text-xs text-red-200">
+            <XCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+            <div>
+              {preview.unsupportedTypes.length}{' '}
+              {preview.unsupportedTypes.length === 1
+                ? 'entry has a type'
+                : 'entries have types'}{' '}
+              not supported by this storage. Remove them from the file and try
+              again.
+              <div className="mt-1 max-h-20 overflow-auto rounded bg-gray-900 px-2 py-1 font-mono text-xs text-red-100">
+                {preview.unsupportedTypes
+                  .map((u) => `${u.key} (${u.type})`)
+                  .join(', ')}
+              </div>
+            </div>
+          </div>
+        )}
+
+        <div className="grid grid-cols-3 gap-2 text-xs">
+          <div className="rounded bg-gray-900 p-2">
+            <div className="text-gray-400">New</div>
+            <div className="text-base font-semibold text-green-400">
+              {preview.newKeys.length}
+            </div>
+          </div>
+          <div className="rounded bg-gray-900 p-2">
+            <div className="text-gray-400">Overwrite</div>
+            <div className="text-base font-semibold text-yellow-400">
+              {preview.overwriteKeys.length}
+            </div>
+          </div>
+          <div className="rounded bg-gray-900 p-2">
+            <div className="text-gray-400">Skipped</div>
+            <div className="text-base font-semibold text-gray-400">
+              {preview.skippedKeys.length}
+            </div>
+          </div>
+        </div>
+
+        <KeyList title="New keys" items={preview.newKeys} />
+        <KeyList title="Overwrite keys" items={preview.overwriteKeys} />
+        <KeyList
+          title="Skipped (filtered by storage)"
+          items={preview.skippedKeys.map((s) => s.key)}
+        />
+      </div>
+
+      <div className="mt-6 flex items-center justify-end gap-2">
+        <button
+          onClick={onCancel}
+          className="rounded px-4 py-2 text-sm text-gray-300 transition-colors hover:bg-gray-700 hover:text-white"
+        >
+          Cancel
+        </button>
+        <button
+          onClick={onApply}
+          disabled={hasUnsupported}
+          className="rounded bg-blue-600 px-4 py-2 text-sm text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-gray-600"
+        >
+          Apply ({entriesToWrite.length})
+        </button>
+      </div>
+    </>
+  );
+};
+
+const ImportingBody = ({
+  state,
+}: {
+  state: Extract<ImportFlightState, { phase: 'importing' }>;
+}) => (
+  <div className="flex flex-col items-center gap-3 py-6">
+    <Loader2 className="h-6 w-6 animate-spin text-blue-400" />
+    <div className="text-sm text-gray-200">
+      Importing… {state.written} / {state.total}
+    </div>
+  </div>
+);
+
+const ResultBody = ({
+  state,
+  onClose,
+}: {
+  state: Extract<ImportFlightState, { phase: 'result' }>;
+  onClose: () => void;
+}) => (
+  <>
+    {state.ok ? (
+      <div className="flex flex-col items-center gap-3 py-4">
+        <CheckCircle2 className="h-8 w-8 text-green-400" />
+        <div className="text-sm text-gray-200">
+          Imported {state.written} {state.written === 1 ? 'entry' : 'entries'}.
+        </div>
+      </div>
+    ) : (
+      <div className="space-y-2 py-2">
+        <div className="flex items-center gap-2 text-red-300">
+          <XCircle className="h-5 w-5" />
+          <div className="text-sm font-medium">
+            Import failed after {state.written} of {state.total}.
+          </div>
+        </div>
+        {state.failedKey && (
+          <div className="text-xs text-gray-300">
+            Failed at key:{' '}
+            <span className="font-mono text-gray-100">{state.failedKey}</span>
+          </div>
+        )}
+        <div className="rounded bg-gray-900 px-2 py-1 font-mono text-xs text-red-200">
+          {state.error}
+        </div>
+      </div>
+    )}
+
+    <div className="mt-4 flex items-center justify-end">
+      <button
+        onClick={onClose}
+        autoFocus
+        className="rounded bg-blue-600 px-4 py-2 text-sm text-white transition-colors hover:bg-blue-700"
+      >
+        Close
+      </button>
+    </div>
+  </>
+);
+
+export const ImportDialog = ({
+  state,
+  onApply,
+  onCancel,
+  onClose,
+}: ImportDialogProps) => {
+  if (!state) return null;
+
+  const title =
+    state.phase === 'preview'
+      ? 'Import snapshot'
+      : state.phase === 'importing'
+        ? 'Importing…'
+        : state.ok
+          ? 'Import complete'
+          : 'Import failed';
+
+  // Importing phase: dialog is locked; only the success/failure transition closes it.
+  const isDismissible = state.phase !== 'importing';
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
+      onClick={isDismissible ? onClose : undefined}
+    >
+      <div
+        className="mx-4 w-[28rem] max-w-full rounded-lg bg-gray-800 p-6"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-gray-100">{title}</h2>
+          {isDismissible && (
+            <button
+              onClick={onClose}
+              className="rounded p-1 text-gray-400 transition-colors hover:bg-gray-700 hover:text-gray-200"
+              title="Close dialog"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          )}
+        </div>
+
+        {state.phase === 'preview' && (
+          <PreviewBody state={state} onApply={onApply} onCancel={onCancel} />
+        )}
+        {state.phase === 'importing' && <ImportingBody state={state} />}
+        {state.phase === 'result' && (
+          <ResultBody state={state} onClose={onClose} />
+        )}
+      </div>
+    </div>
+  );
+};

--- a/packages/storage-plugin/src/ui/panel.tsx
+++ b/packages/storage-plugin/src/ui/panel.tsx
@@ -1,9 +1,10 @@
 import { useRozeniteDevToolsClient } from '@rozenite/plugin-bridge';
-import { useEffect, useMemo, useState } from 'react';
-import { Search, Plus } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Download, Plus, Search, Upload } from 'lucide-react';
 import type {
   StorageDeleteEntryEvent,
   StorageEventMap,
+  StorageImportResultEvent,
   StorageSetEntryEvent,
   StorageSnapshotEvent,
 } from '../shared/messaging';
@@ -14,10 +15,18 @@ import type {
   StorageTarget,
 } from '../shared/types';
 import { getStorageViewId } from '../shared/types';
+import {
+  buildSnapshot,
+  computePreview,
+  parseSnapshot,
+} from '../shared/snapshot';
 import { EditableTable } from './editable-table';
 import { AddEntryDialog } from './add-entry-dialog';
 import { EntryDetailDialog } from './entry-detail-dialog';
 import { EditEntryDialog } from './edit-entry-dialog';
+import { ConfirmDialog } from './confirm-dialog';
+import { ImportDialog, type ImportFlightState } from './import-dialog';
+import { buildExportFilename, downloadJson } from './utils';
 import './globals.css';
 
 type StorageSnapshotState = {
@@ -25,10 +34,22 @@ type StorageSnapshotState = {
   adapterName: string;
   storageName: string;
   capabilities: StorageCapabilities;
+  blacklist?: RegExp;
   entries: StorageEntry[];
 };
 
-const getEntryTypeFromValue = (value: StorageEntryValue): StorageEntry['type'] => {
+type AlertState = {
+  isOpen: boolean;
+  title: string;
+  message: string;
+};
+
+const sameTarget = (a: StorageTarget, b: StorageTarget) =>
+  a.adapterId === b.adapterId && a.storageId === b.storageId;
+
+const getEntryTypeFromValue = (
+  value: StorageEntryValue,
+): StorageEntry['type'] => {
   if (typeof value === 'string') {
     return 'string';
   }
@@ -46,11 +67,11 @@ const getEntryTypeFromValue = (value: StorageEntryValue): StorageEntry['type'] =
 
 export default function StoragePanel() {
   const [snapshots, setSnapshots] = useState<Map<string, StorageSnapshotState>>(
-    new Map()
+    new Map(),
   );
-  const [selectedStorageViewId, setSelectedStorageViewId] = useState<string | null>(
-    null
-  );
+  const [selectedStorageViewId, setSelectedStorageViewId] = useState<
+    string | null
+  >(null);
   const [loading, setLoading] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
   const [showAddDialog, setShowAddDialog] = useState(false);
@@ -58,6 +79,15 @@ export default function StoragePanel() {
   const [showDetailDialog, setShowDetailDialog] = useState(false);
   const [editingEntry, setEditingEntry] = useState<StorageEntry | null>(null);
   const [showEditDialog, setShowEditDialog] = useState(false);
+  const [importFlight, setImportFlight] = useState<ImportFlightState | null>(
+    null,
+  );
+  const [alertState, setAlertState] = useState<AlertState>({
+    isOpen: false,
+    title: '',
+    message: '',
+  });
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const client = useRozeniteDevToolsClient<StorageEventMap>({
     pluginId: '@rozenite/storage-plugin',
@@ -71,61 +101,91 @@ export default function StoragePanel() {
     const snapshotSubscription = client.onMessage(
       'snapshot',
       (event: StorageSnapshotEvent) => {
-      const viewId = getStorageViewId(event.target);
-      setSnapshots((previous) => {
-        const next = new Map(previous);
-        next.set(viewId, {
-          target: event.target,
-          adapterName: event.adapterName,
-          storageName: event.storageName,
-          capabilities: event.capabilities,
-          entries: event.entries,
+        const viewId = getStorageViewId(event.target);
+        setSnapshots((previous) => {
+          const next = new Map(previous);
+          next.set(viewId, {
+            target: event.target,
+            adapterName: event.adapterName,
+            storageName: event.storageName,
+            capabilities: event.capabilities,
+            blacklist: event.blacklist
+              ? new RegExp(event.blacklist.source, event.blacklist.flags)
+              : undefined,
+            entries: event.entries,
+          });
+
+          if (previous.size === 0 && !selectedStorageViewId) {
+            setSelectedStorageViewId(viewId);
+          }
+
+          return next;
         });
 
-        if (previous.size === 0 && !selectedStorageViewId) {
-          setSelectedStorageViewId(viewId);
+        if (viewId === selectedStorageViewId) {
+          setLoading(false);
         }
-
-        return next;
-      });
-
-      if (viewId === selectedStorageViewId) {
-        setLoading(false);
-      }
-      }
+      },
     );
 
     const setEntrySubscription = client.onMessage(
       'set-entry',
       (event: StorageSetEntryEvent) => {
-      const viewId = getStorageViewId(event.target);
-      setSnapshots((previous) => {
-        const next = new Map(previous);
-        const current = next.get(viewId);
+        const viewId = getStorageViewId(event.target);
+        setSnapshots((previous) => {
+          const next = new Map(previous);
+          const current = next.get(viewId);
 
-        if (!current) {
-          return previous;
-        }
+          if (!current) {
+            return previous;
+          }
 
-        const existingIndex = current.entries.findIndex(
-          (entry) => entry.key === event.entry.key
-        );
+          const existingIndex = current.entries.findIndex(
+            (entry) => entry.key === event.entry.key,
+          );
 
-        const entries =
-          existingIndex >= 0
-            ? current.entries.map((entry) =>
-                entry.key === event.entry.key ? event.entry : entry
-              )
-            : [...current.entries, event.entry];
+          const entries =
+            existingIndex >= 0
+              ? current.entries.map((entry) =>
+                  entry.key === event.entry.key ? event.entry : entry,
+                )
+              : [...current.entries, event.entry];
 
-        next.set(viewId, {
-          ...current,
-          entries,
+          next.set(viewId, {
+            ...current,
+            entries,
+          });
+
+          return next;
         });
 
-        return next;
-      });
-      }
+        setImportFlight((previous) => {
+          if (!previous || previous.phase !== 'importing') return previous;
+          if (!sameTarget(event.target, previous.target)) return previous;
+          return { ...previous, written: previous.written + 1 };
+        });
+      },
+    );
+
+    const importResultSubscription = client.onMessage(
+      'import-result',
+      (event: StorageImportResultEvent) => {
+        setImportFlight((previous) => {
+          if (!previous || previous.phase !== 'importing') return previous;
+          if (!sameTarget(event.target, previous.target)) return previous;
+          if (event.ok) {
+            return { phase: 'result', ok: true, written: event.written };
+          }
+          return {
+            phase: 'result',
+            ok: false,
+            written: event.written,
+            total: event.total,
+            failedKey: event.failedKey,
+            error: event.error ?? 'Unknown error',
+          };
+        });
+      },
     );
 
     const deleteEntrySubscription = client.onMessage(
@@ -148,7 +208,7 @@ export default function StoragePanel() {
 
           return next;
         });
-      }
+      },
     );
 
     client.send('get-snapshot', {
@@ -160,6 +220,7 @@ export default function StoragePanel() {
       snapshotSubscription.remove();
       setEntrySubscription.remove();
       deleteEntrySubscription.remove();
+      importResultSubscription.remove();
     };
   }, [client, selectedStorageViewId]);
 
@@ -178,7 +239,7 @@ export default function StoragePanel() {
     const separatorIndex = selectedStorageViewId.indexOf(':');
     if (separatorIndex < 0) {
       console.warn(
-        `[Rozenite] Storage Plugin: Invalid storage view id "${selectedStorageViewId}".`
+        `[Rozenite] Storage Plugin: Invalid storage view id "${selectedStorageViewId}".`,
       );
       setLoading(false);
       return;
@@ -198,7 +259,7 @@ export default function StoragePanel() {
   }, [client, selectedStorageViewId, snapshots]);
 
   const selectedStorage = selectedStorageViewId
-    ? snapshots.get(selectedStorageViewId) ?? null
+    ? (snapshots.get(selectedStorageViewId) ?? null)
     : null;
 
   const entries = selectedStorage?.entries ?? [];
@@ -206,15 +267,15 @@ export default function StoragePanel() {
   const filteredEntries = useMemo(
     () =>
       entries.filter((entry) =>
-        entry.key.toLowerCase().includes(searchTerm.toLowerCase())
+        entry.key.toLowerCase().includes(searchTerm.toLowerCase()),
       ),
-    [entries, searchTerm]
+    [entries, searchTerm],
   );
 
   const supportedTypes = selectedStorage?.capabilities.supportedTypes ?? [];
 
   const updateEntriesForSelectedStorage = (
-    mutate: (entries: StorageEntry[]) => StorageEntry[]
+    mutate: (entries: StorageEntry[]) => StorageEntry[],
   ) => {
     if (!selectedStorageViewId) {
       return;
@@ -266,7 +327,7 @@ export default function StoragePanel() {
     });
 
     updateEntriesForSelectedStorage((currentEntries) =>
-      currentEntries.map((entry) => (entry.key === key ? updatedEntry : entry))
+      currentEntries.map((entry) => (entry.key === key ? updatedEntry : entry)),
     );
   };
 
@@ -282,7 +343,7 @@ export default function StoragePanel() {
     });
 
     updateEntriesForSelectedStorage((currentEntries) =>
-      currentEntries.filter((entry) => entry.key !== key)
+      currentEntries.filter((entry) => entry.key !== key),
     );
   };
 
@@ -297,7 +358,105 @@ export default function StoragePanel() {
       entry,
     });
 
-    updateEntriesForSelectedStorage((currentEntries) => [...currentEntries, entry]);
+    updateEntriesForSelectedStorage((currentEntries) => [
+      ...currentEntries,
+      entry,
+    ]);
+  };
+
+  const showAlert = (title: string, message: string) =>
+    setAlertState({ isOpen: true, title, message });
+
+  const handleImportClick = () => {
+    if (!fileInputRef.current) return;
+    fileInputRef.current.value = '';
+    fileInputRef.current.click();
+  };
+
+  const handleFileChange = async (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const file = event.target.files?.[0];
+    if (!file || !selectedStorage) {
+      return;
+    }
+
+    let raw: unknown;
+    try {
+      const text = await file.text();
+      raw = JSON.parse(text);
+    } catch (parseError) {
+      showAlert(
+        'Could not read file',
+        parseError instanceof Error ? parseError.message : String(parseError),
+      );
+      return;
+    }
+
+    const parsed = parseSnapshot(raw);
+    if (!parsed.ok) {
+      showAlert(
+        'Invalid snapshot',
+        `${parsed.error.path}: ${parsed.error.message}`,
+      );
+      return;
+    }
+
+    const preview = computePreview(parsed.snapshot, {
+      target: selectedStorage.target,
+      capabilities: selectedStorage.capabilities,
+      entryKeys: new Set(selectedStorage.entries.map((entry) => entry.key)),
+      isBlacklisted: selectedStorage.blacklist
+        ? (key) => selectedStorage.blacklist!.test(key)
+        : () => false,
+    });
+
+    const skippedSet = new Set(preview.skippedKeys.map((s) => s.key));
+    const unsupportedSet = new Set(preview.unsupportedTypes.map((u) => u.key));
+    const entriesToWrite = parsed.snapshot.entries.filter(
+      (entry) => !skippedSet.has(entry.key) && !unsupportedSet.has(entry.key),
+    );
+
+    setImportFlight({
+      phase: 'preview',
+      target: selectedStorage.target,
+      targetLabel: `${selectedStorage.adapterName} / ${selectedStorage.storageName}`,
+      snapshot: parsed.snapshot,
+      preview,
+      entriesToWrite,
+    });
+  };
+
+  const handleApplyImport = () => {
+    if (!client) return;
+    if (!importFlight || importFlight.phase !== 'preview') return;
+
+    client.send('import-entries', {
+      type: 'import-entries',
+      target: importFlight.target,
+      entries: importFlight.entriesToWrite,
+    });
+
+    setImportFlight({
+      phase: 'importing',
+      target: importFlight.target,
+      total: importFlight.entriesToWrite.length,
+      written: 0,
+    });
+  };
+
+  const handleCloseImport = () => setImportFlight(null);
+
+  const handleExport = () => {
+    if (!selectedStorage) return;
+    const snapshot = buildSnapshot({
+      target: selectedStorage.target,
+      adapterName: selectedStorage.adapterName,
+      storageName: selectedStorage.storageName,
+      capabilities: selectedStorage.capabilities,
+      entries: selectedStorage.entries,
+    });
+    downloadJson(snapshot, buildExportFilename(selectedStorage.target));
   };
 
   const storageOptions = [...snapshots.entries()].map(([viewId, snapshot]) => ({
@@ -346,6 +505,31 @@ export default function StoragePanel() {
           <Plus className="h-3 w-3" />
           Add Entry
         </button>
+        <button
+          onClick={handleImportClick}
+          disabled={!selectedStorage}
+          className="flex items-center gap-1 px-3 h-8 text-xs bg-gray-700 hover:bg-gray-600 disabled:bg-gray-800 disabled:cursor-not-allowed text-gray-100 rounded transition-colors"
+          title="Import entries from a JSON snapshot"
+        >
+          <Upload className="h-3 w-3" />
+          Import
+        </button>
+        <button
+          onClick={handleExport}
+          disabled={!selectedStorage || entries.length === 0}
+          className="flex items-center gap-1 px-3 h-8 text-xs bg-gray-700 hover:bg-gray-600 disabled:bg-gray-800 disabled:cursor-not-allowed text-gray-100 rounded transition-colors"
+          title="Export entries to a JSON snapshot"
+        >
+          <Download className="h-3 w-3" />
+          Export
+        </button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="application/json,.json"
+          className="hidden"
+          onChange={handleFileChange}
+        />
         <div className="flex-1">
           <div className="relative">
             <Search className="absolute left-2 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
@@ -436,6 +620,22 @@ export default function StoragePanel() {
         }}
         supportedTypes={supportedTypes}
         entry={editingEntry}
+      />
+
+      <ImportDialog
+        state={importFlight}
+        onApply={handleApplyImport}
+        onCancel={handleCloseImport}
+        onClose={handleCloseImport}
+      />
+
+      <ConfirmDialog
+        isOpen={alertState.isOpen}
+        onClose={() => setAlertState((prev) => ({ ...prev, isOpen: false }))}
+        onConfirm={() => setAlertState((prev) => ({ ...prev, isOpen: false }))}
+        title={alertState.title}
+        message={alertState.message}
+        type="alert"
       />
     </div>
   );

--- a/packages/storage-plugin/src/ui/utils.ts
+++ b/packages/storage-plugin/src/ui/utils.ts
@@ -1,0 +1,30 @@
+import type { StorageTarget } from '../shared/types';
+
+export const downloadJson = (data: unknown, filename: string): void => {
+  const json = JSON.stringify(data, null, 2);
+  const blob = new Blob([json], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+};
+
+const sanitize = (value: string) => value.replace(/[^a-zA-Z0-9_-]/g, '-');
+
+export const buildExportFilename = (
+  target: StorageTarget,
+  now: Date = new Date(),
+): string => {
+  const yyyy = now.getFullYear().toString().padStart(4, '0');
+  const mm = (now.getMonth() + 1).toString().padStart(2, '0');
+  const dd = now.getDate().toString().padStart(2, '0');
+  const hh = now.getHours().toString().padStart(2, '0');
+  const mi = now.getMinutes().toString().padStart(2, '0');
+  const ss = now.getSeconds().toString().padStart(2, '0');
+  const timestamp = `${yyyy}${mm}${dd}-${hh}${mi}${ss}`;
+  return `rozenite-storage-${sanitize(target.adapterId)}-${sanitize(target.storageId)}-${timestamp}.json`;
+};

--- a/website/src/docs/official-plugins/storage.mdx
+++ b/website/src/docs/official-plugins/storage.mdx
@@ -125,4 +125,69 @@ createAsyncStorageAdapter({
 });
 ```
 
+## Import / Export
+
+The panel can export the currently selected storage to a JSON snapshot and import a snapshot back. Use this to reproduce bugs from a captured state, share state between teammates, or seed known test scenarios without writing one-off app code.
+
+### Behavior
+
+- **Scope**: Import and Export always operate on the **currently selected storage** only. Importing into a different storage requires switching the dropdown first; the file's metadata is never used to redirect the target.
+- **Upsert**: Import overwrites existing keys and creates missing ones. Keys not present in the file are left untouched. There is no "replace all" mode.
+- **Validate before write**: The file is fully parsed and validated before any entries are applied. If validation fails, nothing is written and the error points at the offending path (for example, `entries[3].value`).
+- **Stop on first error**: If a write fails mid-import (rare — most failures are caught up-front), the import stops and reports which key failed. Already-written entries stay; rerunning import is safe because writes are idempotent.
+- **Skipped keys**: Keys matching the target storage's `blacklist` are skipped during write. The preview shows the count and the keys before you apply.
+- **Live updates**: As entries are written, the table updates row by row.
+
+### JSON snapshot schema
+
+Exports use a stable, versioned format:
+
+```json title="rozenite-storage-mmkv-user-20260511-104643.json"
+{
+  "version": 1,
+  "plugin": "@rozenite/storage-plugin",
+  "createdAt": "2026-05-11T10:46:43.000Z",
+  "storage": {
+    "adapterId": "mmkv",
+    "storageId": "user",
+    "adapterName": "MMKV",
+    "storageName": "user",
+    "capabilities": {
+      "supportedTypes": ["string", "number", "boolean", "buffer"]
+    }
+  },
+  "entries": [
+    { "key": "token", "type": "string", "value": "abc" },
+    { "key": "launchCount", "type": "number", "value": 3 },
+    { "key": "seenOnboarding", "type": "boolean", "value": true },
+    { "key": "blob", "type": "buffer", "value": [1, 2, 255] }
+  ]
+}
+```
+
+Fields:
+
+- `version` (number, required) — load-bearing. The current build accepts `1` only.
+- `plugin` (string, required) — informational. Always `@rozenite/storage-plugin` for files this plugin produces.
+- `createdAt` (string, required) — ISO-8601 timestamp of the export. Informational.
+- `storage` (object, required) — describes the source storage. Used for the preview's "imported from" label and the metadata-mismatch warning when the target storage differs. **Never used to redirect the import.**
+- `entries` (array, required) — typed entry list. Each entry has `key` (string), `type` (`"string" | "number" | "boolean" | "buffer"`), and `value` matching the type. Buffer values are `number[]` of integers in `0–255`. Empty arrays are allowed (a no-op import).
+- Unknown top-level fields are ignored for forward compatibility.
+
+### Cross-adapter compatibility
+
+The schema is portable across adapters, but each adapter only stores types it supports:
+
+| Adapter          | string | number | boolean | buffer |
+| ---------------- | :----: | :----: | :-----: | :----: |
+| MMKV             |   ✓    |   ✓    |    ✓    |   ✓    |
+| AsyncStorage     |   ✓    |   ✓    |    ✓    |   —    |
+| Expo SecureStore |   ✓    |   —    |    —    |   —    |
+
+If a file contains an entry whose `type` is not supported by the selected target, the preview disables **Apply** and lists the offending keys. Remove them from the file (or import into a more capable storage) and retry.
+
+### Versioning
+
+The current build accepts `version: 1` snapshots. Any other value is rejected with a clear error. Future schema bumps will either be backward-compatible additions or documented as breaking — but `version !== 1` is never silently coerced.
+
 **Next**: See [MMKV](./mmkv.md), [Network Activity](./network-activity.md), and [Plugin Development](../plugin-development/plugin-development.md).


### PR DESCRIPTION
Closes #247.

## Summary

- Adds **Import** and **Export** buttons to the storage panel toolbar, scoped to the currently selected storage.
- Defines a stable, versioned (`version: 1`) JSON snapshot format with `plugin`, `createdAt`, source `storage` metadata, and typed `entries[]`.
- Hand-written `parseSnapshot` with path-precise errors (e.g. `entries[3].value: Expected finite number…`). No new runtime deps.
- Import is an **upsert** with **validate-before-write**: any unsupported type aborts before any writes. The preview shows new / overwrite / skipped (blacklisted) counts and warns when the file's source storage differs from the target.
- Runtime delivers a new `import-entries` event; emits a `set-entry` echo per successful write so the table updates row by row, then a single `import-result` for completion. Stops at the first failed write and reports the offending key.
- Extends the snapshot wire format with an optional serialized `blacklist` (RegExp `source`/`flags`) so the panel can compute skip counts against the runtime's filter.
- Docs: new **Import / Export** section in the storage plugin docs covering behavior, schema, cross-adapter compatibility, and versioning. Pointer added to the package README.
- Changeset: minor bump for `@rozenite/storage-plugin`.

## Test plan

Automated:

- [x] Snapshot parser unit tests — happy paths, every rejection branch, path precision (`packages/storage-plugin/src/shared/__tests__/snapshot.test.ts`).
- [x] `computePreview` pure-function tests — bucket priority, blacklist skip, unsupported types, metadata mismatch.
- [x] Runtime bulk handler tests — per-write echo, stop-on-first-error, unknown target, empty entries (`packages/storage-plugin/src/react-native/__tests__/import.test.ts`).
- [x] `pnpm --filter @rozenite/storage-plugin test` — 48/48 passing.
- [x] `pnpm --filter @rozenite/storage-plugin typecheck` — clean.
- [x] `pnpm --filter @rozenite/storage-plugin lint` — 0 errors (1 pre-existing unrelated warning).
- [x] `pnpm --filter @rozenite/docs build` — website builds; new section renders.

Manual (playground, MMKV / AsyncStorage / SecureStore via `apps/playground`):

- [x] Export downloads a valid JSON file named `rozenite-storage-<adapter>-<storage>-YYYYMMDD-HHmmss.json`.
- [x] Importing an exported file (unchanged) is a no-op preview that applies cleanly.
- [x] Importing a file with `version: 2` is rejected with a path-pointed error.
- [x] Importing into an adapter that doesn't support a present type (e.g. `buffer` into AsyncStorage) disables **Apply** and lists offenders.
- [x] Importing from a different storage source triggers the metadata-mismatch warning banner.
- [x] Importing an empty `entries: []` file applies as a no-op.
- [x] Importing valid edits updates the table row by row as writes land.

## Out of scope

- Global cross-storage export.
- `replace-all` / clear-storage semantics during import.
- Adapter-specific native dump formats.
- Surfacing storages that use `shouldFilterKey` (function form) — only the `blacklist` RegExp form is exposed to the UI today.