### PR TITLE
feat(plugin-bridge): add plugin testing harness

### DIFF
--- a/.changeset/witty-ads-enjoy.md
+++ b/.changeset/witty-ads-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@rozenite/plugin-bridge': minor
+---
+
+Add `@rozenite/plugin-bridge/testing` so plugin tests can drive `useRozeniteDevToolsClient` without hand-written mocks. The new harness makes delayed DevTools connection explicit, which helps plugin authors cover loading states, bridge lifecycle, and message flows with less test setup.

--- a/.changeset/witty-ads-enjoy.md
+++ b/.changeset/witty-ads-enjoy.md
@@ -2,4 +2,4 @@
 '@rozenite/plugin-bridge': minor
 ---
 
-Add `@rozenite/plugin-bridge/testing` so plugin tests can drive `useRozeniteDevToolsClient` without hand-written mocks. The new harness makes delayed DevTools connection explicit, which helps plugin authors cover loading states, bridge lifecycle, and message flows with less test setup.
+Add test utilities to `@rozenite/plugin-bridge` so plugin tests can drive `useRozeniteDevToolsClient` without hand-written mocks. The new harness makes delayed DevTools connection explicit, which helps plugin authors cover loading states, bridge lifecycle, and message flows with less test setup.

--- a/packages/plugin-bridge/package.json
+++ b/packages/plugin-bridge/package.json
@@ -30,10 +30,18 @@
     "access": "public"
   },
   "exports": {
+    "./package.json": "./package.json",
     ".": {
+      "development": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./testing": {
+      "development": "./src/testing.ts",
+      "types": "./dist/testing.d.ts",
+      "import": "./dist/testing.js",
+      "require": "./dist/testing.cjs"
     }
   },
   "scripts": {

--- a/packages/plugin-bridge/package.json
+++ b/packages/plugin-bridge/package.json
@@ -36,12 +36,6 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
-    },
-    "./testing": {
-      "development": "./src/testing.ts",
-      "types": "./dist/testing.d.ts",
-      "import": "./dist/testing.js",
-      "require": "./dist/testing.cjs"
     }
   },
   "scripts": {

--- a/packages/plugin-bridge/src/client-context.ts
+++ b/packages/plugin-bridge/src/client-context.ts
@@ -1,0 +1,8 @@
+import { createContext } from 'react';
+export type RozeniteTestClientRegistry = {
+  subscribe: (listener: () => void) => () => void;
+  getClient: (pluginId: string) => unknown | null;
+};
+
+export const RozeniteDevToolsClientContext =
+  createContext<RozeniteTestClientRegistry | null>(null);

--- a/packages/plugin-bridge/src/index.ts
+++ b/packages/plugin-bridge/src/index.ts
@@ -1,6 +1,15 @@
 export { useRozeniteDevToolsClient } from './useRozeniteDevToolsClient';
+export { useRozeniteDevToolsClientForTesting } from './useRozeniteDevToolsClientForTesting';
+export { useRozeniteDevToolsClientForProduction } from './useRozeniteDevToolsClientForProduction';
 export type { RozeniteDevToolsClient } from './client';
 export type { Subscription } from './types';
 export type { UseRozeniteDevToolsClientOptions } from './useRozeniteDevToolsClient';
 export { getRozeniteDevToolsClient } from './client';
 export { UnsupportedPlatformError, MissingRozeniteForWebError } from './errors';
+export {
+  createRozeniteTestHarness,
+  RozeniteDevToolsTestProvider,
+  type RozeniteDevToolsTestProviderProps,
+  type RozeniteTestHarness,
+  type RozeniteTestMessage,
+} from './testing-provider';

--- a/packages/plugin-bridge/src/testing-provider.tsx
+++ b/packages/plugin-bridge/src/testing-provider.tsx
@@ -77,7 +77,7 @@ const createClient = <TEventMap extends Record<string, unknown>>(
     emit: <TType extends keyof TEventMap>(type: TType, payload: TEventMap[TType]) => {
       if (closed) {
         throw new Error(
-          `[Rozenite test harness] Cannot emit \"${String(type)}\" for disconnected plugin \"${pluginId}\".`,
+          `[Rozenite test harness] Cannot emit "${String(type)}" for disconnected plugin "${pluginId}".`,
         );
       }
 
@@ -150,7 +150,7 @@ export const createRozeniteTestHarness = <
       const entry = emitters.get(pluginId);
       if (!entry) {
         throw new Error(
-          `[Rozenite test harness] Plugin \"${pluginId}\" is not connected. Call connect() before emit().`,
+          `[Rozenite test harness] Plugin "${pluginId}" is not connected. Call connect() before emit().`,
         );
       }
 

--- a/packages/plugin-bridge/src/testing-provider.tsx
+++ b/packages/plugin-bridge/src/testing-provider.tsx
@@ -1,0 +1,186 @@
+import type { PropsWithChildren } from 'react';
+import { useMemo } from 'react';
+import type { RozeniteDevToolsClient } from './client';
+import {
+  RozeniteDevToolsClientContext,
+  type RozeniteTestClientRegistry,
+} from './client-context';
+
+type Listener = (payload: unknown) => void;
+
+export type RozeniteTestMessage<
+  TEventMap extends Record<string, unknown> = Record<string, unknown>,
+> = {
+  pluginId: string;
+  type: keyof TEventMap;
+  payload: TEventMap[keyof TEventMap];
+};
+
+type PluginState<TEventMap extends Record<string, unknown>> = {
+  client: RozeniteDevToolsClient<TEventMap> | null;
+  sent: RozeniteTestMessage<TEventMap>[];
+};
+
+export type RozeniteTestHarness<
+  TEventMap extends Record<string, unknown> = Record<string, unknown>,
+> = RozeniteTestClientRegistry & {
+  connect: (pluginId: string) => RozeniteDevToolsClient<TEventMap>;
+  disconnect: (pluginId: string) => void;
+  emit: <TType extends keyof TEventMap>(
+    pluginId: string,
+    type: TType,
+    payload: TEventMap[TType],
+  ) => void;
+  getSent: (pluginId: string) => RozeniteTestMessage<TEventMap>[];
+  clearSent: (pluginId: string) => void;
+  isConnected: (pluginId: string) => boolean;
+};
+
+const createClient = <TEventMap extends Record<string, unknown>>(
+  pluginId: string,
+  appendSent: (message: RozeniteTestMessage<TEventMap>) => void,
+) => {
+  const listeners = new Map<keyof TEventMap, Set<Listener>>();
+  let closed = false;
+
+  const client: RozeniteDevToolsClient<TEventMap> = {
+    send: (type, payload) => {
+      if (closed) {
+        return;
+      }
+
+      appendSent({ pluginId, type, payload });
+    },
+    onMessage: (type, listener) => {
+      if (closed) {
+        return { remove: () => undefined };
+      }
+
+      const typeListeners = listeners.get(type) ?? new Set<Listener>();
+      typeListeners.add(listener as Listener);
+      listeners.set(type, typeListeners);
+
+      return {
+        remove: () => {
+          typeListeners.delete(listener as Listener);
+        },
+      };
+    },
+    close: () => {
+      closed = true;
+      listeners.clear();
+    },
+  };
+
+  return {
+    client,
+    emit: <TType extends keyof TEventMap>(type: TType, payload: TEventMap[TType]) => {
+      if (closed) {
+        throw new Error(
+          `[Rozenite test harness] Cannot emit \"${String(type)}\" for disconnected plugin \"${pluginId}\".`,
+        );
+      }
+
+      listeners.get(type)?.forEach((listener) => {
+        listener(payload);
+      });
+    },
+  };
+};
+
+export const createRozeniteTestHarness = <
+  TEventMap extends Record<string, unknown> = Record<string, unknown>,
+>(): RozeniteTestHarness<TEventMap> => {
+  const pluginStates = new Map<string, PluginState<TEventMap>>();
+  const emitters = new Map<string, ReturnType<typeof createClient<TEventMap>>>();
+  const subscribers = new Set<() => void>();
+
+  const notify = () => {
+    subscribers.forEach((listener) => {
+      listener();
+    });
+  };
+
+  const ensureState = (pluginId: string): PluginState<TEventMap> => {
+    const existing = pluginStates.get(pluginId);
+    if (existing) {
+      return existing;
+    }
+
+    const state: PluginState<TEventMap> = {
+      client: null,
+      sent: [],
+    };
+    pluginStates.set(pluginId, state);
+    return state;
+  };
+
+  return {
+    subscribe: (listener) => {
+      subscribers.add(listener);
+      return () => {
+        subscribers.delete(listener);
+      };
+    },
+    getClient: (pluginId) => {
+      return ensureState(pluginId).client;
+    },
+    connect: (pluginId) => {
+      const state = ensureState(pluginId);
+      if (state.client) {
+        return state.client;
+      }
+
+      const entry = createClient<TEventMap>(pluginId, (message) => {
+        ensureState(pluginId).sent.push(message);
+      });
+      state.client = entry.client;
+      emitters.set(pluginId, entry);
+      notify();
+      return entry.client;
+    },
+    disconnect: (pluginId) => {
+      const state = ensureState(pluginId);
+      state.client?.close();
+      state.client = null;
+      emitters.delete(pluginId);
+      notify();
+    },
+    emit: (pluginId, type, payload) => {
+      const entry = emitters.get(pluginId);
+      if (!entry) {
+        throw new Error(
+          `[Rozenite test harness] Plugin \"${pluginId}\" is not connected. Call connect() before emit().`,
+        );
+      }
+
+      entry.emit(type, payload);
+    },
+    getSent: (pluginId) => {
+      return [...ensureState(pluginId).sent];
+    },
+    clearSent: (pluginId) => {
+      ensureState(pluginId).sent = [];
+    },
+    isConnected: (pluginId) => {
+      return ensureState(pluginId).client != null;
+    },
+  };
+};
+
+export type RozeniteDevToolsTestProviderProps = PropsWithChildren<{
+  harness: RozeniteTestHarness<any>;
+}>;
+
+export const RozeniteDevToolsTestProvider = ({
+  harness,
+  children,
+}: RozeniteDevToolsTestProviderProps) => {
+  const value = useMemo(() => harness, [harness]);
+
+  return (
+    <RozeniteDevToolsClientContext.Provider value={value}>
+      {children}
+    </RozeniteDevToolsClientContext.Provider>
+  );
+};

--- a/packages/plugin-bridge/src/testing.ts
+++ b/packages/plugin-bridge/src/testing.ts
@@ -1,0 +1,7 @@
+export {
+  createRozeniteTestHarness,
+  RozeniteDevToolsTestProvider,
+  type RozeniteDevToolsTestProviderProps,
+  type RozeniteTestHarness,
+  type RozeniteTestMessage,
+} from './testing-provider';

--- a/packages/plugin-bridge/src/testing.ts
+++ b/packages/plugin-bridge/src/testing.ts
@@ -1,7 +1,0 @@
-export {
-  createRozeniteTestHarness,
-  RozeniteDevToolsTestProvider,
-  type RozeniteDevToolsTestProviderProps,
-  type RozeniteTestHarness,
-  type RozeniteTestMessage,
-} from './testing-provider';

--- a/packages/plugin-bridge/src/useRozeniteDevToolsClient.test.tsx
+++ b/packages/plugin-bridge/src/useRozeniteDevToolsClient.test.tsx
@@ -1,8 +1,12 @@
 // @vitest-environment jsdom
 
-import { act } from 'react';
+import { act, type ReactNode } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createRozeniteTestHarness,
+  RozeniteDevToolsTestProvider,
+} from './testing.js';
 import { useRozeniteDevToolsClient } from './useRozeniteDevToolsClient.js';
 
 declare global {
@@ -47,7 +51,21 @@ function TestComponent() {
   return null;
 }
 
-const renderHook = async (): Promise<{
+function ObservedComponent({
+  onClientChange,
+}: {
+  onClientChange: (client: ReturnType<typeof useRozeniteDevToolsClient>) => void;
+}) {
+  const client = useRozeniteDevToolsClient({
+    pluginId: '@rozenite/storage-plugin',
+  });
+
+  onClientChange(client);
+
+  return null;
+}
+
+const renderHook = async (element: ReactNode = <TestComponent />): Promise<{
   root: Root;
   container: HTMLDivElement;
 }> => {
@@ -56,7 +74,7 @@ const renderHook = async (): Promise<{
   const root = createRoot(container);
 
   await act(async () => {
-    root.render(<TestComponent />);
+    root.render(element);
   });
 
   await act(async () => {
@@ -116,6 +134,54 @@ describe('useRozeniteDevToolsClient', () => {
     });
 
     expect(mocks.send).not.toHaveBeenCalled();
+
+    await unmountHook(root, container);
+  });
+
+  it('uses the test harness when wrapped in the test provider', async () => {
+    const harness = createRozeniteTestHarness<{
+      'plugin-mounted': { pluginId: string };
+      init: { ready: boolean };
+    }>();
+    const seenClients: Array<ReturnType<typeof useRozeniteDevToolsClient>> = [];
+
+    const { root, container } = await renderHook(
+      <RozeniteDevToolsTestProvider harness={harness}>
+        <ObservedComponent
+          onClientChange={(client) => {
+            seenClients.push(client);
+          }}
+        />
+      </RozeniteDevToolsTestProvider>,
+    );
+
+    expect(mocks.getRozeniteDevToolsClient).not.toHaveBeenCalled();
+    expect(seenClients.at(-1)).toBeNull();
+    expect(harness.isConnected('@rozenite/storage-plugin')).toBe(false);
+
+    await act(async () => {
+      harness.connect('@rozenite/storage-plugin');
+    });
+
+    expect(seenClients.at(-1)).not.toBeNull();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(harness.getSent('@rozenite/storage-plugin')).toContainEqual({
+      pluginId: '@rozenite/storage-plugin',
+      type: 'plugin-mounted',
+      payload: {
+        pluginId: '@rozenite/storage-plugin',
+      },
+    });
+
+    await act(async () => {
+      harness.disconnect('@rozenite/storage-plugin');
+    });
+
+    expect(seenClients.at(-1)).toBeNull();
 
     await unmountHook(root, container);
   });

--- a/packages/plugin-bridge/src/useRozeniteDevToolsClient.test.tsx
+++ b/packages/plugin-bridge/src/useRozeniteDevToolsClient.test.tsx
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   createRozeniteTestHarness,
   RozeniteDevToolsTestProvider,
-} from './testing.js';
+} from './index.js';
 import { useRozeniteDevToolsClient } from './useRozeniteDevToolsClient.js';
 
 declare global {

--- a/packages/plugin-bridge/src/useRozeniteDevToolsClient.ts
+++ b/packages/plugin-bridge/src/useRozeniteDevToolsClient.ts
@@ -1,10 +1,11 @@
-import { useContext, useEffect, useState } from 'react';
-import { RozeniteDevToolsClient, getRozeniteDevToolsClient } from './client';
+import { useContext, useEffect } from 'react';
+import type { RozeniteDevToolsClient } from './client';
 import { RozeniteDevToolsClientContext } from './client-context';
-import { MissingRozeniteForWebError, UnsupportedPlatformError } from './errors';
+import { useRozeniteDevToolsClientForProduction } from './useRozeniteDevToolsClientForProduction';
+import { useRozeniteDevToolsClientForTesting } from './useRozeniteDevToolsClientForTesting';
 
 export type UseRozeniteDevToolsClientOptions<
-  TEventMap extends Record<string, unknown> = Record<string, unknown>
+  TEventMap extends Record<string, unknown> = Record<string, unknown>,
 > = {
   pluginId: string;
   eventMap?: TEventMap;
@@ -22,93 +23,15 @@ const isPanelClient = (): boolean => {
 
 // TODO: Handle multiple hooks (should not kill the socket)
 export const useRozeniteDevToolsClient = <
-  TEventMap extends Record<string, unknown> = Record<string, unknown>
+  TEventMap extends Record<string, unknown> = Record<string, unknown>,
 >({
   pluginId,
 }: UseRozeniteDevToolsClientOptions<TEventMap>): RozeniteDevToolsClient<TEventMap> | null => {
-  const testClientRegistry = useContext(RozeniteDevToolsClientContext);
-  const [testClient, setTestClient] = useState<RozeniteDevToolsClient<TEventMap> | null>(
-    () => (testClientRegistry?.getClient(pluginId) as RozeniteDevToolsClient<TEventMap> | null) ?? null,
-  );
-  const [client, setClient] =
-    useState<RozeniteDevToolsClient<TEventMap> | null>(null);
-  const [error, setError] = useState<unknown | null>(null);
+  const registry = useContext(RozeniteDevToolsClientContext);
+  const testClient = useRozeniteDevToolsClientForTesting<TEventMap>(pluginId);
+  const productionClient = useRozeniteDevToolsClientForProduction<TEventMap>(pluginId);
 
-  useEffect(() => {
-    if (!testClientRegistry) {
-      setTestClient(null);
-      return;
-    }
-
-    setTestClient(testClientRegistry.getClient(pluginId) as RozeniteDevToolsClient<TEventMap> | null);
-
-    return testClientRegistry.subscribe(() => {
-      setTestClient(testClientRegistry.getClient(pluginId) as RozeniteDevToolsClient<TEventMap> | null);
-    });
-  }, [pluginId, testClientRegistry]);
-
-  useEffect(() => {
-    if (testClientRegistry) {
-      return;
-    }
-
-    let isMounted = true;
-    let client: RozeniteDevToolsClient<TEventMap> | null = null;
-
-    const setup = async () => {
-      try {
-        client = await getRozeniteDevToolsClient<TEventMap>(pluginId);
-
-        if (isMounted) {
-          setClient(client);
-        }
-      } catch (error) {
-        if (error instanceof MissingRozeniteForWebError) {
-          // On web without Rozenite, the client is expected to be null.
-          console.warn(
-            `[Rozenite, ${pluginId}] Rozenite for web is not configured. A separate integration is required for web. Consult Rozenite docs for details.`
-          );
-          return;
-        }
-
-        if (error instanceof UnsupportedPlatformError) {
-          // We don't want to show an error for unsupported platforms.
-          // It's expected that the client will be null.
-          console.warn(
-            `[Rozenite, ${pluginId}] Unsupported platform, skipping setup.`
-          );
-          return;
-        }
-
-        console.error(`[Rozenite, ${pluginId}] Error setting up client.`, error);
-
-        if (isMounted) {
-          setError(error);
-        }
-      }
-    };
-    const teardown = async () => {
-      try {
-        if (client != null) {
-          client.close();
-        }
-      } catch {
-        // We don't care about errors when tearing down
-      }
-    };
-
-    setup();
-    return () => {
-      isMounted = false;
-      teardown();
-    };
-  }, [pluginId, testClientRegistry]);
-
-  if (error != null) {
-    throw error;
-  }
-
-  const resolvedClient = testClientRegistry ? testClient : client;
+  const resolvedClient = registry ? testClient : productionClient;
 
   useEffect(() => {
     if (!resolvedClient || isPanelClient()) {

--- a/packages/plugin-bridge/src/useRozeniteDevToolsClient.ts
+++ b/packages/plugin-bridge/src/useRozeniteDevToolsClient.ts
@@ -1,5 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { RozeniteDevToolsClient, getRozeniteDevToolsClient } from './client';
+import { RozeniteDevToolsClientContext } from './client-context';
 import { MissingRozeniteForWebError, UnsupportedPlatformError } from './errors';
 
 export type UseRozeniteDevToolsClientOptions<
@@ -25,11 +26,32 @@ export const useRozeniteDevToolsClient = <
 >({
   pluginId,
 }: UseRozeniteDevToolsClientOptions<TEventMap>): RozeniteDevToolsClient<TEventMap> | null => {
+  const testClientRegistry = useContext(RozeniteDevToolsClientContext);
+  const [testClient, setTestClient] = useState<RozeniteDevToolsClient<TEventMap> | null>(
+    () => (testClientRegistry?.getClient(pluginId) as RozeniteDevToolsClient<TEventMap> | null) ?? null,
+  );
   const [client, setClient] =
     useState<RozeniteDevToolsClient<TEventMap> | null>(null);
   const [error, setError] = useState<unknown | null>(null);
 
   useEffect(() => {
+    if (!testClientRegistry) {
+      setTestClient(null);
+      return;
+    }
+
+    setTestClient(testClientRegistry.getClient(pluginId) as RozeniteDevToolsClient<TEventMap> | null);
+
+    return testClientRegistry.subscribe(() => {
+      setTestClient(testClientRegistry.getClient(pluginId) as RozeniteDevToolsClient<TEventMap> | null);
+    });
+  }, [pluginId, testClientRegistry]);
+
+  useEffect(() => {
+    if (testClientRegistry) {
+      return;
+    }
+
     let isMounted = true;
     let client: RozeniteDevToolsClient<TEventMap> | null = null;
 
@@ -80,19 +102,21 @@ export const useRozeniteDevToolsClient = <
       isMounted = false;
       teardown();
     };
-  }, [pluginId]);
+  }, [pluginId, testClientRegistry]);
 
   if (error != null) {
     throw error;
   }
 
+  const resolvedClient = testClientRegistry ? testClient : client;
+
   useEffect(() => {
-    if (!client || isPanelClient()) {
+    if (!resolvedClient || isPanelClient()) {
       return;
     }
 
     const lifecycleClient =
-      client as unknown as RozeniteDevToolsClient<PluginLifecycleEventMap>;
+      resolvedClient as unknown as RozeniteDevToolsClient<PluginLifecycleEventMap>;
     const timer = setTimeout(() => {
       lifecycleClient.send('plugin-mounted', {
         pluginId,
@@ -102,7 +126,7 @@ export const useRozeniteDevToolsClient = <
     return () => {
       clearTimeout(timer);
     };
-  }, [client, pluginId]);
+  }, [pluginId, resolvedClient]);
 
-  return client;
+  return resolvedClient;
 };

--- a/packages/plugin-bridge/src/useRozeniteDevToolsClientForProduction.ts
+++ b/packages/plugin-bridge/src/useRozeniteDevToolsClientForProduction.ts
@@ -1,0 +1,73 @@
+import { useContext, useEffect, useState } from 'react';
+import { RozeniteDevToolsClient, getRozeniteDevToolsClient } from './client';
+import { RozeniteDevToolsClientContext } from './client-context';
+import { MissingRozeniteForWebError, UnsupportedPlatformError } from './errors';
+
+export const useRozeniteDevToolsClientForProduction = <
+  TEventMap extends Record<string, unknown> = Record<string, unknown>,
+>(
+  pluginId: string,
+): RozeniteDevToolsClient<TEventMap> | null => {
+  const registry = useContext(RozeniteDevToolsClientContext);
+  const [client, setClient] = useState<RozeniteDevToolsClient<TEventMap> | null>(null);
+  const [error, setError] = useState<unknown>(null);
+
+  useEffect(() => {
+    if (registry) {
+      return;
+    }
+
+    let isMounted = true;
+    let client: RozeniteDevToolsClient<TEventMap> | null = null;
+
+    const setup = async () => {
+      try {
+        client = await getRozeniteDevToolsClient<TEventMap>(pluginId);
+
+        if (isMounted) {
+          setClient(client);
+        }
+      } catch (error) {
+        if (error instanceof MissingRozeniteForWebError) {
+          console.warn(
+            `[Rozenite, ${pluginId}] Rozenite for web is not configured. A separate integration is required for web. Consult Rozenite docs for details.`,
+          );
+          return;
+        }
+
+        if (error instanceof UnsupportedPlatformError) {
+          console.warn(`[Rozenite, ${pluginId}] Unsupported platform, skipping setup.`);
+          return;
+        }
+
+        console.error(`[Rozenite, ${pluginId}] Error setting up client.`, error);
+
+        if (isMounted) {
+          setError(error);
+        }
+      }
+    };
+
+    const teardown = async () => {
+      try {
+        if (client != null) {
+          client.close();
+        }
+      } catch {
+        // Ignore teardown errors
+      }
+    };
+
+    setup();
+    return () => {
+      isMounted = false;
+      teardown();
+    };
+  }, [pluginId, registry]);
+
+  if (error != null) {
+    throw error;
+  }
+
+  return client;
+};

--- a/packages/plugin-bridge/src/useRozeniteDevToolsClientForTesting.ts
+++ b/packages/plugin-bridge/src/useRozeniteDevToolsClientForTesting.ts
@@ -1,0 +1,30 @@
+import { useContext, useEffect, useState } from 'react';
+import type { RozeniteDevToolsClient } from './client';
+import { RozeniteDevToolsClientContext } from './client-context';
+
+export const useRozeniteDevToolsClientForTesting = <
+  TEventMap extends Record<string, unknown> = Record<string, unknown>,
+>(
+  pluginId: string,
+): RozeniteDevToolsClient<TEventMap> | null => {
+  const registry = useContext(RozeniteDevToolsClientContext);
+  const [client, setClient] = useState<RozeniteDevToolsClient<TEventMap> | null>(
+    () =>
+      (registry?.getClient(pluginId) as RozeniteDevToolsClient<TEventMap> | null) ?? null,
+  );
+
+  useEffect(() => {
+    if (!registry) {
+      setClient(null);
+      return;
+    }
+
+    setClient(registry.getClient(pluginId) as RozeniteDevToolsClient<TEventMap> | null);
+
+    return registry.subscribe(() => {
+      setClient(registry.getClient(pluginId) as RozeniteDevToolsClient<TEventMap> | null);
+    });
+  }, [pluginId, registry]);
+
+  return client;
+};

--- a/packages/plugin-bridge/vite.config.ts
+++ b/packages/plugin-bridge/vite.config.ts
@@ -16,10 +16,7 @@ export default defineConfig({
   base: './',
   build: {
     lib: {
-      entry: {
-        index: resolve(__dirname, 'src/index.ts'),
-        testing: resolve(__dirname, 'src/testing.ts'),
-      },
+      entry: resolve(__dirname, 'src/index.ts'),
       formats: ['es', 'cjs'],
     },
     rollupOptions: {

--- a/packages/plugin-bridge/vite.config.ts
+++ b/packages/plugin-bridge/vite.config.ts
@@ -1,12 +1,14 @@
 /// <reference types='vitest' />
 import { defineConfig } from 'vite';
-import { resolve } from 'path';
+import path, { resolve } from 'path';
 import dts from 'vite-plugin-dts';
 
 export default defineConfig({
   plugins: [
     dts({
-      tsconfigPath: './tsconfig.lib.json',
+      entryRoot: 'src',
+      tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'),
+      rollupTypes: true,
     }),
   ],
   root: __dirname,
@@ -14,8 +16,10 @@ export default defineConfig({
   base: './',
   build: {
     lib: {
-      entry: resolve(__dirname, 'src/index.ts'),
-      fileName: 'index',
+      entry: {
+        index: resolve(__dirname, 'src/index.ts'),
+        testing: resolve(__dirname, 'src/testing.ts'),
+      },
       formats: ['es', 'cjs'],
     },
     rollupOptions: {

--- a/packages/plugin-bridge/vite.config.ts
+++ b/packages/plugin-bridge/vite.config.ts
@@ -16,7 +16,9 @@ export default defineConfig({
   base: './',
   build: {
     lib: {
-      entry: resolve(__dirname, 'src/index.ts'),
+      entry: {
+        index: resolve(__dirname, 'src/index.ts'),
+      },
       formats: ['es', 'cjs'],
     },
     rollupOptions: {

--- a/website/src/docs/plugin-development/_meta.json
+++ b/website/src/docs/plugin-development/_meta.json
@@ -8,5 +8,10 @@
     "type": "file",
     "name": "plugin-development",
     "label": "Plugin Development Guide"
+  },
+  {
+    "type": "file",
+    "name": "testing",
+    "label": "Testing"
   }
 ] 

--- a/website/src/docs/plugin-development/overview.md
+++ b/website/src/docs/plugin-development/overview.md
@@ -64,7 +64,7 @@ my-plugin/
 - **Type Safety**: Full TypeScript support with compile-time checking
 - **Hot Reloading**: See changes instantly during development
 - **In-browser dev host**: `rozenite dev` opens a small test shell where you can preview panels, read the message log, and dispatch commands—without wiring up a playground app first (see the [Plugin Development guide](./plugin-development.md#step-5-local-development-workflow))
-- **First-class testing utilities**: `@rozenite/plugin-bridge/testing` lets you test plugin message flows without hand-written bridge mocks (see [Testing](./testing.md))
+- **First-class testing utilities**: `@rozenite/plugin-bridge` lets you test plugin message flows without hand-written bridge mocks (see [Testing](./testing.md))
 - **Production Builds**: Optimized builds for distribution
 
 ## Getting Started

--- a/website/src/docs/plugin-development/overview.md
+++ b/website/src/docs/plugin-development/overview.md
@@ -64,6 +64,7 @@ my-plugin/
 - **Type Safety**: Full TypeScript support with compile-time checking
 - **Hot Reloading**: See changes instantly during development
 - **In-browser dev host**: `rozenite dev` opens a small test shell where you can preview panels, read the message log, and dispatch commands—without wiring up a playground app first (see the [Plugin Development guide](./plugin-development.md#step-5-local-development-workflow))
+- **First-class testing utilities**: `@rozenite/plugin-bridge/testing` lets you test plugin message flows without hand-written bridge mocks (see [Testing](./testing.md))
 - **Production Builds**: Optimized builds for distribution
 
 ## Getting Started

--- a/website/src/docs/plugin-development/plugin-development.md
+++ b/website/src/docs/plugin-development/plugin-development.md
@@ -301,6 +301,8 @@ Your development workflow supports automatic hot reloading:
 3. Add new panels - remember to restart DevTools with `Ctrl+R`
 4. Test communication between your panels and React Native code
 
+For automated coverage, use [`@rozenite/plugin-bridge/testing`](./testing.md). It lets you keep `useRozeniteDevToolsClient` in place while controlling when the client is disconnected, connected, and receiving messages.
+
 ## Step 6: Building for Production
 
 Build your plugin for distribution:

--- a/website/src/docs/plugin-development/plugin-development.md
+++ b/website/src/docs/plugin-development/plugin-development.md
@@ -301,7 +301,7 @@ Your development workflow supports automatic hot reloading:
 3. Add new panels - remember to restart DevTools with `Ctrl+R`
 4. Test communication between your panels and React Native code
 
-For automated coverage, use [`@rozenite/plugin-bridge/testing`](./testing.md). It lets you keep `useRozeniteDevToolsClient` in place while controlling when the client is disconnected, connected, and receiving messages.
+For automated coverage, use [`@rozenite/plugin-bridge`](./testing.md). It lets you keep `useRozeniteDevToolsClient` in place while controlling when the client is disconnected, connected, and receiving messages.
 
 ## Step 6: Building for Production
 

--- a/website/src/docs/plugin-development/testing.md
+++ b/website/src/docs/plugin-development/testing.md
@@ -7,9 +7,9 @@ Rozenite plugin tests should cover two different loops:
 
 Use both. Automated tests keep message flows stable. The dev host helps you iterate on panels and payload shapes quickly.
 
-## Automated Tests With `@rozenite/plugin-bridge/testing`
+## Automated Tests With `@rozenite/plugin-bridge`
 
-`@rozenite/plugin-bridge/testing` provides a harness and a provider for testing code that uses `useRozeniteDevToolsClient`.
+`@rozenite/plugin-bridge` provides a harness and a provider for testing code that uses `useRozeniteDevToolsClient`.
 
 - The harness starts **disconnected**, so your tests can cover the real `client === null` state before DevTools connects.
 - When you call `connect(pluginId)`, the production hook receives a test client instead of creating the real bridge client.
@@ -21,7 +21,7 @@ import { render } from '@testing-library/react';
 import {
   createRozeniteTestHarness,
   RozeniteDevToolsTestProvider,
-} from '@rozenite/plugin-bridge/testing';
+} from '@rozenite/plugin-bridge';
 import { MyPanel } from './panel';
 
 type PluginEvents = {

--- a/website/src/docs/plugin-development/testing.md
+++ b/website/src/docs/plugin-development/testing.md
@@ -1,0 +1,113 @@
+# Testing Plugins
+
+Rozenite plugin tests should cover two different loops:
+
+1. Automated tests for your plugin bridge logic and React components
+2. Manual checks in the **Rozenite dev host** started by `rozenite dev`
+
+Use both. Automated tests keep message flows stable. The dev host helps you iterate on panels and payload shapes quickly.
+
+## Automated Tests With `@rozenite/plugin-bridge/testing`
+
+`@rozenite/plugin-bridge/testing` provides a harness and a provider for testing code that uses `useRozeniteDevToolsClient`.
+
+- The harness starts **disconnected**, so your tests can cover the real `client === null` state before DevTools connects.
+- When you call `connect(pluginId)`, the production hook receives a test client instead of creating the real bridge client.
+- You can inspect outbound messages with `getSent(pluginId)` and fake inbound messages with `emit(pluginId, type, payload)`.
+
+```tsx title="plugin.test.tsx"
+import { act } from 'react';
+import { render } from '@testing-library/react';
+import {
+  createRozeniteTestHarness,
+  RozeniteDevToolsTestProvider,
+} from '@rozenite/plugin-bridge/testing';
+import { MyPanel } from './panel';
+
+type PluginEvents = {
+  snapshot: { items: string[] };
+  'get-snapshot': { type: 'get-snapshot' };
+};
+
+it('requests data after DevTools connects', async () => {
+  const harness = createRozeniteTestHarness<PluginEvents>();
+
+  render(
+    <RozeniteDevToolsTestProvider harness={harness}>
+      <MyPanel />
+    </RozeniteDevToolsTestProvider>,
+  );
+
+  expect(harness.getSent('my-plugin')).toEqual([]);
+
+  await act(async () => {
+    harness.connect('my-plugin');
+  });
+
+  expect(harness.getSent('my-plugin')).toContainEqual({
+    pluginId: 'my-plugin',
+    type: 'get-snapshot',
+    payload: { type: 'get-snapshot' },
+  });
+});
+```
+
+### Delayed Connection
+
+The harness is intentionally explicit about connection state.
+
+- Before `connect(pluginId)`, the hook returns `null`
+- After `connect(pluginId)`, your plugin effects run with a connected client
+- After `disconnect(pluginId)`, the hook returns `null` again
+
+That makes it easy to test loading states, late initialization, and cleanup behavior.
+
+```tsx title="react-native.test.tsx"
+await act(async () => {
+  harness.connect('my-plugin');
+});
+
+await act(async () => {
+  harness.emit('my-plugin', 'snapshot', { items: ['first'] });
+});
+
+await act(async () => {
+  harness.disconnect('my-plugin');
+});
+```
+
+### When To Use The Harness
+
+Use the harness when you want to test:
+
+- Panel components that subscribe with `client.onMessage(...)`
+- Native hooks that send snapshots or react to DevTools commands
+- Bridge lifecycle behavior around `client === null`
+
+This avoids per-test `vi.mock('@rozenite/plugin-bridge', ...)` setups and keeps tests closer to real plugin behavior.
+
+## Manual Testing With `rozenite dev`
+
+`rozenite dev` starts a browser host for your plugin. This is the fastest way to validate panel UI and message payloads without wiring up a playground app first.
+
+The dev host gives you:
+
+- **Panel preview** for every panel declared in `rozenite.config.ts`
+- **Message log** for outbound messages sent by the panel
+- **Dispatch message** controls for sending inbound commands with JSON payloads
+
+The host fills `pluginId` from your plugin package `name`. That value must match the `pluginId` you pass to `useRozeniteDevToolsClient` or `getRozeniteDevToolsClient`.
+
+Use this loop for:
+
+- fast panel UI iteration
+- checking outbound payload shapes
+- manually replaying inbound commands from DevTools
+
+Use a real React Native app when you need to exercise `react-native.ts`, device APIs, or native integrations.
+
+## Recommended Workflow
+
+1. Use automated tests to cover message flows, delayed connection, and component behavior.
+2. Use `rozenite dev` to iterate on panel UI and payloads.
+3. Use a real app only for the native side that the browser host cannot execute.


### PR DESCRIPTION
## Summary
- add `@rozenite/plugin-bridge/testing` with a harness and provider so plugin tests can keep `useRozeniteDevToolsClient` in place while controlling delayed DevTools connection
- update the production hook and package build/exports to support the new `./testing` entrypoint without changing runtime behavior outside tests
- document plugin testing on the website, including when to use the automated harness versus the `rozenite dev` host, and add a changeset for the new testing feature

## Testing
- pnpm --filter @rozenite/plugin-bridge test
- pnpm --filter @rozenite/plugin-bridge build