### PR TITLE
feat(network-activity-plugin): add advanced request filters

### DIFF
--- a/.changeset/network-activity-advanced-filters.md
+++ b/.changeset/network-activity-advanced-filters.md
@@ -1,0 +1,5 @@
+---
+"@rozenite/network-activity-plugin": minor
+---
+
+Add advanced request filters to Network Activity.

--- a/packages/network-activity-plugin/src/ui/components/FilterBar.tsx
+++ b/packages/network-activity-plugin/src/ui/components/FilterBar.tsx
@@ -1,14 +1,20 @@
+import { useState } from 'react';
+import {
+  autoUpdate,
+  flip,
+  FloatingPortal,
+  offset,
+  shift,
+  size,
+  useClick,
+  useDismiss,
+  useFloating,
+  useInteractions,
+  useRole,
+} from '@floating-ui/react';
 import { Input } from './Input';
 import { Button } from './Button';
-import { X, Filter, ChevronDown } from 'lucide-react';
-import {
-  DropdownMenu,
-  DropdownMenuTrigger,
-  DropdownMenuContent,
-  DropdownMenuCheckboxItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-} from './DropdownMenu';
+import { X, Filter, ChevronDown, Check } from 'lucide-react';
 import type { HttpMethod, NetworkEventSource } from '../../shared/client';
 
 export type RequestTypeFilter = 'http' | 'websocket' | 'sse';
