### PR TITLE
chore: pin GitHub Actions by SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,16 +24,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           filter: tree:0
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup
-        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: 'pnpm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,13 +42,12 @@ jobs:
           git config user.email "$GIT_AUTHOR_EMAIL"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-          cache: pnpm
           registry-url: https://registry.npmjs.org
 
       - name: Install dependencies

--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -8,7 +8,7 @@ jobs:
     if: github.repository == 'callstackincubator/rozenite'
     steps:
       - name: Close stale issues & pull requests
-        uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
+        uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:
           days-before-stale: 30
           days-before-close: 14

--- a/.github/workflows/website-release-deploy.yml
+++ b/.github/workflows/website-release-deploy.yml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Set up Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: 'pnpm'


### PR DESCRIPTION
## Summary
GitHub recommends pinning third-party workflow actions to full commit SHAs so workflow execution cannot silently change when a mutable tag is moved. This PR updates every referenced GitHub Action in this repository to the latest published release SHA and keeps the release tags in inline comments for maintainability.

## Context
This updates all action references under `.github/workflows/` to immutable SHAs for `actions/checkout`, `pnpm/action-setup`, `actions/setup-node`, and `actions/stale`.

It also removes `setup-node` package-manager caching from the release workflow so release runs stay deterministic and do not rely on restored cache state.

## Proposed Testing Scenario
Review the workflow diffs and confirm each `uses:` entry points to a full commit SHA with the corresponding release tag preserved in the trailing comment.

Trigger the `Release` workflow through `workflow_dispatch` and confirm the Node setup step runs without cache restoration while the rest of the release job still completes normally.