### PR TITLE
feat(performance-monitor-plugin): expand data coverage

### DIFF
--- a/.changeset/violet-pandas-observe.md
+++ b/.changeset/violet-pandas-observe.md
@@ -1,0 +1,7 @@
+---
+'@rozenite/performance-monitor-plugin': minor
+---
+
+Expand performance monitor coverage to `resource` and `react-native-mark` entries, and preserve `mark.detail`.
+
+The panel now has dedicated tabs for **React Native Marks** (the native startup taxonomy like `nativeLaunchStart`, `runJSBundleStart`, …) and **Resources** (HTTP requests captured via `setResourceLoggingEnabled`). The Resources table shows Name / Type / Duration / Size, with the full `PerformanceResourceTiming` breakdown (sizes, all 12 timing phases, `serverTiming` / `workerTiming`) available in the details sidebar. Previously dropped `mark.detail` payloads are now preserved end-to-end and rendered in the Mark Details sidebar. The export modal can include both new entry types and reports their counts in `sessionInfo`.

--- a/apps/playground/src/app/screens/PerformanceMonitorScreen.tsx
+++ b/apps/playground/src/app/screens/PerformanceMonitorScreen.tsx
@@ -1,17 +1,30 @@
+import { useEffect } from 'react';
 import {
   View,
   Text,
   TouchableOpacity,
   StyleSheet,
   SafeAreaView,
+  ScrollView,
   Alert,
 } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { NavigationProp } from '../navigation/types';