@@ -135,7 +141,66 @@ const FilterField = ({
   </label>
 );
 
+const FilterPanelLabel = ({ children }: { children: string }) => (
+  <div className="px-2 py-1.5 text-xs font-semibold text-gray-400">
+    {children}
+  </div>
+);
+
+const FilterPanelSeparator = () => (
+  <div className="-mx-1 my-1 h-px bg-gray-700" />
+);
+
+const FilterCheckbox = ({
+  checked,
+  onCheckedChange,
+  children,
+}: {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  children: string;
+}) => (
+  <button
+    type="button"
+    role="checkbox"
+    aria-checked={checked}
+    className="relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-left text-sm outline-none transition-colors hover:bg-gray-700 focus:bg-gray-700 focus:text-gray-100"
+    onClick={() => onCheckedChange(!checked)}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      {checked && <Check className="h-4 w-4" />}
+    </span>
+    {children}
+  </button>
+);
+
 export const FilterBar = ({ filter, onFilterChange }: FilterBarProps) => {
+  const [isFilterPanelOpen, setIsFilterPanelOpen] = useState(false);
+  const { refs, floatingStyles, context } = useFloating({
+    open: isFilterPanelOpen,
+    onOpenChange: setIsFilterPanelOpen,
+    whileElementsMounted: autoUpdate,
+    middleware: [
+      offset(5),
+      flip({ padding: 8 }),
+      shift({ padding: 8 }),
+      size({
+        padding: 8,
+        apply({ availableHeight, elements }) {
+          elements.floating.style.maxHeight = `${availableHeight}px`;
+        },
+      }),
+    ],
+  });
+  const click = useClick(context);
+  const dismiss = useDismiss(context);
+  const role = useRole(context);
+  const { getReferenceProps, getFloatingProps } = useInteractions([
+    click,
+    dismiss,
+    role,
+  ]);
+
   const handleTextChange = (text: string) => {
     onFilterChange({ ...filter, text });
   };
@@ -185,8 +250,7 @@ export const FilterBar = ({ filter, onFilterChange }: FilterBarProps) => {
   };
 
   const activeFilterCount = getActiveFilterCount(filter);
-  const hasActiveFilters =
-    filter.text !== '' || activeFilterCount > 0;
+  const hasActiveFilters = filter.text !== '' || activeFilterCount > 0;
 
   return (
     <div className="flex items-center gap-2 p-2 border-b border-gray-700 bg-gray-800">
@@ -199,139 +263,152 @@ export const FilterBar = ({ filter, onFilterChange }: FilterBarProps) => {
         />
       </div>
 
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            variant="ghost"
-            size="sm"
-            className={`h-8 px-3 text-xs transition-all ${
-              activeFilterCount > 0
-                ? 'bg-blue-600/20 border border-blue-500/50 text-blue-300 hover:bg-blue-600/30'
-                : 'text-gray-300 hover:text-gray-100 hover:bg-gray-700'
-            }`}
+      <Button
+        ref={refs.setReference}
+        variant="ghost"
+        size="sm"
+        className={`h-8 px-3 text-xs transition-all ${
+          activeFilterCount > 0
+            ? 'bg-blue-600/20 border border-blue-500/50 text-blue-300 hover:bg-blue-600/30'
+            : 'text-gray-300 hover:text-gray-100 hover:bg-gray-700'
+        }`}
+        {...getReferenceProps()}
+      >
+        <Filter className="h-3 w-3 mr-1" />
+        Filters
+        {activeFilterCount > 0 && (
+          <span className="rounded bg-blue-500/30 px-1 text-[10px] text-blue-100">
+            {activeFilterCount}
+          </span>
+        )}
+        <ChevronDown className="h-3 w-3 ml-1" />
+      </Button>
+
+      {isFilterPanelOpen && (
+        <FloatingPortal>
+          <div
+            ref={refs.setFloating}
+            className="z-50 w-80 space-y-1 overflow-y-auto overscroll-contain rounded-md border border-gray-600 bg-gray-800 p-1 text-gray-100 shadow-lg"
+            style={floatingStyles}
+            {...getFloatingProps()}
           >
-            <Filter className="h-3 w-3 mr-1" />
-            Filters
-            {activeFilterCount > 0 && (
-              <span className="rounded bg-blue-500/30 px-1 text-[10px] text-blue-100">
-                {activeFilterCount}
-              </span>
-            )}
-            <ChevronDown className="h-3 w-3 ml-1" />
-          </Button>
-        </DropdownMenuTrigger>
-
-        <DropdownMenuContent sideOffset={5} className="w-80 space-y-1">
-          <DropdownMenuLabel>Request Type</DropdownMenuLabel>
-          {REQUEST_TYPES.map((type) => (
-            <DropdownMenuCheckboxItem
-              key={type}
-              checked={filter.types.has(type)}
-              onCheckedChange={() => toggleType(type)}
-            >
-              {getTypeLabel(type)}
-            </DropdownMenuCheckboxItem>
-          ))}
-
-          <DropdownMenuSeparator />
-          <DropdownMenuLabel>Method</DropdownMenuLabel>
-          <div className="grid grid-cols-2">
-            {HTTP_METHODS.map((method) => (
-              <DropdownMenuCheckboxItem
-                key={method}
-                checked={filter.advanced.methods.has(method)}
-                onCheckedChange={() => toggleMethod(method)}
+            <FilterPanelLabel>Request Type</FilterPanelLabel>
+            {REQUEST_TYPES.map((type) => (
+              <FilterCheckbox
+                key={type}
+                checked={filter.types.has(type)}
+                onCheckedChange={() => toggleType(type)}
               >
-                {method}
-              </DropdownMenuCheckboxItem>
+                {getTypeLabel(type)}
+              </FilterCheckbox>
             ))}
-          </div>
 
-          <DropdownMenuSeparator />
-          <DropdownMenuLabel>Request Source</DropdownMenuLabel>
-          {SOURCES.map((source) => (
-            <DropdownMenuCheckboxItem
-              key={source}
-              checked={filter.advanced.sources.has(source)}
-              onCheckedChange={() => toggleSource(source)}
+            <FilterPanelSeparator />
+            <FilterPanelLabel>Method</FilterPanelLabel>
+            <div className="grid grid-cols-2">
+              {HTTP_METHODS.map((method) => (
+                <FilterCheckbox
+                  key={method}
+                  checked={filter.advanced.methods.has(method)}
+                  onCheckedChange={() => toggleMethod(method)}
+                >
+                  {method}
+                </FilterCheckbox>
+              ))}
+            </div>
+
+            <FilterPanelSeparator />
+            <FilterPanelLabel>Request Source</FilterPanelLabel>
+            {SOURCES.map((source) => (
+              <FilterCheckbox
+                key={source}
+                checked={filter.advanced.sources.has(source)}
+                onCheckedChange={() => toggleSource(source)}
+              >
+                {getSourceLabel(source)}
+              </FilterCheckbox>
+            ))}
+
+            <FilterPanelSeparator />
+            <FilterCheckbox
+              checked={filter.advanced.failedOnly}
+              onCheckedChange={(checked) =>
+                updateAdvancedFilter({ failedOnly: checked })
+              }
             >
-              {getSourceLabel(source)}
-            </DropdownMenuCheckboxItem>
-          ))}
+              Failed only
+            </FilterCheckbox>
+            <FilterCheckbox
+              checked={filter.advanced.inFlightOnly}
+              onCheckedChange={(checked) =>
+                updateAdvancedFilter({ inFlightOnly: checked })
+              }
+            >
+              In-flight only
+            </FilterCheckbox>
+            <FilterCheckbox
+              checked={filter.advanced.overriddenOnly}
+              onCheckedChange={(checked) =>
+                updateAdvancedFilter({ overriddenOnly: checked })
+              }
+            >
+              Overridden only
+            </FilterCheckbox>
 
-          <DropdownMenuSeparator />
-          <DropdownMenuCheckboxItem
-            checked={filter.advanced.failedOnly}
-            onCheckedChange={(checked) =>
-              updateAdvancedFilter({ failedOnly: checked })
-            }
-          >
-            Failed only
-          </DropdownMenuCheckboxItem>
-          <DropdownMenuCheckboxItem
-            checked={filter.advanced.inFlightOnly}
-            onCheckedChange={(checked) =>
-              updateAdvancedFilter({ inFlightOnly: checked })
-            }
-          >
-            In-flight only
-          </DropdownMenuCheckboxItem>
-          <DropdownMenuCheckboxItem
-            checked={filter.advanced.overriddenOnly}
-            onCheckedChange={(checked) =>
-              updateAdvancedFilter({ overriddenOnly: checked })
-            }
-          >
-            Overridden only
-          </DropdownMenuCheckboxItem>
-
-          <DropdownMenuSeparator />
-          <div className="grid grid-cols-2 gap-x-2">
-            <FilterField
-              label="Status"
-              value={filter.advanced.status}
-              placeholder="200, 2xx, >=400"
-              onChange={(status) => updateAdvancedFilter({ status })}
-            />
-            <FilterField
-              label="Domain"
-              value={filter.advanced.domain}
-              placeholder="api.example.com"
-              onChange={(domain) => updateAdvancedFilter({ domain })}
-            />
-            <FilterField
-              label="MIME Type"
-              value={filter.advanced.contentType}
-              placeholder="json"
-              onChange={(contentType) => updateAdvancedFilter({ contentType })}
-            />
-            <FilterField
-              label="Min Size"
-              value={filter.advanced.minSize}
-              placeholder="1024"
-              onChange={(minSize) => updateAdvancedFilter({ minSize })}
-            />
-            <FilterField
-              label="Max Size"
-              value={filter.advanced.maxSize}
-              placeholder="50000"
-              onChange={(maxSize) => updateAdvancedFilter({ maxSize })}
-            />
-            <FilterField
-              label="Min Duration"
-              value={filter.advanced.minDuration}
-              placeholder="500"
-              onChange={(minDuration) => updateAdvancedFilter({ minDuration })}
-            />
-            <FilterField
-              label="Max Duration"
-              value={filter.advanced.maxDuration}
-              placeholder="2000"
-              onChange={(maxDuration) => updateAdvancedFilter({ maxDuration })}
-            />
+            <FilterPanelSeparator />
+            <div className="grid grid-cols-2 gap-x-2">
+              <FilterField
+                label="Status"
+                value={filter.advanced.status}
+                placeholder="200, 2xx, >=400"
+                onChange={(status) => updateAdvancedFilter({ status })}
+              />
+              <FilterField
+                label="Domain"
+                value={filter.advanced.domain}
+                placeholder="api.example.com"
+                onChange={(domain) => updateAdvancedFilter({ domain })}
+              />
+              <FilterField
+                label="MIME Type"
+                value={filter.advanced.contentType}
+                placeholder="json"
+                onChange={(contentType) =>
+                  updateAdvancedFilter({ contentType })
+                }
+              />
+              <FilterField
+                label="Min Size"
+                value={filter.advanced.minSize}
+                placeholder="1024"
+                onChange={(minSize) => updateAdvancedFilter({ minSize })}
+              />
+              <FilterField
+                label="Max Size"
+                value={filter.advanced.maxSize}
+                placeholder="50000"
+                onChange={(maxSize) => updateAdvancedFilter({ maxSize })}
+              />
+              <FilterField
+                label="Min Duration"
+                value={filter.advanced.minDuration}
+                placeholder="500"
+                onChange={(minDuration) =>
+                  updateAdvancedFilter({ minDuration })
+                }
+              />
+              <FilterField
+                label="Max Duration"
+                value={filter.advanced.maxDuration}
+                placeholder="2000"
+                onChange={(maxDuration) =>
+                  updateAdvancedFilter({ maxDuration })
+                }
+              />
+            </div>
           </div>
-        </DropdownMenuContent>
-      </DropdownMenu>
+        </FloatingPortal>
+      )}
 
       {hasActiveFilters && (
         <Button

--- a/packages/network-activity-plugin/src/ui/components/FilterBar.tsx
+++ b/packages/network-activity-plugin/src/ui/components/FilterBar.tsx
@@ -1,16 +1,36 @@
 import { Input } from './Input';
 import { Button } from './Button';
-import { X, Filter, ChevronDown } from 'lucide-react';
+import { X, Filter, ChevronDown, SlidersHorizontal } from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuTrigger,
   DropdownMenuContent,
-  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
 } from './DropdownMenu';
+import type { HttpMethod, NetworkEventSource } from '../../shared/client';
+
+export type RequestTypeFilter = 'http' | 'websocket' | 'sse';
+export type AdvancedFilterState = {
+  methods: Set<HttpMethod>;
+  sources: Set<NetworkEventSource>;
+  status: string;
+  domain: string;
+  contentType: string;
+  failedOnly: boolean;
+  inFlightOnly: boolean;
+  overriddenOnly: boolean;
+  minSize: string;
+  maxSize: string;
+  minDuration: string;
+  maxDuration: string;
+};
 
 export type FilterState = {
   text: string;
-  types: Set<'http' | 'websocket' | 'sse'>;
+  types: Set<RequestTypeFilter>;
+  advanced: AdvancedFilterState;
 };
 
 type FilterBarProps = {
@@ -18,12 +38,113 @@ type FilterBarProps = {
   onFilterChange: (filter: FilterState) => void;
 };
 
+const REQUEST_TYPES: RequestTypeFilter[] = ['http', 'sse', 'websocket'];
+const HTTP_METHODS: HttpMethod[] = [
+  'GET',
+  'POST',
+  'PUT',
+  'PATCH',
+  'DELETE',
+  'HEAD',
+];
+const SOURCES: NetworkEventSource[] = ['builtin', 'nitro'];
+
+export const createDefaultFilter = (): FilterState => ({
+  text: '',
+  types: new Set(REQUEST_TYPES),
+  advanced: {
+    methods: new Set(),
+    sources: new Set(),
+    status: '',
+    domain: '',
+    contentType: '',
+    failedOnly: false,
+    inFlightOnly: false,
+    overriddenOnly: false,
+    minSize: '',
+    maxSize: '',
+    minDuration: '',
+    maxDuration: '',
+  },
+});
+
+const getTypeLabel = (type: RequestTypeFilter) => {
+  switch (type) {
+    case 'http':
+      return 'XHR';
+    case 'websocket':
+      return 'WS';
+    case 'sse':
+      return 'SSE';
+  }
+};
+
+const getSourceLabel = (source: NetworkEventSource) => {
+  switch (source) {
+    case 'builtin':
+      return 'Built-in';
+    case 'nitro':
+      return 'Nitro';
+  }
+};
+
+const getAdvancedFilterCount = (advanced: AdvancedFilterState) => {
+  return [
+    advanced.methods.size > 0,
+    advanced.sources.size > 0,
+    advanced.status.trim() !== '',
+    advanced.domain.trim() !== '',
+    advanced.contentType.trim() !== '',
+    advanced.failedOnly,
+    advanced.inFlightOnly,
+    advanced.overriddenOnly,
+    advanced.minSize.trim() !== '',
+    advanced.maxSize.trim() !== '',
+    advanced.minDuration.trim() !== '',
+    advanced.maxDuration.trim() !== '',
+  ].filter(Boolean).length;
+};
+
+const FilterField = ({
+  label,
+  value,
+  placeholder,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  placeholder: string;
+  onChange: (value: string) => void;
+}) => (
+  <label className="block space-y-1 px-2 py-1">
+    <span className="text-xs text-gray-400">{label}</span>
+    <Input
+      value={value}
+      placeholder={placeholder}
+      onChange={(event) => onChange(event.target.value)}
+      onClick={(event) => event.stopPropagation()}
+      onKeyDown={(event) => event.stopPropagation()}
+      className="h-7 bg-gray-900 border-gray-700 text-xs text-gray-100 placeholder:text-gray-500"
+    />
+  </label>
+);
+
 export const FilterBar = ({ filter, onFilterChange }: FilterBarProps) => {
   const handleTextChange = (text: string) => {
     onFilterChange({ ...filter, text });
   };
 
-  const toggleType = (type: 'http' | 'websocket' | 'sse') => {
+  const updateAdvancedFilter = (patch: Partial<AdvancedFilterState>) => {
+    onFilterChange({
+      ...filter,
+      advanced: {
+        ...filter.advanced,
+        ...patch,
+      },
+    });
+  };
+
+  const toggleType = (type: RequestTypeFilter) => {
     const newTypes = new Set(filter.types);
     if (newTypes.has(type)) {
       newTypes.delete(type);
@@ -33,30 +154,39 @@ export const FilterBar = ({ filter, onFilterChange }: FilterBarProps) => {
     onFilterChange({ ...filter, types: newTypes });
   };
 
-  const clearFilters = () => {
-    onFilterChange({
-      text: '',
-      types: new Set(['http', 'websocket', 'sse']),
-    });
-  };
-
-  const hasActiveFilters = filter.text !== '' || filter.types.size < 3;
-  const isTypeFilterActive = filter.types.size < 3;
-
-  const getTypeLabel = (type: 'http' | 'websocket' | 'sse') => {
-    switch (type) {
-      case 'http':
-        return 'XHR';
-      case 'websocket':
-        return 'WS';
-      case 'sse':
-        return 'SSE';
+  const toggleMethod = (method: HttpMethod) => {
+    const methods = new Set(filter.advanced.methods);
+    if (methods.has(method)) {
+      methods.delete(method);
+    } else {
+      methods.add(method);
     }
+    updateAdvancedFilter({ methods });
   };
+
+  const toggleSource = (source: NetworkEventSource) => {
+    const sources = new Set(filter.advanced.sources);
+    if (sources.has(source)) {
+      sources.delete(source);
+    } else {
+      sources.add(source);
+    }
+    updateAdvancedFilter({ sources });
+  };
+
+  const clearFilters = () => {
+    onFilterChange(createDefaultFilter());
+  };
+
+  const advancedFilterCount = getAdvancedFilterCount(filter.advanced);
+  const hasActiveFilters =
+    filter.text !== '' ||
+    filter.types.size < REQUEST_TYPES.length ||
+    advancedFilterCount > 0;
+  const isTypeFilterActive = filter.types.size < REQUEST_TYPES.length;
 
   return (
     <div className="flex items-center gap-2 p-2 border-b border-gray-700 bg-gray-800">
-      {/* Text Filter */}
       <div className="flex-1">
         <Input
           placeholder="Filter requests..."
@@ -66,7 +196,6 @@ export const FilterBar = ({ filter, onFilterChange }: FilterBarProps) => {
         />
       </div>
 
-      {/* Request Type Filters Dropdown */}
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button
@@ -85,23 +214,140 @@ export const FilterBar = ({ filter, onFilterChange }: FilterBarProps) => {
         </DropdownMenuTrigger>
 
         <DropdownMenuContent sideOffset={5} className="space-y-1">
-          {(['http', 'sse', 'websocket'] as const).map((type) => (
-            <DropdownMenuItem
+          {REQUEST_TYPES.map((type) => (
+            <DropdownMenuCheckboxItem
               key={type}
-              onClick={() => toggleType(type)}
-              className={
-                filter.types.has(type)
-                  ? 'bg-blue-600 text-white'
-                  : 'text-gray-300 hover:bg-gray-700 hover:text-gray-100'
-              }
+              checked={filter.types.has(type)}
+              onCheckedChange={() => toggleType(type)}
             >
               {getTypeLabel(type)}
-            </DropdownMenuItem>
+            </DropdownMenuCheckboxItem>
           ))}
         </DropdownMenuContent>
       </DropdownMenu>
 
-      {/* Clear Filters */}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="sm"
+            className={`h-8 px-3 text-xs transition-all ${
+              advancedFilterCount > 0
+                ? 'bg-blue-600/20 border border-blue-500/50 text-blue-300 hover:bg-blue-600/30'
+                : 'text-gray-300 hover:text-gray-100 hover:bg-gray-700'
+            }`}
+          >
+            <SlidersHorizontal className="h-3 w-3 mr-1" />
+            Advanced
+            {advancedFilterCount > 0 && (
+              <span className="rounded bg-blue-500/30 px-1 text-[10px] text-blue-100">
+                {advancedFilterCount}
+              </span>
+            )}
+            <ChevronDown className="h-3 w-3 ml-1" />
+          </Button>
+        </DropdownMenuTrigger>
+
+        <DropdownMenuContent sideOffset={5} className="w-80 space-y-1">
+          <DropdownMenuLabel>Method</DropdownMenuLabel>
+          <div className="grid grid-cols-2">
+            {HTTP_METHODS.map((method) => (
+              <DropdownMenuCheckboxItem
+                key={method}
+                checked={filter.advanced.methods.has(method)}
+                onCheckedChange={() => toggleMethod(method)}
+              >
+                {method}
+              </DropdownMenuCheckboxItem>
+            ))}
+          </div>
+
+          <DropdownMenuSeparator />
+          <DropdownMenuLabel>Request Source</DropdownMenuLabel>
+          {SOURCES.map((source) => (
+            <DropdownMenuCheckboxItem
+              key={source}
+              checked={filter.advanced.sources.has(source)}
+              onCheckedChange={() => toggleSource(source)}
+            >
+              {getSourceLabel(source)}
+            </DropdownMenuCheckboxItem>
+          ))}
+
+          <DropdownMenuSeparator />
+          <DropdownMenuCheckboxItem
+            checked={filter.advanced.failedOnly}
+            onCheckedChange={(checked) =>
+              updateAdvancedFilter({ failedOnly: checked })
+            }
+          >
+            Failed only
+          </DropdownMenuCheckboxItem>
+          <DropdownMenuCheckboxItem
+            checked={filter.advanced.inFlightOnly}
+            onCheckedChange={(checked) =>
+              updateAdvancedFilter({ inFlightOnly: checked })
+            }
+          >
+            In-flight only
+          </DropdownMenuCheckboxItem>
+          <DropdownMenuCheckboxItem
+            checked={filter.advanced.overriddenOnly}
+            onCheckedChange={(checked) =>
+              updateAdvancedFilter({ overriddenOnly: checked })
+            }
+          >
+            Overridden only
+          </DropdownMenuCheckboxItem>
+
+          <DropdownMenuSeparator />
+          <div className="grid grid-cols-2 gap-x-2">
+            <FilterField
+              label="Status"
+              value={filter.advanced.status}
+              placeholder="200, 2xx, >=400"
+              onChange={(status) => updateAdvancedFilter({ status })}
+            />
+            <FilterField
+              label="Domain"
+              value={filter.advanced.domain}
+              placeholder="api.example.com"
+              onChange={(domain) => updateAdvancedFilter({ domain })}
+            />
+            <FilterField
+              label="MIME Type"
+              value={filter.advanced.contentType}
+              placeholder="json"
+              onChange={(contentType) => updateAdvancedFilter({ contentType })}
+            />
+            <FilterField
+              label="Min Size"
+              value={filter.advanced.minSize}
+              placeholder="1024"
+              onChange={(minSize) => updateAdvancedFilter({ minSize })}
+            />
+            <FilterField
+              label="Max Size"
+              value={filter.advanced.maxSize}
+              placeholder="50000"
+              onChange={(maxSize) => updateAdvancedFilter({ maxSize })}
+            />
+            <FilterField
+              label="Min Duration"
+              value={filter.advanced.minDuration}
+              placeholder="500"
+              onChange={(minDuration) => updateAdvancedFilter({ minDuration })}
+            />
+            <FilterField
+              label="Max Duration"
+              value={filter.advanced.maxDuration}
+              placeholder="2000"
+              onChange={(maxDuration) => updateAdvancedFilter({ maxDuration })}
+            />
+          </div>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
       {hasActiveFilters && (
         <Button
           variant="ghost"

--- a/packages/network-activity-plugin/src/ui/components/FilterBar.tsx
+++ b/packages/network-activity-plugin/src/ui/components/FilterBar.tsx
@@ -1,6 +1,6 @@
 import { Input } from './Input';
 import { Button } from './Button';
-import { X, Filter, ChevronDown, SlidersHorizontal } from 'lucide-react';
+import { X, Filter, ChevronDown } from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -105,6 +105,12 @@ const getAdvancedFilterCount = (advanced: AdvancedFilterState) => {
   ].filter(Boolean).length;
 };
 
+const getActiveFilterCount = (filter: FilterState) => {
+  const typeFilterCount = filter.types.size < REQUEST_TYPES.length ? 1 : 0;
+
+  return typeFilterCount + getAdvancedFilterCount(filter.advanced);
+};
+
 const FilterField = ({
   label,
   value,
@@ -178,12 +184,9 @@ export const FilterBar = ({ filter, onFilterChange }: FilterBarProps) => {
     onFilterChange(createDefaultFilter());
   };
 
-  const advancedFilterCount = getAdvancedFilterCount(filter.advanced);
+  const activeFilterCount = getActiveFilterCount(filter);
   const hasActiveFilters =
-    filter.text !== '' ||
-    filter.types.size < REQUEST_TYPES.length ||
-    advancedFilterCount > 0;
-  const isTypeFilterActive = filter.types.size < REQUEST_TYPES.length;
+    filter.text !== '' || activeFilterCount > 0;
 
   return (
     <div className="flex items-center gap-2 p-2 border-b border-gray-700 bg-gray-800">
@@ -202,18 +205,24 @@ export const FilterBar = ({ filter, onFilterChange }: FilterBarProps) => {
             variant="ghost"
             size="sm"
             className={`h-8 px-3 text-xs transition-all ${
-              isTypeFilterActive
+              activeFilterCount > 0
                 ? 'bg-blue-600/20 border border-blue-500/50 text-blue-300 hover:bg-blue-600/30'
                 : 'text-gray-300 hover:text-gray-100 hover:bg-gray-700'
             }`}
           >
             <Filter className="h-3 w-3 mr-1" />
-            Types
+            Filters
+            {activeFilterCount > 0 && (
+              <span className="rounded bg-blue-500/30 px-1 text-[10px] text-blue-100">
+                {activeFilterCount}
+              </span>
+            )}
             <ChevronDown className="h-3 w-3 ml-1" />
           </Button>
         </DropdownMenuTrigger>
 
-        <DropdownMenuContent sideOffset={5} className="space-y-1">
+        <DropdownMenuContent sideOffset={5} className="w-80 space-y-1">
+          <DropdownMenuLabel>Request Type</DropdownMenuLabel>
           {REQUEST_TYPES.map((type) => (
             <DropdownMenuCheckboxItem
               key={type}
@@ -223,32 +232,8 @@ export const FilterBar = ({ filter, onFilterChange }: FilterBarProps) => {
               {getTypeLabel(type)}
             </DropdownMenuCheckboxItem>
           ))}
-        </DropdownMenuContent>
-      </DropdownMenu>
 
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            variant="ghost"
-            size="sm"
-            className={`h-8 px-3 text-xs transition-all ${
-              advancedFilterCount > 0
-                ? 'bg-blue-600/20 border border-blue-500/50 text-blue-300 hover:bg-blue-600/30'
-                : 'text-gray-300 hover:text-gray-100 hover:bg-gray-700'
-            }`}
-          >
-            <SlidersHorizontal className="h-3 w-3 mr-1" />
-            Advanced
-            {advancedFilterCount > 0 && (
-              <span className="rounded bg-blue-500/30 px-1 text-[10px] text-blue-100">
-                {advancedFilterCount}
-              </span>
-            )}
-            <ChevronDown className="h-3 w-3 ml-1" />
-          </Button>
-        </DropdownMenuTrigger>
-
-        <DropdownMenuContent sideOffset={5} className="w-80 space-y-1">
+          <DropdownMenuSeparator />
           <DropdownMenuLabel>Method</DropdownMenuLabel>
           <div className="grid grid-cols-2">
             {HTTP_METHODS.map((method) => (

--- a/packages/network-activity-plugin/src/ui/components/FilterBar.tsx
+++ b/packages/network-activity-plugin/src/ui/components/FilterBar.tsx
@@ -51,7 +51,7 @@ const SOURCES: NetworkEventSource[] = ['builtin', 'nitro'];
 
 export const createDefaultFilter = (): FilterState => ({
   text: '',
-  types: new Set(REQUEST_TYPES),
+  types: new Set(),
   advanced: {
     methods: new Set(),
     sources: new Set(),
@@ -106,7 +106,7 @@ const getAdvancedFilterCount = (advanced: AdvancedFilterState) => {
 };
 
 const getActiveFilterCount = (filter: FilterState) => {
-  const typeFilterCount = filter.types.size < REQUEST_TYPES.length ? 1 : 0;
+  const typeFilterCount = filter.types.size > 0 ? 1 : 0;
 
   return typeFilterCount + getAdvancedFilterCount(filter.advanced);
 };

--- a/packages/network-activity-plugin/src/ui/components/RequestList.tsx
+++ b/packages/network-activity-plugin/src/ui/components/RequestList.tsx
@@ -225,7 +225,7 @@ const filterNetworkRequests = (
   const maxDuration = parseThreshold(filter.advanced.maxDuration);
 
   return requests.filter((request) => {
-    if (!filter.types.has(request.type)) {
+    if (filter.types.size > 0 && !filter.types.has(request.type)) {
       return false;
     }
 

--- a/packages/network-activity-plugin/src/ui/components/RequestList.tsx
+++ b/packages/network-activity-plugin/src/ui/components/RequestList.tsx
@@ -8,8 +8,13 @@ import {
   SortingState,
   useReactTable,
 } from '@tanstack/react-table';
-import { ProcessedRequest } from '../state/model';
-import { RequestId, RequestOverride } from '../../shared/client';
+import type { ProcessedRequest } from '../state/model';
+import type {
+  HttpMethod,
+  NetworkEventSource,
+  RequestId,
+  RequestOverride,
+} from '../../shared/client';
 import {
   useNetworkActivityActions,
   useOverrides,
@@ -20,18 +25,22 @@ import {
 import { getStatusColor } from '../utils/getStatusColor';
 import { FilterState } from './FilterBar';
 import { isNumber } from '../../utils/typeChecks';
-import type { NetworkEventSource } from '../../shared/client';
 
 type NetworkRequest = {
   id: RequestId;
   name: string;
   status: string | number;
-  method: string;
+  statusCode?: number;
+  statusState: ProcessedRequest['status'];
+  method: ProcessedRequest['method'];
   domain: string;
   path: string;
+  contentType?: string;
   size: string;
+  sizeBytes: number | null;
   time: string;
-  type: string;
+  durationMs: number;
+  type: ProcessedRequest['type'];
   source?: NetworkEventSource;
   startTime: string;
   hasOverride: boolean;
@@ -139,6 +148,175 @@ const sortTime: SortingFn<NetworkRequest> = (rowA, rowB, columnId) => {
   return getNumericValue(a) - getNumericValue(b);
 };
 
+const parseThreshold = (value: string): number | null => {
+  const normalizedValue = value.trim();
+  if (!normalizedValue) {
+    return null;
+  }
+
+  const parsedValue = Number(normalizedValue);
+  return Number.isFinite(parsedValue) ? parsedValue : null;
+};
+
+const matchesStatusFilter = (
+  statusCode: number | undefined,
+  statusFilter: string,
+) => {
+  const normalizedFilter = statusFilter.trim().toLowerCase();
+  if (!normalizedFilter) {
+    return true;
+  }
+
+  if (statusCode === undefined) {
+    return false;
+  }
+
+  const statusRangeMatch = normalizedFilter.match(/^(\d{3})\s*-\s*(\d{3})$/);
+  if (statusRangeMatch) {
+    const min = Number(statusRangeMatch[1]);
+    const max = Number(statusRangeMatch[2]);
+    return statusCode >= min && statusCode <= max;
+  }
+
+  const statusClassMatch = normalizedFilter.match(/^([1-5])xx$/);
+  if (statusClassMatch) {
+    return Math.floor(statusCode / 100) === Number(statusClassMatch[1]);
+  }
+
+  const comparisonMatch = normalizedFilter.match(/^(>=|<=|>|<)\s*(\d{3})$/);
+  if (comparisonMatch) {
+    const value = Number(comparisonMatch[2]);
+    switch (comparisonMatch[1]) {
+      case '>=':
+        return statusCode >= value;
+      case '<=':
+        return statusCode <= value;
+      case '>':
+        return statusCode > value;
+      case '<':
+        return statusCode < value;
+    }
+  }
+
+  return statusCode === Number(normalizedFilter);
+};
+
+const isInFlightStatus = (status: string) => {
+  return ['pending', 'loading', 'connecting', 'open'].includes(status);
+};
+
+const isFailedStatus = (status: string) => {
+  return ['failed', 'error'].includes(status);
+};
+
+const isHttpMethod = (method: NetworkRequest['method']): method is HttpMethod =>
+  method !== 'WS' && method !== 'SSE';
+
+const filterNetworkRequests = (
+  requests: NetworkRequest[],
+  filter: FilterState,
+) => {
+  const searchText = filter.text.trim().toLowerCase();
+  const domainFilter = filter.advanced.domain.trim().toLowerCase();
+  const contentTypeFilter = filter.advanced.contentType.trim().toLowerCase();
+  const minSize = parseThreshold(filter.advanced.minSize);
+  const maxSize = parseThreshold(filter.advanced.maxSize);
+  const minDuration = parseThreshold(filter.advanced.minDuration);
+  const maxDuration = parseThreshold(filter.advanced.maxDuration);
+
+  return requests.filter((request) => {
+    if (!filter.types.has(request.type)) {
+      return false;
+    }
+
+    if (
+      filter.advanced.methods.size > 0 &&
+      (!isHttpMethod(request.method) ||
+        !filter.advanced.methods.has(request.method))
+    ) {
+      return false;
+    }
+
+    if (
+      filter.advanced.sources.size > 0 &&
+      (!request.source || !filter.advanced.sources.has(request.source))
+    ) {
+      return false;
+    }
+
+    if (!matchesStatusFilter(request.statusCode, filter.advanced.status)) {
+      return false;
+    }
+
+    if (domainFilter && !request.domain.toLowerCase().includes(domainFilter)) {
+      return false;
+    }
+
+    if (
+      contentTypeFilter &&
+      !request.contentType?.toLowerCase().includes(contentTypeFilter)
+    ) {
+      return false;
+    }
+
+    if (filter.advanced.failedOnly && !isFailedStatus(request.statusState)) {
+      return false;
+    }
+
+    if (
+      filter.advanced.inFlightOnly &&
+      !isInFlightStatus(request.statusState)
+    ) {
+      return false;
+    }
+
+    if (filter.advanced.overriddenOnly && !request.hasOverride) {
+      return false;
+    }
+
+    if (
+      minSize !== null &&
+      (request.sizeBytes === null || request.sizeBytes < minSize)
+    ) {
+      return false;
+    }
+
+    if (
+      maxSize !== null &&
+      (request.sizeBytes === null || request.sizeBytes > maxSize)
+    ) {
+      return false;
+    }
+
+    if (minDuration !== null && request.durationMs < minDuration) {
+      return false;
+    }
+
+    if (maxDuration !== null && request.durationMs > maxDuration) {
+      return false;
+    }
+
+    if (searchText) {
+      const searchableFields = [
+        request.name,
+        request.method,
+        request.status,
+        request.domain,
+        request.path,
+        request.source,
+        request.type,
+        request.contentType,
+      ]
+        .join(' ')
+        .toLowerCase();
+
+      return searchableFields.includes(searchText);
+    }
+
+    return true;
+  });
+};
+
 const processNetworkRequests = (
   processedRequests: ProcessedRequest[],
   overrides: Map<string, RequestOverride>,
@@ -161,11 +339,16 @@ const processNetworkRequests = (
       id: request.id,
       name: generateName(request.name, showEntirePathAsName),
       status: statusDisplay,
+      statusCode: request.httpStatus || undefined,
+      statusState: request.status,
       method: request.method,
       domain,
       path,
+      contentType: request.contentType,
       size: isNumber(request.size) ? formatSize(request.size) : '—',
+      sizeBytes: isNumber(request.size) ? request.size : null,
       time: formatDuration(duration),
+      durationMs: duration,
       type: request.type,
       source: request.source,
       startTime: formatStartTime(request.timestamp),
@@ -256,39 +439,14 @@ export const RequestList = ({ filter }: RequestListProps) => {
   const overrides = useOverrides();
   const clientUISettings = useClientUISettings();
 
-  // Filter requests based on current filter state
-  const filteredRequests = useMemo(() => {
-    return processedRequests.filter((request) => {
-      // Type filter
-      if (!filter.types.has(request.type)) {
-        return false;
-      }
-
-      // Text filter
-      if (filter.text) {
-        const searchText = filter.text.toLowerCase();
-        const searchableFields = [
-          request.name,
-          request.method,
-          request.status.toString(),
-        ]
-          .join(' ')
-          .toLowerCase();
-
-        return searchableFields.includes(searchText);
-      }
-
-      return true;
-    });
-  }, [processedRequests, filter]);
-
   const requests = useMemo(() => {
-    return processNetworkRequests(
-      filteredRequests,
+    const allRequests = processNetworkRequests(
+      processedRequests,
       overrides,
       clientUISettings?.showUrlAsName,
     );
-  }, [filteredRequests, overrides, clientUISettings?.showUrlAsName]);
+    return filterNetworkRequests(allRequests, filter);
+  }, [processedRequests, overrides, clientUISettings?.showUrlAsName, filter]);
 
   const table = useReactTable({
     data: requests,

--- a/packages/network-activity-plugin/src/ui/state/derived.ts
+++ b/packages/network-activity-plugin/src/ui/state/derived.ts
@@ -26,6 +26,7 @@ export const getProcessedRequests = memoize((state: NetworkActivityState) => {
         size: httpEntry.size ?? null,
         method: httpEntry.request.method,
         httpStatus: httpEntry.response?.status,
+        contentType: httpEntry.response?.contentType,
         progress: httpEntry.progress,
       });
     } else if (entry.type === 'websocket') {
@@ -41,12 +42,14 @@ export const getProcessedRequests = memoize((state: NetworkActivityState) => {
         size: null,
         method: 'WS',
         httpStatus: 0,
+        contentType: undefined,
       });
     } else if (entry.type === 'sse') {
       const sseEntry = entry as SSENetworkEntry;
       requests.push({
         id: sseEntry.id,
         type: 'sse',
+        source: sseEntry.source,
         initiator: sseEntry.initiator,
         name: sseEntry.request.url,
         status: sseEntry.status,
@@ -55,6 +58,7 @@ export const getProcessedRequests = memoize((state: NetworkActivityState) => {
         size: null,
         method: 'SSE',
         httpStatus: 0,
+        contentType: sseEntry.response?.contentType,
       });
     }
   }
@@ -90,6 +94,7 @@ export const getRequestSummary = (
         size: httpEntry.size ?? null,
         method: httpEntry.request.method,
         httpStatus: httpEntry.response?.status || 0,
+        contentType: httpEntry.response?.contentType,
         progress: httpEntry.progress,
       };
     } else if (entry.type === 'websocket') {
@@ -105,12 +110,14 @@ export const getRequestSummary = (
         size: null,
         method: 'WS',
         httpStatus: 0,
+        contentType: undefined,
       };
     } else if (entry.type === 'sse') {
       const sseEntry = entry as SSENetworkEntry;
       return {
         id: sseEntry.id,
         type: 'sse',
+        source: sseEntry.source,
         initiator: sseEntry.initiator,
         name: sseEntry.request.url,
         status: sseEntry.status,
@@ -119,6 +126,7 @@ export const getRequestSummary = (
         size: null,
         method: 'SSE',
         httpStatus: 0,
+        contentType: sseEntry.response?.contentType,
       };
     }
 

--- a/packages/network-activity-plugin/src/ui/state/model.ts
+++ b/packages/network-activity-plugin/src/ui/state/model.ts
@@ -151,6 +151,7 @@ export type ProcessedRequest = {
   size: number | null;
   method: HttpMethod | 'WS' | 'SSE';
   httpStatus?: number;
+  contentType?: string;
   progress?: {
     loaded: number;
     total: number;

--- a/packages/network-activity-plugin/src/ui/views/InspectorView.tsx
+++ b/packages/network-activity-plugin/src/ui/views/InspectorView.tsx
@@ -2,7 +2,11 @@ import { useEffect, useState } from 'react';
 import { Toolbar } from '../components/Toolbar';
 import { RequestList } from '../components/RequestList';
 import { SidePanel } from '../components/SidePanel';
-import { FilterBar, FilterState } from '../components/FilterBar';
+import {
+  createDefaultFilter,
+  FilterBar,
+  FilterState,
+} from '../components/FilterBar';
 import { NetworkActivityDevToolsClient } from '../../shared/client';
 import {
   useNetworkActivityClientManagement,
@@ -20,10 +24,9 @@ export const InspectorView = ({ client }: InspectorViewProps) => {
   const clientManagement = useNetworkActivityClientManagement();
   const hasSelectedRequest = useHasSelectedRequest();
   const overrides = useOverrides();
-  const [filter, setFilter] = useState<FilterState>({
-    text: '',
-    types: new Set(['http', 'websocket', 'sse']),
-  });
+  const [filter, setFilter] = useState<FilterState>(() =>
+    createDefaultFilter(),
+  );
 
   useEffect(() => {
     if (!client) {


### PR DESCRIPTION
## Description

Adds advanced request filtering to Network Activity so busy request logs can be narrowed by practical request properties instead of only free-text search and transport type.

The filter bar now supports method, request source, status code/range, domain, MIME type, failed-only, in-flight-only, overridden-only, size thresholds, and duration thresholds. Existing text search and type filters continue to work and can be combined with the new advanced filters.

## Related Issue

Closes #241

## Context

The request list already had most of the data needed to support richer filtering, but some values were only available in detailed entries. This change extends the processed request summary with response content type and SSE source, then normalizes table rows once and applies all filters against those row values.

Status filters support exact codes, ranges such as , classes such as , and comparisons such as . Size and duration thresholds use raw byte and millisecond values so filtering remains predictable.

## Testing
Verified manually in the playground that the advanced filters work and the existing clear-filters button resets the combined filter state.
<img width="1716" height="942" alt="image" src="https://github.com/user-attachments/assets/e51e10bc-34b1-4a03-8ded-29e8ce8d49d0" />
