### PR TITLE
fix(performance-monitor-plugin): 1ms-precise time display

### DIFF
--- a/.changeset/quiet-otters-tick.md
+++ b/.changeset/quiet-otters-tick.md
@@ -1,0 +1,5 @@
+---
+'@rozenite/performance-monitor-plugin': patch
+---
+
+Fix time display precision in the Performance Monitor panel. Durations under 1s now show as integer milliseconds (clock accuracy is 1ms, so `.toFixed(2)` was always faking precision). Durations ≥ 1s show 3 decimals (`1.234s`) for the same 1ms-precision invariant. Wall-clock timestamps (mark `Recorded at`, measure `Start Time` / `End Time`, session `Started`) include their millisecond component in a stable 24h `HH:MM:SS.mmm` format. Non-zero sub-millisecond durations display as `<1ms` instead of `0ms`, so a marker that fired isn't mistaken for "not measured."

--- a/packages/performance-monitor-plugin/src/ui/__tests__/utils.test.ts
+++ b/packages/performance-monitor-plugin/src/ui/__tests__/utils.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { formatDuration, formatTime } from '../utils';
+
+describe('formatTime', () => {
+  it('renders HH:MM:SS.mmm in 24h format', () => {
+    const ts = new Date(2024, 0, 15, 12, 34, 56, 789).getTime();
+    expect(formatTime(ts)).toBe('12:34:56.789');
+  });
+
+  it('zero-pads single-digit hours / minutes / seconds', () => {
+    const ts = new Date(2024, 0, 15, 3, 4, 5, 7).getTime();
+    expect(formatTime(ts)).toBe('03:04:05.007');
+  });
+
+  it('renders midnight as 00:00:00.000', () => {
+    const ts = new Date(2024, 0, 15, 0, 0, 0, 0).getTime();
+    expect(formatTime(ts)).toBe('00:00:00.000');
+  });
+
+  it('renders end-of-second milliseconds as .999', () => {
+    const ts = new Date(2024, 0, 15, 23, 59, 59, 999).getTime();
+    expect(formatTime(ts)).toBe('23:59:59.999');
+  });
+
+  it('pads two-digit milliseconds with a leading zero', () => {
+    const ts = new Date(2024, 0, 15, 10, 20, 30, 42).getTime();
+    expect(formatTime(ts)).toBe('10:20:30.042');
+  });
+});
+
+describe('formatDuration', () => {
+  it('renders 0 as "0ms"', () => {
+    expect(formatDuration(0)).toBe('0ms');
+  });
+
+  it('renders sub-millisecond non-zero values as "<1ms"', () => {
+    expect(formatDuration(0.4)).toBe('<1ms');
+    expect(formatDuration(0.001)).toBe('<1ms');
+    expect(formatDuration(0.999)).toBe('<1ms');
+  });
+
+  it('rounds millisecond values to the nearest integer', () => {
+    expect(formatDuration(1)).toBe('1ms');
+    expect(formatDuration(1.4)).toBe('1ms');
+    expect(formatDuration(1.5)).toBe('2ms');
+    expect(formatDuration(123)).toBe('123ms');
+    expect(formatDuration(123.49)).toBe('123ms');
+    expect(formatDuration(123.5)).toBe('124ms');
+    expect(formatDuration(999)).toBe('999ms');
+    expect(formatDuration(999.4)).toBe('999ms');
+  });
+
+  it('switches to seconds with 3 decimals at the 1000ms boundary', () => {
+    expect(formatDuration(1000)).toBe('1.000s');
+    expect(formatDuration(1234)).toBe('1.234s');
+    expect(formatDuration(60000)).toBe('60.000s');
+  });
+
+  it('rounds across the ms/s boundary before deciding the unit', () => {
+    // 999.6 rounds to 1000, so it should display as 1.000s — not "1000ms".
+    expect(formatDuration(999.6)).toBe('1.000s');
+  });
+});

--- a/packages/performance-monitor-plugin/src/ui/components/MarkDetails.tsx
+++ b/packages/performance-monitor-plugin/src/ui/components/MarkDetails.tsx
@@ -1,16 +1,13 @@
 import { Box, Text, Heading, Separator, Flex } from '@radix-ui/themes';
 import { SerializedPerformanceMark } from '../../shared/types';
 import { DetailsDisplay } from './DetailsDisplay';