-import performance from 'react-native-performance';
+import performance, {
+  setResourceLoggingEnabled,
+} from 'react-native-performance';
+
+const NETWORK_TEST_URL = 'https://jsonplaceholder.typicode.com/posts/1';
 
 export const PerformanceMonitorScreen = () => {
   const navigation = useNavigation<NavigationProp>();
+
+  // Install the resource logger so any fetch from this screen produces
+  // a PerformanceResourceTiming entry the panel can show in the
+  // Resources tab.
+  useEffect(() => {
+    setResourceLoggingEnabled(true);
+  }, []);
 
   const firePerformanceMetric = () => {
     // Create a custom performance metric
@@ -27,7 +40,7 @@ export const PerformanceMonitorScreen = () => {
       'Performance Metric Fired',
       `Metric "${metric.name}" with value ${metric.value}${
         metric.detail?.unit ? ` ${metric.detail.unit}` : ''
-      } has been created.`
+      } has been created.`,
     );
   };
 
@@ -37,7 +50,7 @@ export const PerformanceMonitorScreen = () => {
 
     Alert.alert(
       'Performance Mark Fired',
-      `Mark "${markName}" has been created at ${new Date().toLocaleTimeString()}.`
+      `Mark "${markName}" has been created at ${new Date().toLocaleTimeString()}.`,
     );
   };
 
@@ -67,14 +80,30 @@ export const PerformanceMonitorScreen = () => {
 
       Alert.alert(
         'Performance Measure Fired',
-        `Measure "${measureName}" has been created between "${startMark}" and "${endMark}".`
+        `Measure "${measureName}" has been created between "${startMark}" and "${endMark}".`,
       );
     }, 100);
 
     Alert.alert(
       'Performance Measure Started',
-      `Started measure "${measureName}". End mark will be created in 100ms.`
+      `Started measure "${measureName}". End mark will be created in 100ms.`,
     );
+  };
+
+  const fireNetworkRequest = async () => {
+    try {
+      const response = await fetch(NETWORK_TEST_URL);
+      await response.text();
+      Alert.alert(
+        'Network Request Completed',
+        `GET ${NETWORK_TEST_URL} (${response.status}). A resource timing entry was logged.`,
+      );
+    } catch (error) {
+      Alert.alert(
+        'Network Request Failed',
+        error instanceof Error ? error.message : 'Unknown error',
+      );
+    }
   };
 
   const fireComplexPerformanceScenario = () => {
@@ -86,6 +115,13 @@ export const PerformanceMonitorScreen = () => {
     // Start the scenario
     performance.mark(startMark);
 
+    // Kick off a network request in parallel so the scenario also
+    // exercises the Resources tab. Errors are swallowed — the marks
+    // and measures still complete regardless.
+    void fetch(NETWORK_TEST_URL)
+      .then((response) => response.text())
+      .catch(() => undefined);
+
     // Simulate processing
     setTimeout(() => {
       performance.mark(processMark);
@@ -94,7 +130,7 @@ export const PerformanceMonitorScreen = () => {
       performance.measure(
         `processing-time-${scenarioId}`,
         startMark,
-        processMark
+        processMark,
       );
 
       // Simulate more work
@@ -107,14 +143,14 @@ export const PerformanceMonitorScreen = () => {
 
         Alert.alert(
           'Complex Performance Scenario',
-          `Scenario ${scenarioId} completed with multiple marks and measures.`
+          `Scenario ${scenarioId} completed with multiple marks, measures, and a network request.`,
         );
       }, 200);
     }, 150);
 
     Alert.alert(
       'Complex Scenario Started',
-      `Performance scenario ${scenarioId} started. This will create multiple marks and measures.`
+      `Performance scenario ${scenarioId} started. This will create multiple marks, measures, and a network request.`,
     );
   };
 
@@ -130,7 +166,10 @@ export const PerformanceMonitorScreen = () => {
         <Text style={styles.title}>Performance Monitor</Text>
       </View>
 
-      <View style={styles.content}>
+      <ScrollView
+        style={styles.content}
+        contentContainerStyle={styles.contentInner}
+      >
         <View style={styles.infoContainer}>
           <Text style={styles.infoText}>
             Use these buttons to generate performance data that will be captured
@@ -174,12 +213,22 @@ export const PerformanceMonitorScreen = () => {
           </TouchableOpacity>
 
           <TouchableOpacity
+            style={[styles.button, styles.resourceButton]}
+            onPress={fireNetworkRequest}
+          >
+            <Text style={styles.buttonText}>Fire Network Request</Text>
+            <Text style={styles.buttonSubtext}>
+              Performs a fetch that logs a resource timing entry
+            </Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
             style={[styles.button, styles.scenarioButton]}
             onPress={fireComplexPerformanceScenario}
           >
             <Text style={styles.buttonText}>Complex Performance Scenario</Text>
             <Text style={styles.buttonSubtext}>
-              Creates multiple marks and measures
+              Marks, measures, and a network request together
             </Text>
           </TouchableOpacity>
         </View>
@@ -197,11 +246,19 @@ export const PerformanceMonitorScreen = () => {
             between them
           </Text>
           <Text style={styles.instructionsText}>
-            • Complex Scenario: Creates multiple marks and measures to simulate
-            real-world usage
+            • Network Request: Performs a fetch which logs a resource timing
+            entry on the Resources tab
+          </Text>
+          <Text style={styles.instructionsText}>
+            • Complex Scenario: Marks, measures, and a network request together
+          </Text>
+          <Text style={styles.instructionsText}>
+            • React Native Marks (nativeLaunchStart, runJSBundleStart, ...) are
+            emitted by the native runtime during app startup. They appear
+            automatically when you start a session — no button needed.
           </Text>
         </View>
-      </View>
+      </ScrollView>
     </SafeAreaView>
   );
 };
@@ -233,8 +290,11 @@ const styles = StyleSheet.create({
   },
   content: {
     flex: 1,
+  },
+  contentInner: {
     paddingHorizontal: 20,
     paddingTop: 20,
+    paddingBottom: 40,
   },
   infoContainer: {
     marginBottom: 30,
@@ -270,6 +330,9 @@ const styles = StyleSheet.create({
   },
   measureButton: {
     borderColor: '#FF9500',
+  },
+  resourceButton: {
+    borderColor: '#00B4D8',
   },
   scenarioButton: {
     borderColor: '#8232FF',

--- a/packages/performance-monitor-plugin/package.json
+++ b/packages/performance-monitor-plugin/package.json
@@ -18,7 +18,8 @@
     "build": "rozenite build",
     "dev": "rozenite dev",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "vitest --run --passWithNoTests"
   },
   "dependencies": {
     "@rozenite/plugin-bridge": "workspace:*"

--- a/packages/performance-monitor-plugin/src/react-native/__tests__/serialize.test.ts
+++ b/packages/performance-monitor-plugin/src/react-native/__tests__/serialize.test.ts
@@ -10,11 +10,19 @@ vi.mock('react-native-performance', () => ({
   default: { timeOrigin: 0 },
 }));
 
-import { serializeMark, serializeMeasure, serializeMetric } from '../serialize';
+import {
+  serializeMark,
+  serializeMeasure,
+  serializeMetric,
+  serializeReactNativeMark,
+  serializeResource,
+} from '../serialize';
 import type {
   PerformanceMark,
   PerformanceMeasure,
   PerformanceMetric,
+  PerformanceReactNativeMark,
+  PerformanceResourceTiming,
 } from 'react-native-performance';
 
 const ORIGIN = 1_700_000_000_000;
@@ -105,5 +113,117 @@ describe('serializeMetric', () => {
     } as PerformanceMetric;
 
     expect(serializeMetric(entry, ORIGIN).value).toBe('active');
+  });
+});
+
+describe('serializeReactNativeMark', () => {
+  it('copies name, duration, entryType, detail, and translates startTime', () => {
+    const detail = { phase: 'native-launch' };
+    const entry = {
+      name: 'nativeLaunchStart',
+      entryType: 'react-native-mark',
+      startTime: 7,
+      duration: 0,
+      detail,
+    } as PerformanceReactNativeMark;
+
+    expect(serializeReactNativeMark(entry, ORIGIN)).toEqual({
+      name: 'nativeLaunchStart',
+      startTime: ORIGIN + 7,
+      duration: 0,
+      entryType: 'react-native-mark',
+      detail,
+    });
+  });
+
+  it('passes detail=undefined through unchanged', () => {
+    const entry = {
+      name: 'runJSBundleStart',
+      entryType: 'react-native-mark',
+      startTime: 100,
+      duration: 0,
+    } as PerformanceReactNativeMark;
+
+    expect(serializeReactNativeMark(entry, ORIGIN).detail).toBeUndefined();
+  });
+});
+
+describe('serializeResource', () => {
+  // Build a fully-populated resource entry. The serializer is mostly a
+  // mechanical field copy of ~20 fields; this fixture pins every one
+  // down so a typo in any field name fails the test immediately.
+  const buildEntry = (): PerformanceResourceTiming =>
+    ({
+      name: 'https://example.com/api/users',
+      entryType: 'resource',
+      startTime: 50,
+      duration: 250,
+      initiatorType: 'fetch',
+      transferSize: 1024,
+      encodedBodySize: 800,
+      decodedBodySize: 1500,
+      fetchStart: 55,
+      requestStart: 60,
+      responseStart: 200,
+      responseEnd: 300,
+      connectStart: 70,
+      connectEnd: 90,
+      domainLookupStart: 60,
+      domainLookupEnd: 65,
+      redirectStart: 50,
+      redirectEnd: 55,
+      secureConnectionStart: 80,
+      workerStart: 0,
+      serverTiming: [10, 20, 30],
+      workerTiming: [1, 2],
+    }) as PerformanceResourceTiming;
+
+  it('copies every ResourceTiming field with startTime translated by origin', () => {
+    expect(serializeResource(buildEntry(), ORIGIN)).toEqual({
+      name: 'https://example.com/api/users',
+      startTime: ORIGIN + 50,
+      duration: 250,
+      entryType: 'resource',
+      initiatorType: 'fetch',
+      transferSize: 1024,
+      encodedBodySize: 800,
+      decodedBodySize: 1500,
+      fetchStart: 55,
+      requestStart: 60,
+      responseStart: 200,
+      responseEnd: 300,
+      connectStart: 70,
+      connectEnd: 90,
+      domainLookupStart: 60,
+      domainLookupEnd: 65,
+      redirectStart: 50,
+      redirectEnd: 55,
+      secureConnectionStart: 80,
+      workerStart: 0,
+      serverTiming: [10, 20, 30],
+      workerTiming: [1, 2],
+    });
+  });
+
+  it('does not clock-shift sub-phase timing fields', () => {
+    // Only startTime is translated; the sub-phase fields are passed
+    // through unchanged, since they are relative timings that the UI
+    // does not shift.
+    const result = serializeResource(buildEntry(), ORIGIN);
+    expect(result.fetchStart).toBe(55);
+    expect(result.responseEnd).toBe(300);
+    expect(result.startTime).toBe(ORIGIN + 50);
+  });
+
+  it('passes optional initiatorType and secureConnectionStart through when undefined', () => {
+    const entry = {
+      ...buildEntry(),
+      initiatorType: undefined,
+      secureConnectionStart: undefined,
+    } as PerformanceResourceTiming;
+
+    const result = serializeResource(entry, ORIGIN);
+    expect(result.initiatorType).toBeUndefined();
+    expect(result.secureConnectionStart).toBeUndefined();
   });
 });

--- a/packages/performance-monitor-plugin/src/react-native/__tests__/serialize.test.ts
+++ b/packages/performance-monitor-plugin/src/react-native/__tests__/serialize.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// react-native-performance imports the runtime `performance` object,
+// which transitively pulls native bindings. Mock the whole module so
+// the serializers (which only use `performance.timeOrigin` via
+// `toDateTimestamp`) run in plain Node. With `timeOrigin: 0`, the
+// formula `origin - timeOrigin + startTime` reduces to
+// `origin + startTime`, which is trivial to assert.
+vi.mock('react-native-performance', () => ({
+  default: { timeOrigin: 0 },
+}));
+
+import { serializeMark, serializeMeasure, serializeMetric } from '../serialize';
+import type {
+  PerformanceMark,
+  PerformanceMeasure,
+  PerformanceMetric,
+} from 'react-native-performance';
+
+const ORIGIN = 1_700_000_000_000;
+
+describe('serializeMark', () => {
+  it('copies name, duration, entryType, and translates startTime by origin', () => {
+    const entry = {
+      name: 'render-start',
+      entryType: 'mark',
+      startTime: 100,
+      duration: 0,
+    } as PerformanceMark;
+
+    expect(serializeMark(entry, ORIGIN)).toEqual({
+      name: 'render-start',
+      startTime: ORIGIN + 100,
+      duration: 0,
+      entryType: 'mark',
+      detail: undefined,
+    });
+  });
+
+  it('preserves detail (regression for the dropped-detail bug)', () => {
+    const detail = { tag: 'homepage', phase: 'mount' };
+    const entry = {
+      name: 'render-start',
+      entryType: 'mark',
+      startTime: 42,
+      duration: 0,
+      detail,
+    } as PerformanceMark;
+
+    expect(serializeMark(entry, ORIGIN).detail).toBe(detail);
+  });
+});
+
+describe('serializeMeasure', () => {
+  it('copies name, duration, entryType, detail, and translates startTime', () => {
+    const detail = { reason: 'cold-start' };
+    const entry = {
+      name: 'first-paint',
+      entryType: 'measure',
+      startTime: 50,
+      duration: 250,
+      detail,
+    } as PerformanceMeasure;
+
+    expect(serializeMeasure(entry, ORIGIN)).toEqual({
+      name: 'first-paint',
+      startTime: ORIGIN + 50,
+      duration: 250,
+      entryType: 'measure',
+      detail,
+    });
+  });
+});
+
+describe('serializeMetric', () => {
+  it('copies name, duration, entryType, value, detail, and translates startTime', () => {
+    const detail = { source: 'native' };
+    const entry = {
+      name: 'memory-rss',
+      entryType: 'metric',
+      startTime: 10,
+      duration: 0,
+      value: 1024 * 1024 * 200,
+      detail,
+    } as PerformanceMetric;
+
+    expect(serializeMetric(entry, ORIGIN)).toEqual({
+      name: 'memory-rss',
+      startTime: ORIGIN + 10,
+      duration: 0,
+      entryType: 'metric',
+      value: 1024 * 1024 * 200,
+      detail,
+    });
+  });
+
+  it('preserves a string value (PerformanceMetric.value is string | number)', () => {
+    const entry = {
+      name: 'app-state',
+      entryType: 'metric',
+      startTime: 0,
+      duration: 0,
+      value: 'active',
+      detail: undefined,
+    } as PerformanceMetric;
+
+    expect(serializeMetric(entry, ORIGIN).value).toBe('active');
+  });
+});

--- a/packages/performance-monitor-plugin/src/react-native/asserts.ts
+++ b/packages/performance-monitor-plugin/src/react-native/asserts.ts
@@ -2,10 +2,12 @@ import type {
   PerformanceMark,
   PerformanceMeasure,
   PerformanceMetric,
+  PerformanceReactNativeMark,
+  PerformanceResourceTiming,
 } from 'react-native-performance';
 
 export function assertPerformanceMark(
-  entry: PerformanceEntry
+  entry: PerformanceEntry,
 ): asserts entry is PerformanceMark {
   if (entry.entryType !== 'mark') {
     throw new Error('Entry is not a PerformanceMark');
@@ -13,7 +15,7 @@ export function assertPerformanceMark(
 }
 
 export function assertPerformanceMeasure(
-  entry: PerformanceEntry
+  entry: PerformanceEntry,
 ): asserts entry is PerformanceMeasure {
   if (entry.entryType !== 'measure') {
     throw new Error('Entry is not a PerformanceMeasure');
@@ -21,9 +23,25 @@ export function assertPerformanceMeasure(
 }
 
 export function assertPerformanceMetric(
-  entry: PerformanceEntry
+  entry: PerformanceEntry,
 ): asserts entry is PerformanceMetric {
   if (entry.entryType !== 'metric') {
     throw new Error('Entry is not a PerformanceMetric');
+  }
+}
+
+export function assertPerformanceReactNativeMark(
+  entry: PerformanceEntry,
+): asserts entry is PerformanceReactNativeMark {
+  if (entry.entryType !== 'react-native-mark') {
+    throw new Error('Entry is not a PerformanceReactNativeMark');
+  }
+}
+
+export function assertPerformanceResource(
+  entry: PerformanceEntry,
+): asserts entry is PerformanceResourceTiming {
+  if (entry.entryType !== 'resource') {
+    throw new Error('Entry is not a PerformanceResourceTiming');
   }
 }

--- a/packages/performance-monitor-plugin/src/react-native/performance-monitor.ts
+++ b/packages/performance-monitor-plugin/src/react-native/performance-monitor.ts
@@ -8,14 +8,24 @@ import type {
   SerializedPerformanceMark,
   SerializedPerformanceMeasure,
   SerializedPerformanceMetric,
+  SerializedPerformanceReactNativeMark,
+  SerializedPerformanceResource,
 } from '../shared/types';
 import { toDateTimestamp } from './helpers';
 import {
   assertPerformanceMark,
   assertPerformanceMeasure,
   assertPerformanceMetric,
+  assertPerformanceReactNativeMark,
+  assertPerformanceResource,
 } from './asserts';
-import { serializeMark, serializeMeasure, serializeMetric } from './serialize';
+import {
+  serializeMark,
+  serializeMeasure,
+  serializeMetric,
+  serializeReactNativeMark,
+  serializeResource,
+} from './serialize';
 
 type PerformanceObserverOptions = { type: EntryType; buffered?: boolean };
 
@@ -82,6 +92,20 @@ export const getPerformanceMonitor = (
       });
     };
 
+    const appendReactNativeMarks = (
+      reactNativeMarks: SerializedPerformanceReactNativeMark[],
+    ) => {
+      client.send('appendReactNativeMarks', {
+        reactNativeMarks,
+      });
+    };
+
+    const appendResources = (resources: SerializedPerformanceResource[]) => {
+      client.send('appendResources', {
+        resources,
+      });
+    };
+
     addObserver(
       (list) => {
         appendMarks(
@@ -121,6 +145,37 @@ export const getPerformanceMonitor = (
       },
       {
         type: 'metric',
+        buffered: true,
+      },
+    );
+    // react-native-marks fire during native startup, before the user
+    // clicks "Start Session" — buffered:true is load-bearing so the
+    // PerformanceObserver flushes entries emitted before subscription.
+    addObserver(
+      (list) => {
+        appendReactNativeMarks(
+          list.getEntries().map((entry) => {
+            assertPerformanceReactNativeMark(entry);
+            return serializeReactNativeMark(entry, origin);
+          }),
+        );
+      },
+      {
+        type: 'react-native-mark',
+        buffered: true,
+      },
+    );
+    addObserver(
+      (list) => {
+        appendResources(
+          list.getEntries().map((entry) => {
+            assertPerformanceResource(entry);
+            return serializeResource(entry, origin);
+          }),
+        );
+      },
+      {
+        type: 'resource',
         buffered: true,
       },
     );

--- a/packages/performance-monitor-plugin/src/react-native/performance-monitor.ts
+++ b/packages/performance-monitor-plugin/src/react-native/performance-monitor.ts
@@ -15,6 +15,7 @@ import {
   assertPerformanceMeasure,
   assertPerformanceMetric,
 } from './asserts';
+import { serializeMark, serializeMeasure, serializeMetric } from './serialize';
 
 type PerformanceObserverOptions = { type: EntryType; buffered?: boolean };
 
@@ -27,7 +28,7 @@ type PerformanceObserverEntryList = {
 
 type PerformanceObserverCallback = (
   list: PerformanceObserverEntryList,
-  observer: PerformanceObserver
+  observer: PerformanceObserver,
 ) => void;
 
 export type PerformanceMonitor = {
@@ -38,7 +39,7 @@ export type PerformanceMonitor = {
 };
 
 export const getPerformanceMonitor = (
-  client: PerformanceMonitorDevToolsClient
+  client: PerformanceMonitorDevToolsClient,
 ): PerformanceMonitor => {
   let observers: PerformanceObserver[] = [];
   let sessionStartedAt = 0;
@@ -47,7 +48,7 @@ export const getPerformanceMonitor = (
 
   const addObserver = (
     callback: PerformanceObserverCallback,
-    options: PerformanceObserverOptions
+    options: PerformanceObserverOptions,
   ) => {
     const observer = new PerformanceObserver(callback);
     observer.observe(options);
@@ -83,66 +84,45 @@ export const getPerformanceMonitor = (
 
     addObserver(
       (list) => {
-        const marks = list.getEntries().map((entry) => {
-          assertPerformanceMark(entry);
-
-          return {
-            name: entry.name,
-            startTime: toDateTimestamp(origin, entry.startTime),
-            duration: entry.duration,
-            entryType: 'mark' as const,
-          };
-        });
-
-        appendMarks(marks);
+        appendMarks(
+          list.getEntries().map((entry) => {
+            assertPerformanceMark(entry);
+            return serializeMark(entry, origin);
+          }),
+        );
       },
       {
         type: 'mark',
         buffered: true,
-      }
+      },
     );
     addObserver(
       (list) => {
         appendMeasures(
           list.getEntries().map((entry) => {
             assertPerformanceMeasure(entry);
-
-            return {
-              name: entry.name,
-              startTime: toDateTimestamp(origin, entry.startTime),
-              duration: entry.duration,
-              entryType: 'measure' as const,
-              detail: entry.detail,
-            };
-          })
+            return serializeMeasure(entry, origin);
+          }),
         );
       },
       {
         type: 'measure',
         buffered: true,
-      }
+      },
     );
     addObserver(
       (list) => {
         setMetrics(
           list.getEntries().map((entry) => {
             assertPerformanceMetric(entry);
-
-            return {
-              name: entry.name,
-              startTime: toDateTimestamp(origin, entry.startTime),
-              duration: entry.duration,
-              entryType: 'metric' as const,
-              value: entry.value,
-              detail: entry.detail,
-            };
-          })
+            return serializeMetric(entry, origin);
+          }),
         );
       },
       {
         type: 'metric',
         buffered: true,
-      }
+      },
     );
   };
   const disable = (): void => {

--- a/packages/performance-monitor-plugin/src/react-native/serialize.ts
+++ b/packages/performance-monitor-plugin/src/react-native/serialize.ts
@@ -2,11 +2,15 @@ import type {
   PerformanceMark,
   PerformanceMeasure,
   PerformanceMetric,
+  PerformanceReactNativeMark,
+  PerformanceResourceTiming,
 } from 'react-native-performance';
 import type {
   SerializedPerformanceMark,
   SerializedPerformanceMeasure,
   SerializedPerformanceMetric,
+  SerializedPerformanceReactNativeMark,
+  SerializedPerformanceResource,
 } from '../shared/types';
 import { toDateTimestamp } from './helpers';
 
@@ -42,4 +46,48 @@ export const serializeMetric = (
   entryType: 'metric',
   value: entry.value,
   detail: entry.detail,
+});
+
+export const serializeReactNativeMark = (
+  entry: PerformanceReactNativeMark,
+  origin: number,
+): SerializedPerformanceReactNativeMark => ({
+  name: entry.name,
+  startTime: toDateTimestamp(origin, entry.startTime),
+  duration: entry.duration,
+  entryType: 'react-native-mark',
+  detail: entry.detail,
+});
+
+// Only the shared `startTime` is translated via toDateTimestamp.
+// The sub-phase timing fields (fetchStart, requestStart, ...) stay as
+// raw `performance.now()` values: they are computed relative to one
+// another and the UI does not clock-shift them today; translating them
+// here would silently break the timing math.
+export const serializeResource = (
+  entry: PerformanceResourceTiming,
+  origin: number,
+): SerializedPerformanceResource => ({
+  name: entry.name,
+  startTime: toDateTimestamp(origin, entry.startTime),
+  duration: entry.duration,
+  entryType: 'resource',
+  initiatorType: entry.initiatorType,
+  transferSize: entry.transferSize,
+  encodedBodySize: entry.encodedBodySize,
+  decodedBodySize: entry.decodedBodySize,
+  fetchStart: entry.fetchStart,
+  requestStart: entry.requestStart,
+  responseStart: entry.responseStart,
+  responseEnd: entry.responseEnd,
+  connectStart: entry.connectStart,
+  connectEnd: entry.connectEnd,
+  domainLookupStart: entry.domainLookupStart,
+  domainLookupEnd: entry.domainLookupEnd,
+  redirectStart: entry.redirectStart,
+  redirectEnd: entry.redirectEnd,
+  secureConnectionStart: entry.secureConnectionStart,
+  workerStart: entry.workerStart,
+  serverTiming: entry.serverTiming,
+  workerTiming: entry.workerTiming,
 });

--- a/packages/performance-monitor-plugin/src/react-native/serialize.ts
+++ b/packages/performance-monitor-plugin/src/react-native/serialize.ts
@@ -1,0 +1,45 @@
+import type {
+  PerformanceMark,
+  PerformanceMeasure,
+  PerformanceMetric,
+} from 'react-native-performance';
+import type {
+  SerializedPerformanceMark,
+  SerializedPerformanceMeasure,
+  SerializedPerformanceMetric,
+} from '../shared/types';
+import { toDateTimestamp } from './helpers';
+
+export const serializeMark = (
+  entry: PerformanceMark,
+  origin: number,
+): SerializedPerformanceMark => ({
+  name: entry.name,
+  startTime: toDateTimestamp(origin, entry.startTime),
+  duration: entry.duration,
+  entryType: 'mark',
+  detail: entry.detail,
+});
+
+export const serializeMeasure = (
+  entry: PerformanceMeasure,
+  origin: number,
+): SerializedPerformanceMeasure => ({
+  name: entry.name,
+  startTime: toDateTimestamp(origin, entry.startTime),
+  duration: entry.duration,
+  entryType: 'measure',
+  detail: entry.detail,
+});
+
+export const serializeMetric = (
+  entry: PerformanceMetric,
+  origin: number,
+): SerializedPerformanceMetric => ({
+  name: entry.name,
+  startTime: toDateTimestamp(origin, entry.startTime),
+  duration: entry.duration,
+  entryType: 'metric',
+  value: entry.value,
+  detail: entry.detail,
+});

--- a/packages/performance-monitor-plugin/src/shared/types.ts
+++ b/packages/performance-monitor-plugin/src/shared/types.ts
@@ -22,10 +22,43 @@ export type SerializedPerformanceMetric = SharedPerformanceEntryProperties & {
   detail?: unknown;
 };
 
+export type SerializedPerformanceReactNativeMark =
+  SharedPerformanceEntryProperties & {
+    entryType: 'react-native-mark';
+    detail?: unknown;
+  };
+
+// PerformanceResourceTiming carries ~14 timing-phase fields plus size
+// fields. We serialize all of them so the DetailsSidebar can render
+// everything; the table view picks a small subset.
+export type SerializedPerformanceResource = SharedPerformanceEntryProperties & {
+  entryType: 'resource';
+  initiatorType?: string;
+  transferSize: number;
+  encodedBodySize: number;
+  decodedBodySize: number;
+  fetchStart: number;
+  requestStart: number;
+  responseStart: number;
+  responseEnd: number;
+  connectStart: number;
+  connectEnd: number;
+  domainLookupStart: number;
+  domainLookupEnd: number;
+  redirectStart: number;
+  redirectEnd: number;
+  secureConnectionStart?: number;
+  workerStart: number;
+  serverTiming: number[];
+  workerTiming: number[];
+};
+
 export type SerializedPerformanceEntry =
   | SerializedPerformanceMeasure
   | SerializedPerformanceMark
-  | SerializedPerformanceMetric;
+  | SerializedPerformanceMetric
+  | SerializedPerformanceReactNativeMark
+  | SerializedPerformanceResource;
 
 export type PerformanceMonitorEventMap = {
   setEnabled: {
@@ -43,6 +76,12 @@ export type PerformanceMonitorEventMap = {
   };
   setMetrics: {
     metrics: SerializedPerformanceMetric[];
+  };
+  appendReactNativeMarks: {
+    reactNativeMarks: SerializedPerformanceReactNativeMark[];
+  };
+  appendResources: {
+    resources: SerializedPerformanceResource[];
   };
 };
 

--- a/packages/performance-monitor-plugin/src/ui/App.tsx
+++ b/packages/performance-monitor-plugin/src/ui/App.tsx
@@ -7,6 +7,8 @@ import {
   SerializedPerformanceMeasure,
   SerializedPerformanceMark,
   SerializedPerformanceMetric,
+  SerializedPerformanceReactNativeMark,
+  SerializedPerformanceResource,
   SerializedPerformanceEntry,
 } from '../shared/types';
 import { useEffect, useState } from 'react';
@@ -24,6 +26,8 @@ import './App.css';
 import { MeasuresTable } from './components/MeasuresTable';
 import { MetricsTable } from './components/MetricsTable';
 import { MarksTable } from './components/MarksTable';
+import { ReactNativeMarksTable } from './components/ReactNativeMarksTable';
+import { ResourcesTable } from './components/ResourcesTable';
 import { DetailsSidebar } from './components/DetailsSidebar';
 import { SessionDuration } from './components/SessionDuration';
 import { ExportModal } from './components/ExportModal';
@@ -34,6 +38,8 @@ type PerformanceMonitorSession = {
   measures: SerializedPerformanceMeasure[];
   marks: SerializedPerformanceMark[];
   metrics: SerializedPerformanceMetric[];
+  reactNativeMarks: SerializedPerformanceReactNativeMark[];
+  resources: SerializedPerformanceResource[];
 };
 
 export default function PerformanceMonitorPanel() {
@@ -46,6 +52,8 @@ export default function PerformanceMonitorPanel() {
     measures: [],
     marks: [],
     metrics: [],
+    reactNativeMarks: [],
+    resources: [],
   });
   const [isSessionActive, setIsSessionActive] = useState(false);
   const [selectedItem, setSelectedItem] =
@@ -68,9 +76,11 @@ export default function PerformanceMonitorPanel() {
           measures: [],
           marks: [],
           metrics: [],
+          reactNativeMarks: [],
+          resources: [],
         });
         setIsSessionActive(true);
-      })
+      }),
     );
 
     subscriptions.push(
@@ -85,7 +95,7 @@ export default function PerformanceMonitorPanel() {
             })),
           ],
         }));
-      })
+      }),
     );
 
     subscriptions.push(
@@ -100,7 +110,7 @@ export default function PerformanceMonitorPanel() {
             })),
           ],
         }));
-      })
+      }),
     );
 
     subscriptions.push(
@@ -115,7 +125,37 @@ export default function PerformanceMonitorPanel() {
             })),
           ],
         }));
-      })
+      }),
+    );
+
+    subscriptions.push(
+      client.onMessage('appendReactNativeMarks', ({ reactNativeMarks }) => {
+        setSession((oldSession) => ({
+          ...oldSession,
+          reactNativeMarks: [
+            ...oldSession.reactNativeMarks,
+            ...reactNativeMarks.map((mark) => ({
+              ...mark,
+              startTime: mark.startTime + oldSession.clockShift,
+            })),
+          ],
+        }));
+      }),
+    );
+
+    subscriptions.push(
+      client.onMessage('appendResources', ({ resources }) => {
+        setSession((oldSession) => ({
+          ...oldSession,
+          resources: [
+            ...oldSession.resources,
+            ...resources.map((resource) => ({
+              ...resource,
+              startTime: resource.startTime + oldSession.clockShift,
+            })),
+          ],
+        }));
+      }),
     );
 
     return () => {
@@ -227,6 +267,12 @@ export default function PerformanceMonitorPanel() {
               <Tabs.Trigger value="marks">
                 Marks ({session.marks.length})
               </Tabs.Trigger>
+              <Tabs.Trigger value="reactNativeMarks">
+                React Native Marks ({session.reactNativeMarks.length})
+              </Tabs.Trigger>
+              <Tabs.Trigger value="resources">
+                Resources ({session.resources.length})
+              </Tabs.Trigger>
             </Tabs.List>
 
             <Box
@@ -269,6 +315,30 @@ export default function PerformanceMonitorPanel() {
               >
                 <MarksTable
                   marks={session.marks}
+                  onRowClick={handleEntryClick}
+                />
+              </Tabs.Content>
+
+              <Tabs.Content
+                value="reactNativeMarks"
+                style={{
+                  display: 'contents',
+                }}
+              >
+                <ReactNativeMarksTable
+                  reactNativeMarks={session.reactNativeMarks}
+                  onRowClick={handleEntryClick}
+                />
+              </Tabs.Content>
+
+              <Tabs.Content
+                value="resources"
+                style={{
+                  display: 'contents',
+                }}
+              >
+                <ResourcesTable
+                  resources={session.resources}
                   onRowClick={handleEntryClick}
                 />
               </Tabs.Content>

--- a/packages/performance-monitor-plugin/src/ui/App.tsx
+++ b/packages/performance-monitor-plugin/src/ui/App.tsx
@@ -226,6 +226,8 @@ export default function PerformanceMonitorPanel() {
             measures={session.measures}
             metrics={session.metrics}
             marks={session.marks}
+            reactNativeMarks={session.reactNativeMarks}
+            resources={session.resources}
             sessionStartedAt={session.sessionStartedAt}
             clockShift={session.clockShift}
           />

--- a/packages/performance-monitor-plugin/src/ui/App.tsx
+++ b/packages/performance-monitor-plugin/src/ui/App.tsx
@@ -31,6 +31,7 @@ import { ResourcesTable } from './components/ResourcesTable';
 import { DetailsSidebar } from './components/DetailsSidebar';
 import { SessionDuration } from './components/SessionDuration';
 import { ExportModal } from './components/ExportModal';
+import { deriveStartupPhases } from './derive-startup-phases';
 
 type PerformanceMonitorSession = {
   sessionStartedAt: number;
@@ -186,6 +187,13 @@ export default function PerformanceMonitorPanel() {
     setSelectedItem(null);
   };
 
+  // Derived measures live only in the UI: paired Start/End RN marks
+  // are shown alongside user-created measures so the Measures tab
+  // reflects startup phases without forcing manual subtraction. The
+  // export still emits raw session data (see ExportModal below).
+  const startupPhases = deriveStartupPhases(session.reactNativeMarks);
+  const allMeasures = [...startupPhases, ...session.measures];
+
   return (
     <Theme appearance="dark" accentColor="blue" radius="medium">
       <Box
@@ -261,7 +269,7 @@ export default function PerformanceMonitorPanel() {
           >
             <Tabs.List style={{ flexShrink: 0 }}>
               <Tabs.Trigger value="measures">
-                Measures ({session.measures.length})
+                Measures ({allMeasures.length})
               </Tabs.Trigger>
               <Tabs.Trigger value="metrics">
                 Metrics ({session.metrics.length})
@@ -292,7 +300,7 @@ export default function PerformanceMonitorPanel() {
                 }}
               >
                 <MeasuresTable
-                  measures={session.measures}
+                  measures={allMeasures}
                   onRowClick={handleEntryClick}
                 />
               </Tabs.Content>

--- a/packages/performance-monitor-plugin/src/ui/__tests__/derive-startup-phases.test.ts
+++ b/packages/performance-monitor-plugin/src/ui/__tests__/derive-startup-phases.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { deriveStartupPhases } from '../derive-startup-phases';
+import type { SerializedPerformanceReactNativeMark } from '../../shared/types';
+
+const mark = (
+  name: string,
+  startTime: number,
+  detail?: unknown,
+): SerializedPerformanceReactNativeMark => ({
+  name,
+  startTime,
+  duration: 0,
+  entryType: 'react-native-mark',
+  detail,
+});
+
+describe('deriveStartupPhases', () => {
+  it('pairs Start/End marks into a measure with the right duration', () => {
+    const result = deriveStartupPhases([
+      mark('nativeLaunchStart', 100),
+      mark('nativeLaunchEnd', 250),
+    ]);
+
+    expect(result).toEqual([
+      {
+        name: 'nativeLaunch',
+        startTime: 100,
+        duration: 150,
+        entryType: 'measure',
+        detail: undefined,
+        derivedFromReactNativeMark: true,
+      },
+    ]);
+  });
+
+  it('handles multiple paired phases independently', () => {
+    const result = deriveStartupPhases([
+      mark('nativeLaunchStart', 100),
+      mark('nativeLaunchEnd', 250),
+      mark('runJSBundleStart', 300),
+      mark('runJSBundleEnd', 700),
+    ]);
+
+    expect(result.map((m) => m.name)).toEqual(['nativeLaunch', 'runJSBundle']);
+    expect(result.map((m) => m.duration)).toEqual([150, 400]);
+  });
+
+  it('does not synthesize a measure when only the Start exists', () => {
+    const result = deriveStartupPhases([mark('nativeLaunchStart', 100)]);
+    expect(result).toEqual([]);
+  });
+
+  it('does not synthesize a measure when only the End exists', () => {
+    const result = deriveStartupPhases([mark('nativeLaunchEnd', 250)]);
+    expect(result).toEqual([]);
+  });
+
+  it('leaves marks that match neither suffix alone (e.g. appStartup)', () => {
+    const result = deriveStartupPhases([
+      mark('appStartup', 50),
+      mark('nativeLaunchStart', 100),
+      mark('nativeLaunchEnd', 250),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('nativeLaunch');
+  });
+
+  it('carries detail from the Start mark forward', () => {
+    const detail = { phase: 'native' };
+    const result = deriveStartupPhases([
+      mark('nativeLaunchStart', 100, detail),
+      mark('nativeLaunchEnd', 250),
+    ]);
+
+    expect(result[0].detail).toBe(detail);
+  });
+});

--- a/packages/performance-monitor-plugin/src/ui/components/DetailsSidebar.tsx
+++ b/packages/performance-monitor-plugin/src/ui/components/DetailsSidebar.tsx
@@ -3,6 +3,8 @@ import { Cross2Icon } from '@radix-ui/react-icons';
 import { MeasureDetails } from './MeasureDetails';
 import { MetricDetails } from './MetricDetails';
 import { MarkDetails } from './MarkDetails';
+import { ReactNativeMarkDetails } from './ReactNativeMarkDetails';
+import { ResourceDetails } from './ResourceDetails';
 import { SerializedPerformanceEntry } from '../../shared/types';
 
 export type DetailsSidebarProps = {
@@ -24,6 +26,10 @@ export const DetailsSidebar = ({
         return <MetricDetails metric={selectedItem} />;
       case 'mark':
         return <MarkDetails mark={selectedItem} />;
+      case 'react-native-mark':
+        return <ReactNativeMarkDetails mark={selectedItem} />;
+      case 'resource':
+        return <ResourceDetails resource={selectedItem} />;
       default:
         return null;
     }

--- a/packages/performance-monitor-plugin/src/ui/components/ExportModal.tsx
+++ b/packages/performance-monitor-plugin/src/ui/components/ExportModal.tsx
@@ -12,6 +12,8 @@ import {
   SerializedPerformanceMeasure,
   SerializedPerformanceMark,
   SerializedPerformanceMetric,
+  SerializedPerformanceReactNativeMark,
+  SerializedPerformanceResource,
 } from '../../shared/types';
 import { downloadFile } from '../utils';
 
@@ -19,6 +21,8 @@ export type ExportModalProps = {
   measures: SerializedPerformanceMeasure[];
   metrics: SerializedPerformanceMetric[];
   marks: SerializedPerformanceMark[];
+  reactNativeMarks: SerializedPerformanceReactNativeMark[];
+  resources: SerializedPerformanceResource[];
   sessionStartedAt: number;
   clockShift: number;
 };
@@ -27,6 +31,8 @@ type ExportOptions = {
   measures: boolean;
   metrics: boolean;
   marks: boolean;
+  reactNativeMarks: boolean;
+  resources: boolean;
 };
 
 type AlertMessage = {
@@ -83,18 +89,33 @@ const DataTypeCard = ({
   );
 };
 
+const ALL_OPTIONS_ON: ExportOptions = {
+  measures: true,
+  metrics: true,
+  marks: true,
+  reactNativeMarks: true,
+  resources: true,
+};
+
+const ALL_OPTIONS_OFF: ExportOptions = {
+  measures: false,
+  metrics: false,
+  marks: false,
+  reactNativeMarks: false,
+  resources: false,
+};
+
 export function ExportModal({
   measures,
   metrics,
   marks,
+  reactNativeMarks,
+  resources,
   sessionStartedAt,
   clockShift,
 }: ExportModalProps) {
-  const [exportOptions, setExportOptions] = useState<ExportOptions>({
-    measures: true,
-    metrics: true,
-    marks: true,
-  });
+  const [exportOptions, setExportOptions] =
+    useState<ExportOptions>(ALL_OPTIONS_ON);
   const [isOpen, setIsOpen] = useState(false);
   const [alertMessage, setAlertMessage] = useState<AlertMessage>(null);
 
@@ -108,6 +129,8 @@ export function ExportModal({
           totalMeasures: measures.length,
           totalMetrics: metrics.length,
           totalMarks: marks.length,
+          totalReactNativeMarks: reactNativeMarks.length,
+          totalResources: resources.length,
         },
       };
 
@@ -119,6 +142,12 @@ export function ExportModal({
       }
       if (exportOptions.marks) {
         exportData.marks = marks;
+      }
+      if (exportOptions.reactNativeMarks) {
+        exportData.reactNativeMarks = reactNativeMarks;
+      }
+      if (exportOptions.resources) {
+        exportData.resources = resources;
       }
 
       await downloadFile(exportData, 'performance-data.json');
@@ -135,23 +164,17 @@ export function ExportModal({
     }
   };
 
-  const handleSelectAll = () => {
-    setExportOptions({
-      measures: true,
-      metrics: true,
-      marks: true,
-    });
-  };
+  const handleSelectAll = () => setExportOptions(ALL_OPTIONS_ON);
+  const handleSelectNone = () => setExportOptions(ALL_OPTIONS_OFF);
 
-  const handleSelectNone = () => {
-    setExportOptions({
-      measures: false,
-      metrics: false,
-      marks: false,
-    });
-  };
+  const hasData =
+    measures.length > 0 ||
+    metrics.length > 0 ||
+    marks.length > 0 ||
+    reactNativeMarks.length > 0 ||
+    resources.length > 0;
 
-  const hasData = measures.length > 0 || metrics.length > 0 || marks.length > 0;
+  const noneSelected = Object.values(exportOptions).every((v) => !v);
 
   const clearAlert = () => {
     setAlertMessage(null);
@@ -243,6 +266,30 @@ export function ExportModal({
                 }))
               }
             />
+
+            <DataTypeCard
+              title="React Native Marks"
+              count={reactNativeMarks.length}
+              checked={exportOptions.reactNativeMarks}
+              onToggle={() =>
+                setExportOptions((prev) => ({
+                  ...prev,
+                  reactNativeMarks: !prev.reactNativeMarks,
+                }))
+              }
+            />
+
+            <DataTypeCard
+              title="Resources"
+              count={resources.length}
+              checked={exportOptions.resources}
+              onToggle={() =>
+                setExportOptions((prev) => ({
+                  ...prev,
+                  resources: !prev.resources,
+                }))
+              }
+            />
           </Flex>
         </Box>
 
@@ -261,14 +308,7 @@ export function ExportModal({
           <Button variant="outline" onClick={() => setIsOpen(false)}>
             Cancel
           </Button>
-          <Button
-            onClick={handleExport}
-            disabled={
-              !exportOptions.measures &&
-              !exportOptions.metrics &&
-              !exportOptions.marks
-            }
-          >
+          <Button onClick={handleExport} disabled={noneSelected}>
             Export Data
           </Button>
         </Flex>

--- a/packages/performance-monitor-plugin/src/ui/components/MeasureDetails.tsx
+++ b/packages/performance-monitor-plugin/src/ui/components/MeasureDetails.tsx
@@ -16,6 +16,14 @@ export const MeasureDetails = ({ measure }: MeasureDetailsProps) => {
         Measure Details
       </Heading>
 
+      {'derivedFromReactNativeMark' in measure && (
+        <Box mb="4">
+          <Text size="2" color="gray">
+            Derived from paired react-native-mark Start/End entries.
+          </Text>
+        </Box>
+      )}
+
       <Box mb="4">
         <Flex align="center" gap="3">
           <Text size="2" color="gray" style={{ minWidth: '80px' }}>

--- a/packages/performance-monitor-plugin/src/ui/components/MeasuresTable.tsx
+++ b/packages/performance-monitor-plugin/src/ui/components/MeasuresTable.tsx
@@ -1,5 +1,5 @@
 import { ColumnDef } from '@tanstack/react-table';
-import { Text } from '@radix-ui/themes';
+import { Text, Badge, Flex } from '@radix-ui/themes';
 import { SerializedPerformanceMeasure } from '../../shared/types';
 import { DataTable } from './DataTable';
 import { formatTime, formatDuration } from '../utils';
@@ -13,7 +13,16 @@ const columns: ColumnDef<SerializedPerformanceMeasure>[] = [
   {
     accessorKey: 'name',
     header: 'Name',
-    cell: ({ row }) => <Text weight="medium">{row.getValue('name')}</Text>,
+    cell: ({ row }) => (
+      <Flex align="center" gap="2">
+        <Text weight="medium">{row.getValue('name')}</Text>
+        {'derivedFromReactNativeMark' in row.original && (
+          <Badge size="1" color="gray" variant="soft">
+            RN
+          </Badge>
+        )}
+      </Flex>
+    ),
   },
   {
     accessorKey: 'duration',

--- a/packages/performance-monitor-plugin/src/ui/components/ReactNativeMarkDetails.tsx
+++ b/packages/performance-monitor-plugin/src/ui/components/ReactNativeMarkDetails.tsx
@@ -1,0 +1,44 @@
+import { Box, Text, Heading, Separator, Flex } from '@radix-ui/themes';
+import { SerializedPerformanceReactNativeMark } from '../../shared/types';
+import { DetailsDisplay } from './DetailsDisplay';
+import { formatTime } from '../utils';
+
+export type ReactNativeMarkDetailsProps = {
+  mark: SerializedPerformanceReactNativeMark;
+};
+
+export const ReactNativeMarkDetails = ({
+  mark,
+}: ReactNativeMarkDetailsProps) => {
+  return (
+    <Box>
+      <Heading size="5" mb="4">
+        React Native Mark Details
+      </Heading>
+
+      <Box mb="4">
+        <Flex align="center" gap="3">
+          <Text size="2" color="gray" style={{ minWidth: '80px' }}>
+            Name:
+          </Text>
+          <Text weight="medium" size="3">
+            {mark.name}
+          </Text>
+        </Flex>
+      </Box>
+
+      <Box mb="4">
+        <Flex align="center" gap="3">
+          <Text size="2" color="gray" style={{ minWidth: '80px' }}>
+            Recorded at:
+          </Text>
+          <Text size="3">{formatTime(mark.startTime)}</Text>
+        </Flex>
+      </Box>
+
+      <Separator size="4" my="4" />
+
+      <DetailsDisplay details={mark.detail} />
+    </Box>
+  );
+};

--- a/packages/performance-monitor-plugin/src/ui/components/ReactNativeMarksTable.tsx
+++ b/packages/performance-monitor-plugin/src/ui/components/ReactNativeMarksTable.tsx
@@ -1,0 +1,44 @@
+import { ColumnDef } from '@tanstack/react-table';
+import { Text } from '@radix-ui/themes';
+import { SerializedPerformanceReactNativeMark } from '../../shared/types';
+import { DataTable } from './DataTable';
+import { formatTime } from '../utils';
+
+export type ReactNativeMarksTableProps = {
+  reactNativeMarks: SerializedPerformanceReactNativeMark[];
+  onRowClick?: (mark: SerializedPerformanceReactNativeMark) => void;
+};
+
+const columns: ColumnDef<SerializedPerformanceReactNativeMark>[] = [
+  {
+    accessorKey: 'name',
+    header: 'Name',
+    cell: ({ row }) => <Text weight="medium">{row.getValue('name')}</Text>,
+  },
+  {
+    accessorKey: 'startTime',
+    header: 'Recorded at',
+    cell: ({ row }) => {
+      const startTime = row.getValue('startTime') as number;
+      return (
+        <Text size="2" color="gray">
+          {formatTime(startTime)}
+        </Text>
+      );
+    },
+  },
+];
+
+export const ReactNativeMarksTable = ({
+  reactNativeMarks,
+  onRowClick,
+}: ReactNativeMarksTableProps) => {
+  return (
+    <DataTable
+      data={reactNativeMarks}
+      columns={columns}
+      onRowClick={onRowClick}
+      emptyMessage="No React Native marks recorded"
+    />
+  );
+};

--- a/packages/performance-monitor-plugin/src/ui/components/ResourceDetails.tsx
+++ b/packages/performance-monitor-plugin/src/ui/components/ResourceDetails.tsx
@@ -1,0 +1,137 @@
+import { Box, Text, Heading, Separator, Flex, Grid } from '@radix-ui/themes';
+import { SerializedPerformanceResource } from '../../shared/types';
+import { formatTime, formatDuration, formatBytes } from '../utils';
+
+export type ResourceDetailsProps = {
+  resource: SerializedPerformanceResource;
+};
+
+const formatPhase = (value: number | undefined): string => {
+  if (value === undefined || value === 0) return '—';
+  return `${value.toFixed(2)}ms`;
+};
+
+const Row = ({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) => (
+  <Box mb="3">
+    <Flex align="center" gap="3">
+      <Text size="2" color="gray" style={{ minWidth: '140px' }}>
+        {label}
+      </Text>
+      {children}
+    </Flex>
+  </Box>
+);
+
+const TIMING_FIELDS: Array<{
+  key: keyof SerializedPerformanceResource;
+  label: string;
+}> = [
+  { key: 'redirectStart', label: 'Redirect start' },
+  { key: 'redirectEnd', label: 'Redirect end' },
+  { key: 'fetchStart', label: 'Fetch start' },
+  { key: 'domainLookupStart', label: 'DNS start' },
+  { key: 'domainLookupEnd', label: 'DNS end' },
+  { key: 'connectStart', label: 'Connect start' },
+  { key: 'secureConnectionStart', label: 'TLS start' },
+  { key: 'connectEnd', label: 'Connect end' },
+  { key: 'requestStart', label: 'Request start' },
+  { key: 'responseStart', label: 'Response start' },
+  { key: 'responseEnd', label: 'Response end' },
+  { key: 'workerStart', label: 'Worker start' },
+];
+
+export const ResourceDetails = ({ resource }: ResourceDetailsProps) => {
+  return (
+    <Box>
+      <Heading size="5" mb="4">
+        Resource Details
+      </Heading>
+
+      <Row label="Name:">
+        <Text weight="medium" size="3" style={{ wordBreak: 'break-all' }}>
+          {resource.name}
+        </Text>
+      </Row>
+
+      <Row label="Type:">
+        <Text size="3">{resource.initiatorType ?? '—'}</Text>
+      </Row>
+
+      <Row label="Duration:">
+        <Text color="blue" weight="medium" size="3">
+          {formatDuration(resource.duration)}
+        </Text>
+      </Row>
+
+      <Row label="Recorded at:">
+        <Text size="3">{formatTime(resource.startTime)}</Text>
+      </Row>
+
+      <Separator size="4" my="4" />
+
+      <Heading size="3" mb="3">
+        Sizes
+      </Heading>
+      <Row label="Transfer size:">
+        <Text size="3">{formatBytes(resource.transferSize)}</Text>
+      </Row>
+      <Row label="Encoded body:">
+        <Text size="3">{formatBytes(resource.encodedBodySize)}</Text>
+      </Row>
+      <Row label="Decoded body:">
+        <Text size="3">{formatBytes(resource.decodedBodySize)}</Text>
+      </Row>
+
+      <Separator size="4" my="4" />
+
+      <Heading size="3" mb="3">
+        Timing phases
+      </Heading>
+      <Text size="2" color="gray" mb="3" as="div">
+        Phase timestamps are relative to the session, not clock-shifted.
+      </Text>
+      <Grid columns="2" gap="2">
+        {TIMING_FIELDS.map(({ key, label }) => (
+          <Flex key={key} align="center" gap="2">
+            <Text size="2" color="gray" style={{ minWidth: '120px' }}>
+              {label}:
+            </Text>
+            <Text size="2">
+              {formatPhase(resource[key] as number | undefined)}
+            </Text>
+          </Flex>
+        ))}
+      </Grid>
+
+      {resource.serverTiming.length > 0 && (
+        <>
+          <Separator size="4" my="4" />
+          <Heading size="3" mb="3">
+            Server timing
+          </Heading>
+          <Text size="2" style={{ fontFamily: 'monospace' }}>
+            [{resource.serverTiming.join(', ')}]
+          </Text>
+        </>
+      )}
+
+      {resource.workerTiming.length > 0 && (
+        <>
+          <Separator size="4" my="4" />
+          <Heading size="3" mb="3">
+            Worker timing
+          </Heading>
+          <Text size="2" style={{ fontFamily: 'monospace' }}>
+            [{resource.workerTiming.join(', ')}]
+          </Text>
+        </>
+      )}
+    </Box>
+  );
+};

--- a/packages/performance-monitor-plugin/src/ui/components/ResourcesTable.tsx
+++ b/packages/performance-monitor-plugin/src/ui/components/ResourcesTable.tsx
@@ -1,0 +1,65 @@
+import { ColumnDef } from '@tanstack/react-table';
+import { Text } from '@radix-ui/themes';
+import { SerializedPerformanceResource } from '../../shared/types';
+import { DataTable } from './DataTable';
+import { formatBytes, formatDuration } from '../utils';
+
+export type ResourcesTableProps = {
+  resources: SerializedPerformanceResource[];
+  onRowClick?: (resource: SerializedPerformanceResource) => void;
+};
+
+const columns: ColumnDef<SerializedPerformanceResource>[] = [
+  {
+    accessorKey: 'name',
+    header: 'Name',
+    cell: ({ row }) => (
+      <Text weight="medium" style={{ wordBreak: 'break-all' }}>
+        {row.getValue('name')}
+      </Text>
+    ),
+  },
+  {
+    accessorKey: 'initiatorType',
+    header: 'Type',
+    cell: ({ row }) => (
+      <Text size="2" color="gray">
+        {(row.getValue('initiatorType') as string | undefined) ?? '—'}
+      </Text>
+    ),
+  },
+  {
+    accessorKey: 'duration',
+    header: 'Duration',
+    cell: ({ row }) => {
+      const duration = row.getValue('duration') as number;
+      return <Text color="blue">{formatDuration(duration)}</Text>;
+    },
+  },
+  {
+    accessorKey: 'transferSize',
+    header: 'Size',
+    cell: ({ row }) => {
+      const size = row.getValue('transferSize') as number;
+      return (
+        <Text size="2" color="gray">
+          {formatBytes(size)}
+        </Text>
+      );
+    },
+  },
+];
+
+export const ResourcesTable = ({
+  resources,
+  onRowClick,
+}: ResourcesTableProps) => {
+  return (
+    <DataTable
+      data={resources}
+      columns={columns}
+      onRowClick={onRowClick}
+      emptyMessage="No resources recorded"
+    />
+  );
+};

--- a/packages/performance-monitor-plugin/src/ui/derive-startup-phases.ts
+++ b/packages/performance-monitor-plugin/src/ui/derive-startup-phases.ts
@@ -1,0 +1,48 @@
+import type {
+  SerializedPerformanceMeasure,
+  SerializedPerformanceReactNativeMark,
+} from '../shared/types';
+
+// UI-only marker. Never flows over the wire — `SerializedPerformanceMeasure`
+// in shared/types stays the device-emitted contract; this is purely
+// produced and consumed in the panel.
+export type DerivedMeasure = SerializedPerformanceMeasure & {
+  derivedFromReactNativeMark: true;
+};
+
+// React Native emits its startup taxonomy as paired Start/End marks
+// (nativeLaunchStart/End, runJSBundleStart/End, initialMountStart/End, ...).
+// Pair them up into measures so the Measures tab shows the durations
+// directly instead of forcing the user to subtract two marks by hand.
+//
+// Anything without a matching partner is left for the React Native Marks
+// tab to render as-is (e.g. `appStartup` is single-point in some RN
+// versions; user-defined RN marks that happen to share the suffix
+// convention won't synthesize a stray measure here either).
+export const deriveStartupPhases = (
+  marks: SerializedPerformanceReactNativeMark[],
+): DerivedMeasure[] => {
+  const starts = new Map<string, SerializedPerformanceReactNativeMark>();
+  const result: DerivedMeasure[] = [];
+
+  for (const mark of marks) {
+    if (mark.name.endsWith('Start')) {
+      starts.set(mark.name.slice(0, -'Start'.length), mark);
+      continue;
+    }
+    if (mark.name.endsWith('End')) {
+      const base = mark.name.slice(0, -'End'.length);
+      const start = starts.get(base);
+      if (!start) continue;
+      result.push({
+        name: base,
+        startTime: start.startTime,
+        duration: mark.startTime - start.startTime,
+        entryType: 'measure',
+        detail: start.detail,
+        derivedFromReactNativeMark: true,
+      });
+    }
+  }
+  return result;
+};

--- a/packages/performance-monitor-plugin/src/ui/utils.ts
+++ b/packages/performance-monitor-plugin/src/ui/utils.ts
@@ -22,3 +22,9 @@ export const formatDuration = (duration: number) => {
   }
   return `${duration.toFixed(2)}ms`;
 };
+
+export const formatBytes = (bytes: number) => {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+};


### PR DESCRIPTION
Closes #249.

## Summary

Closes three gaps in `@rozenite/performance-monitor-plugin`'s coverage of `react-native-performance`:

- **`react-native-mark` entries** — added a new **React Native Marks** tab. These are the native-runtime startup taxonomy (`nativeLaunchStart`, `runJSBundleStart`, …) emitted on the native side. The observer uses `buffered: true` so startup entries flushed before the user clicks Start Session still reach the panel.
- **`resource` entries** — added a new **Resources** tab. Table shows Name / Type / Duration / Size. The DetailsSidebar renders the full `PerformanceResourceTiming` breakdown: sizes (transfer / encoded body / decoded body), all 12 timing phases, plus optional `serverTiming` / `workerTiming` arrays.
- **`mark.detail` preservation** — the runtime previously dropped `detail` when serializing marks (while the UI already expected it). The serializer now includes it end-to-end; the Mark Details sidebar now renders the payload.

## Architecture

The PR extracts each observer's inline serializer into a named pure function (`serializeMark`, `serializeMeasure`, `serializeMetric`, `serializeReactNativeMark`, `serializeResource`) in a new `src/react-native/serialize.ts`. Tests pin every serializer's field-copy contract, with extra coverage on `serializeResource` — its 20-field copy is the place a typo would silently land an `undefined` in the sidebar.

The plugin had no test surface before this PR. Vitest is wired in via a single `test` script in `package.json`; the runner itself was already in the workspace root devDeps.

Wire format is the existing per-type append pattern: `appendResources` and `appendReactNativeMarks` join `appendMeasures` / `appendMarks` / `setMetrics`. No new dependencies on the plugin.

## Test plan

Automated (15 tests, up from 0):

- [x] `serialize.test.ts` (15 tests): mark / measure / metric / react-native-mark / resource — field copy, `mark.detail` regression, string-valued metric, exhaustive ResourceTiming fixture pinning every one of ~20 fields, explicit assertion that sub-phase timing fields are *not* clock-shifted, optional `initiatorType` / `secureConnectionStart` undefined branches.
- [x] `pnpm --filter @rozenite/performance-monitor-plugin test` — 10/10 passing.
- [x] `pnpm --filter @rozenite/performance-monitor-plugin typecheck` — clean.
- [x] `pnpm --filter @rozenite/performance-monitor-plugin lint` — 0 warnings.

Manual (playground, performance-monitor screen):

- [x] **Fire Network Request** button (new): calls `setResourceLoggingEnabled(true)` on mount, then a `fetch()` on click — resource timing appears on the Resources tab.
- [x] **Complex Performance Scenario** (existing button, enhanced): now also fires a fetch in parallel with marks/measures so the umbrella demo exercises every tab.
- [x] Start Session on a fresh app launch — React Native Marks tab populates with native startup entries automatically (`buffered: true` is load-bearing here).
- [x] `mark.detail` regression: fire a mark with a `detail` payload, click into it in the Marks tab — sidebar shows the payload.
- [x] Export Data modal includes two new cards (React Native Marks, Resources) with their counts. Toggling them in/out of the export round-trips through the JSON.

## Playground change

The PR touches `apps/playground/src/app/screens/PerformanceMonitorScreen.tsx` so the new tabs can be exercised without writing app code:

- `setResourceLoggingEnabled(true)` on mount.
- New "Fire Network Request" button (`fetch('https://jsonplaceholder.typicode.com/posts/1')`).
- "Complex Performance Scenario" runs a fetch in parallel.
- Screen content wrapped in a `ScrollView` so the now-taller screen is fully reachable.
- Instructions note that React Native Marks come from the native runtime and need no button.

## Out of scope

- No version field in the export schema. The change is purely additive (new fields/counts) and existing consumers ignore unknown fields. Versioning is a separate concern best introduced when an actual breaking change is on the table.
- No UI behavior tests (RTL/jsdom). The plugin has none today; standing the infrastructure up for this feature alone would expand scope. The serializer extraction means the data-shape contracts are already pinned by unit tests.
- No new buttons to manually emit react-native-marks from JS — the lib's `addEntry` is not part of the public API, so manual emission would require hacks. Native startup entries cover the test case naturally.