### PR TITLE
fix(network-activity-plugin): avoid Metro optional dependency overlay for Nitro

### DIFF
--- a/.changeset/five-owls-relax.md
+++ b/.changeset/five-owls-relax.md
@@ -1,0 +1,5 @@
+---
+'@rozenite/network-activity-plugin': patch
+---
+
+Resolve the optional `react-native-nitro-fetch` dependency before React Native finishes initializing so Metro 0.82 does not show an error overlay when the package is not installed.

--- a/packages/network-activity-plugin/src/react-native/nitro-fetch/get-nitro-module.ts
+++ b/packages/network-activity-plugin/src/react-native/nitro-fetch/get-nitro-module.ts
@@ -1,9 +1,13 @@
 import type { NitroModule } from './nitro-network-inspector';
 
-export const getNitroModule = (): NitroModule | null => {
+const nitroModule = (() => {
   try {
     return require('react-native-nitro-fetch') as NitroModule;
   } catch {
     return null;
   }
+})();
+
+export const getNitroModule = (): NitroModule | null => {
+  return nitroModule;
 };


### PR DESCRIPTION
## Summary
Move `react-native-nitro-fetch` resolution to module initialization so the network activity plugin reads the optional dependency once before React Native finishes initializing.

## Context
It's supposed to provide a workaround for Metro 0.82 bug, where optional dependencies required at run-time, after react-native is initialized, will show the error overlay. The changes done are moving the require time to before react-native is fully initialized, just like we do currently for `react-native-sse`, so the error overlay is never displayed.

This keeps the existing fallback behavior for apps that do not install `react-native-nitro-fetch`, but avoids re-running the optional require from the nitro inspector enable path.

## Proposed Testing Scenario
1. Run an app that includes `@rozenite/network-activity-plugin` without installing `react-native-nitro-fetch`.
2. Start and stop network recording multiple times after the app has already initialized.
3. Confirm the app does not show the Metro error overlay for the missing optional nitro dependency.
4. Run an app that does install `react-native-nitro-fetch` and verify network recording still works for nitro-backed requests.