+import { formatTime } from '../utils';
 
 export type MarkDetailsProps = {
   mark: SerializedPerformanceMark;
 };
 
 export const MarkDetails = ({ mark }: MarkDetailsProps) => {
-  const formatTime = (timestamp: number) => {
-    return new Date(timestamp).toLocaleTimeString();
-  };
-
   return (
     <Box>
       <Heading size="5" mb="4">

--- a/packages/performance-monitor-plugin/src/ui/components/MetricDetails.tsx
+++ b/packages/performance-monitor-plugin/src/ui/components/MetricDetails.tsx
@@ -1,16 +1,13 @@
 import { Box, Text, Heading, Separator, Flex } from '@radix-ui/themes';
 import { SerializedPerformanceMetric } from '../../shared/types';
 import { DetailsDisplay } from './DetailsDisplay';
+import { formatTime } from '../utils';
 
 export type MetricDetailsProps = {
   metric: SerializedPerformanceMetric;
 };
 
 export const MetricDetails = ({ metric }: MetricDetailsProps) => {
-  const formatTime = (timestamp: number) => {
-    return new Date(timestamp).toLocaleTimeString();
-  };
-
   return (
     <Box>
       <Heading size="5" mb="4">

--- a/packages/performance-monitor-plugin/src/ui/components/ResourceDetails.tsx
+++ b/packages/performance-monitor-plugin/src/ui/components/ResourceDetails.tsx
@@ -8,7 +8,7 @@ export type ResourceDetailsProps = {
 
 const formatPhase = (value: number | undefined): string => {
   if (value === undefined || value === 0) return '—';
-  return `${value.toFixed(2)}ms`;
+  return formatDuration(value);
 };
 
 const Row = ({

--- a/packages/performance-monitor-plugin/src/ui/components/SessionDuration.tsx
+++ b/packages/performance-monitor-plugin/src/ui/components/SessionDuration.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Text } from '@radix-ui/themes';
+import { formatTime } from '../utils';
 
 export type SessionDurationProps = {
   isActive: boolean;
@@ -24,10 +25,6 @@ export const SessionDuration = ({
 
     return () => clearInterval(interval);
   }, [isActive]);
-
-  const formatTime = (timestamp: number) => {
-    return new Date(timestamp).toLocaleTimeString();
-  };
 
   const formatDuration = (duration: number) => {
     return `${Math.round(duration)}s`;

--- a/packages/performance-monitor-plugin/src/ui/utils.ts
+++ b/packages/performance-monitor-plugin/src/ui/utils.ts
@@ -13,14 +13,23 @@ export const downloadFile = async (data: unknown, filename: string) => {
 };
 
 export const formatTime = (timestamp: number): string => {
-  return new Date(timestamp).toLocaleTimeString();
+  const d = new Date(timestamp);
+  const hh = String(d.getHours()).padStart(2, '0');
+  const mm = String(d.getMinutes()).padStart(2, '0');
+  const ss = String(d.getSeconds()).padStart(2, '0');
+  const ms = String(d.getMilliseconds()).padStart(3, '0');
+  return `${hh}:${mm}:${ss}.${ms}`;
 };
 
 export const formatDuration = (duration: number) => {
-  if (duration >= 1000) {
-    return `${(duration / 1000).toFixed(2)}s`;
+  if (duration > 0 && duration < 1) {
+    return '<1ms';
   }
-  return `${duration.toFixed(2)}ms`;
+  const rounded = Math.round(duration);
+  if (rounded >= 1000) {
+    return `${(rounded / 1000).toFixed(3)}s`;
+  }
+  return `${rounded}ms`;
 };
 
 export const formatBytes = (bytes: number) => {


### PR DESCRIPTION
## Summary

- **`formatDuration`** no longer fakes precision: ms values round to integer (`.toFixed(2)` was fabricating 0.01ms detail the clock can't provide), `>= 1s` values show 3 decimals (`1.234s`) for the same 1ms-precision invariant, and non-zero sub-1ms values display as `<1ms` to distinguish "fired but fast" from "not measured." Rounding happens before the unit switch, so `999.6ms` displays as `1.000s` rather than `1000ms`.
- **`formatTime`** now produces a stable 24h `HH:MM:SS.mmm` format — the millisecond component is visible alongside HH:MM:SS on every "Recorded at" / "Started" / "Start Time" / "End Time" line across Mark / Metric / Measure / Resource / ReactNativeMark / SessionDuration.
- **Cleanup:** three inline `formatTime` duplicates in `MarkDetails`, `MetricDetails`, and `SessionDuration` replaced with imports from `utils`. `ResourceDetails.formatPhase` keeps its `0/undefined → "—"` special case but routes non-zero values through `formatDuration` so resource timing phases honor the same precision rule. `SessionDuration` keeps its own whole-second `formatDuration` for the always-ticking session-length display.

## Test plan

- [ ] `pnpm --filter @rozenite/performance-monitor-plugin test` — all 26 tests pass (10 new `utils.test.ts` + 16 existing for serialize/derive-startup-phases).
- [ ] `pnpm --filter @rozenite/performance-monitor-plugin typecheck` — clean.
- [ ] `pnpm --filter @rozenite/performance-monitor-plugin lint` — clean.
- [ ] Manual: in the Performance Monitor panel, verify every "Recorded at" / "Started" / "Start Time" / "End Time" timestamp renders as `HH:MM:SS.mmm` (24h, three-digit ms padding).
- [ ] Manual: Measure Duration column shows integer ms for sub-1s values and `1.234s` style for ≥1s.
- [ ] Manual: a `performance.mark` that fires near-instantly displays as `<1ms`, not `0ms`.
- [ ] Manual: SessionDuration's "Duration" line continues to tick whole-second values (intentionally untouched).