### PR TITLE
feat(file-system-plugin): add file import/export

### DIFF
--- a/.changeset/file-system-import-export.md
+++ b/.changeset/file-system-import-export.md
@@ -1,0 +1,5 @@
+---
+"@rozenite/file-system-plugin": minor
+---
+
+Add opt-in single-file import and export support to the File System plugin, including separately gated Rozenite for Agents tools for raw base64 file transfer.

--- a/apps/playground/src/app/App.tsx
+++ b/apps/playground/src/app/App.tsx
@@ -66,7 +66,13 @@ const Wrapper = () => {
   usePerformanceMonitorDevTools();
   useRequireProfilerDevTools();
   useAgentPlaygroundTools();
-  useFileSystemDevTools({ rnfs: RNFS });
+  useFileSystemDevTools({
+    rnfs: RNFS,
+    fileTransfer: {
+      import: true,
+      export: true,
+    },
+  });
 
   return (
     <Stack.Navigator

--- a/apps/playground/src/app/App.tsx
+++ b/apps/playground/src/app/App.tsx
@@ -71,6 +71,10 @@ const Wrapper = () => {
     fileTransfer: {
       import: true,
       export: true,
+      agent: {
+        import: true,
+        export: true,
+      },
     },
   });
 

--- a/packages/file-system-plugin/README.md
+++ b/packages/file-system-plugin/README.md
@@ -13,6 +13,7 @@ The Rozenite File System Plugin provides an in-app file explorer for React Nativ
 - **Text Preview**: Open text files directly in DevTools for quick inspection
 - **Image Preview**: Preview image files inline without leaving the DevTools panel
 - **Binary Fallback Preview**: Non-text files fall back to a hex-style preview for debugging
+- **File Transfer**: Opt-in single-file import and export workflows for moving raw files in and out of app-accessible directories
 - **Large Directory Handling**: Expo directory reads are capped to keep very large folders responsive
 
 ## Installation
@@ -55,6 +56,10 @@ import {
 function App() {
   useFileSystemDevTools({
     adapter: createExpoFileSystemAdapter(FileSystem),
+    fileTransfer: {
+      import: true,
+      export: true,
+    },
   });
 
   return <YourApp />;
@@ -73,6 +78,10 @@ import {
 function App() {
   useFileSystemDevTools({
     adapter: createRNFSAdapter(RNFS),
+    fileTransfer: {
+      import: true,
+      export: true,
+    },
   });
 
   return <YourApp />;
@@ -92,6 +101,8 @@ Start your development server and open React Native DevTools. You’ll find the 
 - RNFS roots include document, caches, temporary, library, and bundle paths when available.
 - File previews are limited to avoid loading very large files into DevTools.
 - Binary files are shown as a hex-style dump when text decoding is not possible.
+- File import and export are disabled by default. Enable them explicitly with `fileTransfer.import` and `fileTransfer.export`.
+- File transfer supports single files only. Import targets the currently viewed directory and asks before overwriting an existing file.
 
 ## Agent Tools (LLM Integration)
 

--- a/packages/file-system-plugin/README.md
+++ b/packages/file-system-plugin/README.md
@@ -102,7 +102,24 @@ Start your development server and open React Native DevTools. You’ll find the 
 - File previews are limited to avoid loading very large files into DevTools.
 - Binary files are shown as a hex-style dump when text decoding is not possible.
 - File import and export are disabled by default. Enable them explicitly with `fileTransfer.import` and `fileTransfer.export`.
+- Agent-triggered file transfer is disabled separately. Enable it explicitly with `fileTransfer.agent.import` and `fileTransfer.agent.export`.
 - File transfer supports single files only. Import targets the currently viewed directory and asks before overwriting an existing file.
+
+To enable agent-triggered file transfer, opt in separately:
+
+```typescript
+useFileSystemDevTools({
+  adapter: createRNFSAdapter(RNFS),
+  fileTransfer: {
+    import: true,
+    export: true,
+    agent: {
+      import: true,
+      export: true,
+    },
+  },
+});
+```
 
 ## Agent Tools (LLM Integration)
 
@@ -115,6 +132,8 @@ Available tools:
 - `read-entry`: returns metadata for a file or directory path.
 - `read-text-file`: returns a text preview for a file, with binary fallback when decoding fails.
 - `read-image-file`: returns an image preview as a data URI.
+- `export-file`: opt-in agent transfer tool that returns exact base64 file contents for a file under a visible root.
+- `import-file`: opt-in agent transfer tool that writes exact base64 file contents into an existing visible directory, with overwrite preflight.
 
 ## Made with ❤️ at Callstack
 

--- a/packages/file-system-plugin/README.md
+++ b/packages/file-system-plugin/README.md
@@ -56,10 +56,6 @@ import {
 function App() {
   useFileSystemDevTools({
     adapter: createExpoFileSystemAdapter(FileSystem),
-    fileTransfer: {
-      import: true,
-      export: true,
-    },
   });
 
   return <YourApp />;
@@ -78,10 +74,6 @@ import {
 function App() {
   useFileSystemDevTools({
     adapter: createRNFSAdapter(RNFS),
-    fileTransfer: {
-      import: true,
-      export: true,
-    },
   });
 
   return <YourApp />;
@@ -104,6 +96,18 @@ Start your development server and open React Native DevTools. You’ll find the 
 - File import and export are disabled by default. Enable them explicitly with `fileTransfer.import` and `fileTransfer.export`.
 - Agent-triggered file transfer is disabled separately. Enable it explicitly with `fileTransfer.agent.import` and `fileTransfer.agent.export`.
 - File transfer supports single files only. Import targets the currently viewed directory and asks before overwriting an existing file.
+
+To enable file transfer in the DevTools panel, opt in explicitly:
+
+```typescript
+useFileSystemDevTools({
+  adapter: createRNFSAdapter(RNFS),
+  fileTransfer: {
+    import: true,
+    export: true,
+  },
+});
+```
 
 To enable agent-triggered file transfer, opt in separately:
 

--- a/packages/file-system-plugin/react-native.ts
+++ b/packages/file-system-plugin/react-native.ts
@@ -26,6 +26,21 @@ const createNoopFileSystemAdapter = (
     base64: '',
   }),
   readTextFile: async () => '',
+  readFileBase64: async () => ({
+    fileName: '',
+    mime: 'application/octet-stream',
+    size: null,
+    base64: '',
+  }),
+  writeFileBase64: async (path: string): Promise<FsEntry> => ({
+    name: path,
+    path,
+    isDirectory: false,
+    size: null,
+    modifiedAtMs: null,
+    mimeTypeHint: null,
+  }),
+  pathExists: async () => false,
 });
 
 export let createExpoFileSystemAdapter: typeof import('./src/react-native/fileSystemProvider').createExpoFileSystemAdapter;

--- a/packages/file-system-plugin/react-native.ts
+++ b/packages/file-system-plugin/react-native.ts
@@ -4,6 +4,7 @@ export type {
   CreateRNFSAdapterOptions,
   FileSystemAdapter,
   FileSystemRoot,
+  FileSystemTransferConfig,
   UseFileSystemDevToolsOptions,
 } from './src/react-native/fileSystemProvider';
 

--- a/packages/file-system-plugin/sdk.ts
+++ b/packages/file-system-plugin/sdk.ts
@@ -20,6 +20,10 @@ export type {
   FileSystemListRootsArgs,
   FileSystemListRootsResult,
   FileSystemPathArgs,
+  FileSystemExportFileArgs,
+  FileSystemExportFileResult,
+  FileSystemImportFileArgs,
+  FileSystemImportFileResult,
   FileSystemReadEntryArgs,
   FileSystemReadEntryResult,
   FileSystemReadFileArgs,
@@ -30,6 +34,7 @@ export type {
 } from './src/shared/agent-tools.js';
 
 export type {
+  FileSystemAgentTransferCapabilities,
   FileSystemProvider,
   FileSystemTransferCapabilities,
   FsEntry,

--- a/packages/file-system-plugin/sdk.ts
+++ b/packages/file-system-plugin/sdk.ts
@@ -31,6 +31,7 @@ export type {
 
 export type {
   FileSystemProvider,
+  FileSystemTransferCapabilities,
   FsEntry,
   FsRoots,
 } from './src/shared/protocol.js';

--- a/packages/file-system-plugin/src/__tests__/fileSystemProvider.test.ts
+++ b/packages/file-system-plugin/src/__tests__/fileSystemProvider.test.ts
@@ -3,6 +3,7 @@ import type { FsEntry } from '../shared/protocol';
 import {
   createExpoFileSystemAdapter,
   createRNFSAdapter,
+  resolveFileTransferCapabilities,
   resolveFileSystemAdapter,
   type ExpoFileSystemLike,
   type FileSystemAdapter,
@@ -41,6 +42,15 @@ const createExpoFileSystem = (): ExpoFileSystemLike => ({
       };
     }
 
+    if (path === 'file:///documents/import.bin') {
+      return {
+        exists: true,
+        isDirectory: false,
+        size: 4,
+        modificationTime: 103,
+      };
+    }
+
     return {
       exists: true,
       isDirectory: true,
@@ -62,6 +72,7 @@ const createExpoFileSystem = (): ExpoFileSystemLike => ({
       return 'AAECAw==';
     },
   ),
+  writeAsStringAsync: vi.fn(async () => {}),
 });
 
 const createExpoModernFileSystem = (): ExpoFileSystemLike => {
@@ -75,6 +86,10 @@ const createExpoModernFileSystem = (): ExpoFileSystemLike => {
     }
 
     if (path === 'file:///documents/binary.bin') {
+      return { exists: true, isDirectory: false };
+    }
+
+    if (path === 'file:///documents/import.bin') {
       return { exists: true, isDirectory: false };
     }
 
@@ -131,6 +146,7 @@ const createExpoModernFileSystem = (): ExpoFileSystemLike => {
     async base64() {
       return this.uri.endsWith('.txt') ? 'aGVsbG8=' : 'AAECAw==';
     }
+    async write() {}
   }
 
   return {
@@ -188,6 +204,8 @@ const createRNFS = (): RNFSLike => ({
 
     return 'hello';
   }),
+  writeFile: vi.fn(async () => {}),
+  exists: vi.fn(async (path: string) => path === '/documents/hello.txt'),
 });
 
 const createCustomAdapter = (): FileSystemAdapter => ({
@@ -260,6 +278,26 @@ describe('resolveFileSystemAdapter', () => {
   });
 });
 
+describe('resolveFileTransferCapabilities', () => {
+  it('disables file transfer by default', () => {
+    expect(resolveFileTransferCapabilities()).toEqual({
+      import: false,
+      export: false,
+    });
+  });
+
+  it('enables each transfer direction explicitly', () => {
+    expect(
+      resolveFileTransferCapabilities({
+        fileTransfer: { import: true, export: true },
+      }),
+    ).toEqual({
+      import: true,
+      export: true,
+    });
+  });
+});
+
 describe('createExpoFileSystemAdapter', () => {
   it('returns expo roots and normalizes file metadata', async () => {
     const adapter = createExpoFileSystemAdapter(createExpoFileSystem());
@@ -310,6 +348,34 @@ describe('createExpoFileSystemAdapter', () => {
     ).rejects.toThrow('File is too large for preview');
   });
 
+  it('reads and writes raw files as base64', async () => {
+    const fileSystem = createExpoFileSystem();
+    const adapter = createExpoFileSystemAdapter(fileSystem);
+
+    await expect(
+      adapter.readFileBase64?.('file:///documents/binary.bin'),
+    ).resolves.toEqual({
+      fileName: 'binary.bin',
+      mime: 'application/octet-stream',
+      size: 4,
+      base64: 'AAECAw==',
+    });
+
+    await expect(
+      adapter.writeFileBase64?.('file:///documents/import.bin', 'AAECAw=='),
+    ).resolves.toMatchObject({
+      name: 'import.bin',
+      path: 'file:///documents/import.bin',
+      isDirectory: false,
+    });
+
+    expect(fileSystem.writeAsStringAsync).toHaveBeenCalledWith(
+      'file:///documents/import.bin',
+      'AAECAw==',
+      { encoding: 'base64' },
+    );
+  });
+
   it('supports the modern Expo FileSystem API', async () => {
     const adapter = createExpoFileSystemAdapter(createExpoModernFileSystem());
 
@@ -338,6 +404,19 @@ describe('createExpoFileSystemAdapter', () => {
     await expect(
       adapter.readTextFile('file:///documents/binary.bin', 10),
     ).resolves.toContain('[Binary file - 4 bytes]');
+  });
+
+  it('writes raw files through the modern Expo File API', async () => {
+    const expoFileSystem = createExpoModernFileSystem();
+    const adapter = createExpoFileSystemAdapter(expoFileSystem);
+
+    await expect(
+      adapter.writeFileBase64?.('file:///documents/import.bin', 'AAECAw=='),
+    ).resolves.toMatchObject({
+      name: 'import.bin',
+      path: 'file:///documents/import.bin',
+      isDirectory: false,
+    });
   });
 });
 
@@ -399,5 +478,33 @@ describe('createRNFSAdapter', () => {
     await expect(
       adapter.readImageBase64('/documents/hello.txt', 1),
     ).rejects.toThrow('File is too large for preview');
+  });
+
+  it('reads and writes raw files as base64', async () => {
+    const rnfs = createRNFS();
+    const adapter = createRNFSAdapter(rnfs);
+
+    await expect(adapter.readFileBase64?.('/documents/binary.bin')).resolves.toEqual(
+      {
+        fileName: 'binary.bin',
+        mime: 'application/octet-stream',
+        size: 4,
+        base64: 'AAECAw==',
+      },
+    );
+
+    await expect(
+      adapter.writeFileBase64?.('/documents/import.bin', 'AAECAw=='),
+    ).resolves.toMatchObject({
+      name: 'import.bin',
+      path: '/documents/import.bin',
+      isDirectory: false,
+    });
+
+    expect(rnfs.writeFile).toHaveBeenCalledWith(
+      '/documents/import.bin',
+      'AAECAw==',
+      'base64',
+    );
   });
 });

--- a/packages/file-system-plugin/src/__tests__/fileSystemProvider.test.ts
+++ b/packages/file-system-plugin/src/__tests__/fileSystemProvider.test.ts
@@ -283,17 +283,32 @@ describe('resolveFileTransferCapabilities', () => {
     expect(resolveFileTransferCapabilities()).toEqual({
       import: false,
       export: false,
+      agent: {
+        import: false,
+        export: false,
+      },
     });
   });
 
   it('enables each transfer direction explicitly', () => {
     expect(
       resolveFileTransferCapabilities({
-        fileTransfer: { import: true, export: true },
+        fileTransfer: {
+          import: true,
+          export: true,
+          agent: {
+            import: true,
+            export: true,
+          },
+        },
       }),
     ).toEqual({
       import: true,
       export: true,
+      agent: {
+        import: true,
+        export: true,
+      },
     });
   });
 });

--- a/packages/file-system-plugin/src/__tests__/useFileSystemAgentTools.test.ts
+++ b/packages/file-system-plugin/src/__tests__/useFileSystemAgentTools.test.ts
@@ -8,6 +8,7 @@ import type { ProviderImpl } from '../react-native/fileSystemProvider';
 import {
   createFileSystemAgentHandlers,
   fileSystemAgentTools,
+  getFileSystemAgentTools,
 } from '../react-native/useFileSystemAgentTools';
 
 const createEntry = (overrides?: Partial<FsEntry>): FsEntry => ({
@@ -41,6 +42,18 @@ const createProvider = (
     base64: 'ZmFrZQ==',
   })),
   readTextFile: vi.fn(async () => 'hello world'),
+  readFileBase64: vi.fn(async (path: string) => ({
+    fileName: path.slice(path.lastIndexOf('/') + 1),
+    mime: 'application/octet-stream',
+    size: 4,
+    base64: 'AAECAw==',
+  })),
+  writeFileBase64: vi.fn(async (path: string) => createEntry({
+    name: path.slice(path.lastIndexOf('/') + 1),
+    path,
+    size: 4,
+  })),
+  pathExists: vi.fn(async () => false),
   ...overrides,
 });
 
@@ -53,6 +66,28 @@ describe('file system agent tools', () => {
       'read-entry',
       'read-text-file',
       'read-image-file',
+      'export-file',
+      'import-file',
+    ]);
+    expect(fileSystemAgentTools.map((tool) => tool.name)).toEqual([
+      'list-roots',
+      'list-entries',
+      'read-entry',
+      'read-text-file',
+      'read-image-file',
+    ]);
+    expect(
+      getFileSystemAgentTools({ import: true, export: true }).map(
+        (tool) => tool.name,
+      ),
+    ).toEqual([
+      'list-roots',
+      'list-entries',
+      'read-entry',
+      'read-text-file',
+      'read-image-file',
+      'export-file',
+      'import-file',
     ]);
   });
 
@@ -69,7 +104,15 @@ describe('file system agent tools', () => {
     expect(fileSystemToolDefinitions.readImageFile.inputSchema.required).toEqual([
       'path',
     ]);
-    expect(fileSystemAgentTools).toEqual(Object.values(fileSystemToolDefinitions));
+    expect(fileSystemToolDefinitions.exportFile.inputSchema.required).toEqual([
+      'path',
+    ]);
+    expect(fileSystemToolDefinitions.importFile.inputSchema.required).toEqual([
+      'directoryPath',
+      'fileName',
+      'base64',
+    ]);
+    expect(fileSystemAgentTools).toEqual(getFileSystemAgentTools());
   });
 });
 
@@ -283,5 +326,223 @@ describe('createFileSystemAgentHandlers', () => {
     await expect(
       handlers.readImageFile({ path: '/tmp/photo.png', maxBytes: 100 }),
     ).rejects.toThrow('File is too large for preview');
+  });
+
+  it('rejects agent export when agent export is not enabled', async () => {
+    const provider = createProvider(undefined, [
+      createEntry({ path: 'file:///documents/sample.bin' }),
+    ]);
+    const handlers = createFileSystemAgentHandlers(async () => provider);
+
+    await expect(
+      handlers.exportFile({ path: 'file:///documents/sample.bin' }),
+    ).rejects.toThrow('Agent file export is disabled');
+  });
+
+  it('exports files through the agent when explicitly enabled', async () => {
+    const provider = createProvider(undefined, [
+      createEntry({
+        path: 'file:///documents/sample.bin',
+        name: 'sample.bin',
+        size: 4,
+      }),
+    ]);
+    const handlers = createFileSystemAgentHandlers(async () => provider, {
+      import: false,
+      export: true,
+    });
+
+    await expect(
+      handlers.exportFile({ path: 'file:///documents/sample.bin' }),
+    ).resolves.toEqual({
+      provider: 'expo',
+      path: 'file:///documents/sample.bin',
+      fileName: 'sample.bin',
+      mime: 'application/octet-stream',
+      size: 4,
+      base64: 'AAECAw==',
+      attribution: {
+        triggeredBy: 'agent',
+        pluginId: '@rozenite/file-system-plugin',
+        operation: 'export-file',
+      },
+    });
+  });
+
+  it('rejects agent export for directories and paths outside roots', async () => {
+    const provider = createProvider(undefined, [
+      createEntry({
+        path: 'file:///documents/folder/',
+        name: 'folder',
+        isDirectory: true,
+        size: null,
+      }),
+    ]);
+    const handlers = createFileSystemAgentHandlers(async () => provider, {
+      import: false,
+      export: true,
+    });
+
+    await expect(
+      handlers.exportFile({ path: 'file:///documents/folder/' }),
+    ).rejects.toThrow('is a directory, not a file');
+
+    await expect(
+      handlers.exportFile({ path: 'file:///private/sample.bin' }),
+    ).rejects.toThrow('outside the configured filesystem roots');
+  });
+
+  it('rejects agent import when agent import is not enabled', async () => {
+    const provider = createProvider();
+    const handlers = createFileSystemAgentHandlers(async () => provider);
+
+    await expect(
+      handlers.importFile({
+        directoryPath: 'file:///documents/',
+        fileName: 'sample.bin',
+        base64: 'AAECAw==',
+      }),
+    ).rejects.toThrow('Agent file import is disabled');
+  });
+
+  it('returns overwriteRequired before agent import writes', async () => {
+    const provider = createProvider(
+      {
+        pathExists: vi.fn(async () => true),
+      },
+      [
+        createEntry({
+          path: 'file:///documents/',
+          name: 'documents',
+          isDirectory: true,
+          size: null,
+        }),
+      ],
+    );
+    const handlers = createFileSystemAgentHandlers(async () => provider, {
+      import: true,
+      export: false,
+    });
+
+    await expect(
+      handlers.importFile({
+        directoryPath: 'file:///documents/',
+        fileName: 'sample.bin',
+        base64: 'AAECAw==',
+      }),
+    ).resolves.toEqual({
+      provider: 'expo',
+      directoryPath: 'file:///documents/',
+      path: 'file:///documents/sample.bin',
+      overwriteRequired: true,
+      attribution: {
+        triggeredBy: 'agent',
+        pluginId: '@rozenite/file-system-plugin',
+        operation: 'import-file',
+      },
+    });
+    expect(provider.writeFileBase64).not.toHaveBeenCalled();
+  });
+
+  it('writes agent imports only when overwrite is allowed', async () => {
+    const provider = createProvider(
+      {
+        pathExists: vi.fn(async () => true),
+      },
+      [
+        createEntry({
+          path: 'file:///documents/',
+          name: 'documents',
+          isDirectory: true,
+          size: null,
+        }),
+      ],
+    );
+    const handlers = createFileSystemAgentHandlers(async () => provider, {
+      import: true,
+      export: false,
+    });
+
+    await expect(
+      handlers.importFile({
+        directoryPath: 'file:///documents/',
+        fileName: 'sample.bin',
+        base64: 'AAECAw==',
+        overwrite: true,
+      }),
+    ).resolves.toEqual({
+      provider: 'expo',
+      directoryPath: 'file:///documents/',
+      path: 'file:///documents/sample.bin',
+      entry: {
+        name: 'sample.bin',
+        path: 'file:///documents/sample.bin',
+        isDirectory: false,
+        size: 4,
+        modifiedAtMs: 123,
+        mimeTypeHint: null,
+      },
+      attribution: {
+        triggeredBy: 'agent',
+        pluginId: '@rozenite/file-system-plugin',
+        operation: 'import-file',
+      },
+    });
+    expect(provider.writeFileBase64).toHaveBeenCalledWith(
+      'file:///documents/sample.bin',
+      'AAECAw==',
+    );
+  });
+
+  it('rejects unsafe agent import paths and file names', async () => {
+    const provider = createProvider(undefined, [
+      createEntry({
+        path: 'file:///documents/',
+        name: 'documents',
+        isDirectory: true,
+        size: null,
+      }),
+    ]);
+    const handlers = createFileSystemAgentHandlers(async () => provider, {
+      import: true,
+      export: false,
+    });
+
+    await expect(
+      handlers.importFile({
+        directoryPath: 'file:///private/',
+        fileName: 'sample.bin',
+        base64: 'AAECAw==',
+      }),
+    ).rejects.toThrow('outside the configured filesystem roots');
+
+    await expect(
+      handlers.importFile({
+        directoryPath: 'file:///documents/',
+        fileName: '../sample.bin',
+        base64: 'AAECAw==',
+      }),
+    ).rejects.toThrow('single file name');
+  });
+
+  it('surfaces agent transfer provider errors', async () => {
+    const provider = createProvider({
+      readFileBase64: vi.fn(async () => {
+        throw new Error('Permission denied');
+      }),
+    }, [
+      createEntry({
+        path: 'file:///documents/sample.bin',
+        name: 'sample.bin',
+      }),
+    ]);
+    const handlers = createFileSystemAgentHandlers(async () => provider, {
+      import: false,
+      export: true,
+    });
+
+    await expect(
+      handlers.exportFile({ path: 'file:///documents/sample.bin' }),
+    ).rejects.toThrow('Permission denied');
   });
 });

--- a/packages/file-system-plugin/src/file-system.tsx
+++ b/packages/file-system-plugin/src/file-system.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import {
   ActivityIndicator,
   FlatList,
+  Pressable,
   SafeAreaView,
   StyleSheet,
   Text,
@@ -17,6 +18,8 @@ import { TopBar } from './ui/TopBar';
 import { FileEntryRow } from './ui/FileEntryRow';
 import { DetailPanel } from './ui/DetailPanel';
 import { PathDisplay } from './ui/PathDisplay';
+import { downloadBase64File, readFileAsBase64 } from './utils';
+import type { WebPressableState } from './types';
 
 export default function FileSystemPanel() {
   const client = useRozeniteDevToolsClient<FileSystemEventMap>({
@@ -27,6 +30,9 @@ export default function FileSystemPanel() {
   const nav = useFileSystemNavigation(client, requests);
 
   const [selected, setSelected] = useState<FsEntry | null>(null);
+  const [importLoading, setImportLoading] = useState(false);
+  const [exportPath, setExportPath] = useState<string | null>(null);
+  const [transferError, setTransferError] = useState<string | null>(null);
 
   // Clear selection when the directory changes (preserves original loadDir behavior)
   useEffect(() => {
@@ -58,6 +64,127 @@ export default function FileSystemPanel() {
 
   const keyExtractor = useCallback((item: FsEntry) => item.path, []);
 
+  const importSelectedFile = useCallback(
+    async (file: File, overwrite = false) => {
+      if (!nav.currentPath) return;
+
+      setTransferError(null);
+      setImportLoading(true);
+
+      try {
+        const base64 = await readFileAsBase64(file);
+        const res = await requests.requestImportFile(
+          nav.currentPath,
+          file.name,
+          base64,
+          overwrite,
+        );
+
+        if (!res) return;
+
+        if (res.overwriteRequired) {
+          const shouldOverwrite = window.confirm(
+            `"${file.name}" already exists. Overwrite it?`,
+          );
+          if (shouldOverwrite) {
+            const overwriteRes = await requests.requestImportFile(
+              nav.currentPath,
+              file.name,
+              base64,
+              true,
+            );
+            if (overwriteRes?.error) {
+              setTransferError(overwriteRes.error);
+              return;
+            }
+            nav.onReload();
+            if (overwriteRes?.entry) {
+              setSelected(overwriteRes.entry);
+            }
+          }
+          return;
+        }
+
+        if (res.error) {
+          setTransferError(res.error);
+          return;
+        }
+
+        nav.onReload();
+        if (res.entry) {
+          setSelected(res.entry);
+        }
+      } catch (e) {
+        setTransferError(e instanceof Error ? e.message : String(e));
+      } finally {
+        setImportLoading(false);
+      }
+    },
+    [nav.currentPath, nav.onReload, requests.requestImportFile],
+  );
+
+  const onImport = useCallback(() => {
+    if (!nav.currentPath || !nav.fileTransfer.import || importLoading) return;
+
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.style.display = 'none';
+    const removeInput = () => {
+      if (input.parentNode) {
+        document.body.removeChild(input);
+      }
+    };
+    input.onchange = () => {
+      const file = input.files?.[0];
+      removeInput();
+      if (!file) return;
+      void importSelectedFile(file);
+    };
+    input.addEventListener('cancel', removeInput);
+    document.body.appendChild(input);
+    input.click();
+  }, [
+    importLoading,
+    importSelectedFile,
+    nav.currentPath,
+    nav.fileTransfer.import,
+  ]);
+
+  const onExport = useCallback(
+    async (entry: FsEntry) => {
+      if (entry.isDirectory || !nav.fileTransfer.export) return;
+
+      setTransferError(null);
+      setExportPath(entry.path);
+
+      try {
+        const res = await requests.requestExportFile(entry.path);
+        if (!res) return;
+        if (res.error) {
+          setTransferError(res.error);
+          return;
+        }
+        if (res.base64 == null || !res.fileName) {
+          setTransferError('Export did not return file contents.');
+          return;
+        }
+        const didDownload = downloadBase64File(
+          res.fileName,
+          res.base64,
+          res.mime,
+        );
+        if (!didDownload) {
+          setTransferError('Failed to download exported file.');
+        }
+      } catch (e) {
+        setTransferError(e instanceof Error ? e.message : String(e));
+      } finally {
+        setExportPath(null);
+      }
+    },
+    [nav.fileTransfer.export, requests.requestExportFile],
+  );
+
   if (!client) {
     return <ConnectingScreen />;
   }
@@ -86,12 +213,34 @@ export default function FileSystemPanel() {
               <Text style={styles.listHeaderTitle}>—</Text>
             )}
             {nav.loading ? <ActivityIndicator size="small" /> : null}
+            <Pressable
+              style={(state: WebPressableState) => [
+                styles.importButton,
+                state.hovered &&
+                  nav.fileTransfer.import &&
+                  !!nav.currentPath &&
+                  !importLoading &&
+                  styles.importButtonHovered,
+                (!nav.fileTransfer.import ||
+                  !nav.currentPath ||
+                  importLoading) &&
+                  styles.importButtonDisabled,
+              ]}
+              onPress={onImport}
+              disabled={
+                !nav.fileTransfer.import || !nav.currentPath || importLoading
+              }
+            >
+              <Text style={styles.importButtonText}>
+                {importLoading ? 'Importing…' : 'Import'}
+              </Text>
+            </Pressable>
           </View>
 
-          {nav.error ? (
+          {nav.error || transferError ? (
             <View style={styles.errorBox}>
               <Text style={styles.errorTitle}>Error</Text>
-              <Text style={styles.errorText}>{nav.error}</Text>
+              <Text style={styles.errorText}>{nav.error ?? transferError}</Text>
             </View>
           ) : null}
 
@@ -105,8 +254,15 @@ export default function FileSystemPanel() {
 
         <DetailPanel
           selected={selected}
+          canExport={
+            Boolean(selected) &&
+            !selected?.isDirectory &&
+            nav.fileTransfer.export
+          }
+          exportLoading={Boolean(selected && exportPath === selected.path)}
           requestImagePreview={requests.requestImagePreview}
           requestTextPreview={requests.requestTextPreview}
+          onExport={onExport}
         />
       </View>
     </SafeAreaView>
@@ -141,6 +297,25 @@ const styles = StyleSheet.create({
     color: '#eaeaf2',
     fontSize: 12,
     fontFamily: 'Menlo',
+  },
+  importButton: {
+    paddingHorizontal: 10,
+    paddingVertical: 7,
+    borderRadius: 8,
+    backgroundColor: '#1b1c25',
+    borderWidth: 1,
+    borderColor: '#2a2b37',
+  },
+  importButtonHovered: {
+    backgroundColor: '#252633',
+  },
+  importButtonDisabled: {
+    opacity: 0.45,
+  },
+  importButtonText: {
+    color: '#e9e9ee',
+    fontSize: 12,
+    fontWeight: '700',
   },
   listContent: {
     paddingVertical: 6,

--- a/packages/file-system-plugin/src/react-native/fileSystemProvider.ts
+++ b/packages/file-system-plugin/src/react-native/fileSystemProvider.ts
@@ -1,5 +1,6 @@
 import type {
   FileSystemProvider,
+  FileSystemAgentTransferCapabilities,
   FileSystemTransferCapabilities,
   FsEntry,
 } from '../shared/protocol';
@@ -7,6 +8,12 @@ import { joinPath, mimeTypeFromName, normalizeDirPath } from '../shared/path';
 
 export type ExpoFileSystemLike = any;
 export type RNFSLike = any;
+
+export type FileSystemTransferConfig = {
+  import?: boolean;
+  export?: boolean;
+  agent?: Partial<FileSystemAgentTransferCapabilities>;
+};
 
 export type UseFileSystemDevToolsOptions = {
   /**
@@ -27,7 +34,7 @@ export type UseFileSystemDevToolsOptions = {
    *
    * Both directions are disabled by default.
    */
-  fileTransfer?: Partial<FileSystemTransferCapabilities>;
+  fileTransfer?: FileSystemTransferConfig;
 };
 
 export type FileSystemRoot = {
@@ -71,6 +78,10 @@ export const DEFAULT_FILE_TRANSFER_CAPABILITIES: FileSystemTransferCapabilities 
   {
     import: false,
     export: false,
+    agent: {
+      import: false,
+      export: false,
+    },
   };
 
 export function resolveFileTransferCapabilities(
@@ -83,6 +94,20 @@ export function resolveFileTransferCapabilities(
     export:
       options?.fileTransfer?.export ??
       DEFAULT_FILE_TRANSFER_CAPABILITIES.export,
+    agent: resolveAgentFileTransferCapabilities(options),
+  };
+}
+
+export function resolveAgentFileTransferCapabilities(
+  options?: UseFileSystemDevToolsOptions,
+): FileSystemAgentTransferCapabilities {
+  return {
+    import:
+      options?.fileTransfer?.agent?.import ??
+      DEFAULT_FILE_TRANSFER_CAPABILITIES.agent.import,
+    export:
+      options?.fileTransfer?.agent?.export ??
+      DEFAULT_FILE_TRANSFER_CAPABILITIES.agent.export,
   };
 }
 

--- a/packages/file-system-plugin/src/react-native/fileSystemProvider.ts
+++ b/packages/file-system-plugin/src/react-native/fileSystemProvider.ts
@@ -1,4 +1,8 @@
-import type { FileSystemProvider, FsEntry } from '../shared/protocol';
+import type {
+  FileSystemProvider,
+  FileSystemTransferCapabilities,
+  FsEntry,
+} from '../shared/protocol';
 import { joinPath, mimeTypeFromName, normalizeDirPath } from '../shared/path';
 
 export type ExpoFileSystemLike = any;
@@ -18,6 +22,12 @@ export type UseFileSystemDevToolsOptions = {
    * Supports `react-native-fs` or `@dr.pogodin/react-native-fs` (same surface).
    */
   rnfs?: RNFSLike;
+  /**
+   * Enables raw file import/export transfer features.
+   *
+   * Both directions are disabled by default.
+   */
+  fileTransfer?: Partial<FileSystemTransferCapabilities>;
 };
 
 export type FileSystemRoot = {
@@ -36,6 +46,14 @@ export type FileSystemAdapter = {
     maxBytes: number,
   ) => Promise<{ mime: string; base64: string }>;
   readTextFile: (path: string, maxBytes: number) => Promise<string>;
+  readFileBase64?: (path: string) => Promise<{
+    fileName: string;
+    mime: string;
+    size: number | null;
+    base64: string;
+  }>;
+  writeFileBase64?: (path: string, base64: string) => Promise<FsEntry>;
+  pathExists?: (path: string) => Promise<boolean>;
 };
 
 export type ProviderImpl = FileSystemAdapter;
@@ -48,6 +66,25 @@ const warnedLegacyOptions = new Set<'expoFileSystem' | 'rnfs'>();
 
 const LEGACY_OPTION_WARNING =
   '[Rozenite][file-system-plugin] `expoFileSystem` and `rnfs` options are deprecated. Use `adapter: createExpoFileSystemAdapter(...)` or `adapter: createRNFSAdapter(...)` instead.';
+
+export const DEFAULT_FILE_TRANSFER_CAPABILITIES: FileSystemTransferCapabilities =
+  {
+    import: false,
+    export: false,
+  };
+
+export function resolveFileTransferCapabilities(
+  options?: UseFileSystemDevToolsOptions,
+): FileSystemTransferCapabilities {
+  return {
+    import:
+      options?.fileTransfer?.import ??
+      DEFAULT_FILE_TRANSFER_CAPABILITIES.import,
+    export:
+      options?.fileTransfer?.export ??
+      DEFAULT_FILE_TRANSFER_CAPABILITIES.export,
+  };
+}
 
 export function createExpoFileSystemAdapter(
   fileSystem: CreateExpoFileSystemAdapterOptions,
@@ -188,6 +225,31 @@ function createExpoLegacyFileSystemAdapter(
         });
         return `[Binary file - ${size} bytes]\n\n` + formatBase64AsHex(base64);
       }
+    },
+    async readFileBase64(path) {
+      const entry = await buildEntry(path);
+      if (entry.isDirectory) {
+        throw new Error(`Path "${entry.path}" is a directory, not a file.`);
+      }
+      const base64 = await FileSystem.readAsStringAsync(entry.path, {
+        encoding: 'base64',
+      });
+      return {
+        fileName: entry.name,
+        mime: entry.mimeTypeHint ?? 'application/octet-stream',
+        size: entry.size ?? null,
+        base64,
+      };
+    },
+    async writeFileBase64(path, base64) {
+      await FileSystem.writeAsStringAsync(path, base64, {
+        encoding: 'base64',
+      });
+      return buildEntry(path);
+    },
+    async pathExists(path) {
+      const info = await FileSystem.getInfoAsync(path, { size: true });
+      return Boolean(info.exists);
     },
   };
 }
@@ -336,12 +398,50 @@ function createExpoModernFileSystemAdapter(
         return `[Binary file - ${size} bytes]\n\n` + formatBase64AsHex(base64);
       }
     },
+    async readFileBase64(path) {
+      const entry = await buildEntry(path);
+      if (entry.isDirectory) {
+        throw new Error(`Path "${entry.path}" is a directory, not a file.`);
+      }
+      const file = new FileSystem.File(entry.path);
+      const base64 = await file.base64();
+      return {
+        fileName: entry.name,
+        mime: entry.mimeTypeHint ?? 'application/octet-stream',
+        size: entry.size ?? null,
+        base64,
+      };
+    },
+    async writeFileBase64(path, base64) {
+      const file = new FileSystem.File(path);
+      await file.write(base64ToBytes(base64));
+      return buildEntry(file.uri ?? path);
+    },
+    async pathExists(path) {
+      const pathInfo = await FileSystem.Paths.info(path);
+      return Boolean(pathInfo?.exists);
+    },
   };
 }
 
 export function createRNFSAdapter(
   RNFS: CreateRNFSAdapterOptions,
 ): FileSystemAdapter {
+  const buildEntry = async (path: string): Promise<FsEntry> => {
+    const normalizedPath = normalizeRnfsPath(path);
+    const stat = await RNFS.stat(normalizedPath);
+    const isDirectory = isRnfsDirectory(stat);
+
+    return {
+      name: basename(path),
+      path: isDirectory ? normalizeDirPath(normalizedPath) : normalizedPath,
+      isDirectory,
+      size: isDirectory ? null : (stat.size ?? null),
+      modifiedAtMs: stat.mtime ? new Date(stat.mtime).getTime() : null,
+      mimeTypeHint: mimeTypeFromName(normalizedPath),
+    };
+  };
+
   return {
     provider: 'rnfs',
     async getRoots() {
@@ -396,18 +496,7 @@ export function createRNFSAdapter(
       return entries;
     },
     async statPath(path) {
-      const normalizedPath = normalizeRnfsPath(path);
-      const stat = await RNFS.stat(normalizedPath);
-      const isDirectory = isRnfsDirectory(stat);
-
-      return {
-        name: basename(path),
-        path: isDirectory ? normalizeDirPath(normalizedPath) : normalizedPath,
-        isDirectory,
-        size: isDirectory ? null : (stat.size ?? null),
-        modifiedAtMs: stat.mtime ? new Date(stat.mtime).getTime() : null,
-        mimeTypeHint: mimeTypeFromName(normalizedPath),
-      };
+      return buildEntry(path);
     },
     async readImageBase64(path, maxBytes) {
       const normalizedPath = normalizeRnfsPath(path);
@@ -436,6 +525,36 @@ export function createRNFSAdapter(
       } catch {
         const base64 = await RNFS.readFile(normalizedPath, 'base64');
         return `[Binary file - ${size} bytes]\n\n` + formatBase64AsHex(base64);
+      }
+    },
+    async readFileBase64(path) {
+      const entry = await buildEntry(path);
+      if (entry.isDirectory) {
+        throw new Error(`Path "${entry.path}" is a directory, not a file.`);
+      }
+      const base64 = await RNFS.readFile(entry.path, 'base64');
+      return {
+        fileName: entry.name,
+        mime: entry.mimeTypeHint ?? 'application/octet-stream',
+        size: entry.size ?? null,
+        base64,
+      };
+    },
+    async writeFileBase64(path, base64) {
+      const normalizedPath = normalizeRnfsPath(path);
+      await RNFS.writeFile(normalizedPath, base64, 'base64');
+      return buildEntry(normalizedPath);
+    },
+    async pathExists(path) {
+      const normalizedPath = normalizeRnfsPath(path);
+      if (typeof RNFS.exists === 'function') {
+        return Boolean(await RNFS.exists(normalizedPath));
+      }
+      try {
+        await RNFS.stat(normalizedPath);
+        return true;
+      } catch {
+        return false;
       }
     },
   };
@@ -576,6 +695,26 @@ function formatBase64AsHex(base64: string): string {
   }
 
   return lines.join('\n');
+}
+
+function base64ToBytes(base64: string): Uint8Array {
+  const chars =
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+  const clean = base64.replace(/[\s=]/g, '');
+  const bytes: number[] = [];
+
+  for (let i = 0; i < clean.length; i += 4) {
+    const a = chars.indexOf(clean[i] || 'A');
+    const b = chars.indexOf(clean[i + 1] || 'A');
+    const c = chars.indexOf(clean[i + 2] || 'A');
+    const d = chars.indexOf(clean[i + 3] || 'A');
+
+    bytes.push((a << 2) | (b >> 4));
+    if (i + 2 < clean.length) bytes.push(((b & 15) << 4) | (c >> 2));
+    if (i + 3 < clean.length) bytes.push(((c & 3) << 6) | d);
+  }
+
+  return Uint8Array.from(bytes);
 }
 
 function normalizeRnfsPath(path: string): string {

--- a/packages/file-system-plugin/src/react-native/fileTransfer.ts
+++ b/packages/file-system-plugin/src/react-native/fileTransfer.ts
@@ -1,0 +1,151 @@
+import type { FsEntry } from '../shared/protocol';
+import { joinPath, normalizeDirPath } from '../shared/path';
+import type { FileSystemAdapter, FileSystemRoot } from './fileSystemProvider';
+
+export type ExportedFileTransfer = {
+  provider: FileSystemAdapter['provider'];
+  path: string;
+  fileName: string;
+  mime: string;
+  size: number | null;
+  base64: string;
+};
+
+export type ImportedFileTransfer = {
+  provider: FileSystemAdapter['provider'];
+  directoryPath: string;
+  path?: string;
+  entry?: FsEntry;
+  overwriteRequired?: boolean;
+};
+
+export async function exportFileTransfer(
+  provider: FileSystemAdapter,
+  path: string,
+): Promise<ExportedFileTransfer> {
+  if (!provider.readFileBase64) {
+    throw new Error('The active filesystem adapter does not support export.');
+  }
+
+  const roots = await provider.getRoots();
+  assertInsideRoots(path, roots);
+  const entry = await provider.statPath(path);
+
+  if (entry.isDirectory) {
+    throw new Error(`Path "${entry.path}" is a directory, not a file.`);
+  }
+
+  const file = await provider.readFileBase64(entry.path);
+
+  return {
+    provider: provider.provider,
+    path: entry.path,
+    fileName: file.fileName,
+    mime: file.mime,
+    size: file.size,
+    base64: file.base64,
+  };
+}
+
+export async function importFileTransfer(
+  provider: FileSystemAdapter,
+  {
+    directoryPath,
+    fileName,
+    base64,
+    overwrite = false,
+  }: {
+    directoryPath: string;
+    fileName: string;
+    base64: string;
+    overwrite?: boolean;
+  },
+): Promise<ImportedFileTransfer> {
+  if (!provider.writeFileBase64) {
+    throw new Error('The active filesystem adapter does not support import.');
+  }
+
+  assertSafeFileName(fileName);
+  const roots = await provider.getRoots();
+  const normalizedDirectoryPath = normalizeDirPath(directoryPath);
+  assertInsideRoots(normalizedDirectoryPath, roots);
+
+  const directory = await provider.statPath(normalizedDirectoryPath);
+  if (!directory.isDirectory) {
+    throw new Error(`Path "${directory.path}" is not a directory.`);
+  }
+
+  const destinationPath = joinPath(directory.path, fileName);
+  assertInsideRoots(destinationPath, roots);
+
+  if (!overwrite && (await pathExists(provider, destinationPath))) {
+    return {
+      provider: provider.provider,
+      directoryPath: directory.path,
+      path: destinationPath,
+      overwriteRequired: true,
+    };
+  }
+
+  const entry = await provider.writeFileBase64(destinationPath, base64);
+
+  return {
+    provider: provider.provider,
+    directoryPath: directory.path,
+    path: entry.path,
+    entry,
+  };
+}
+
+export async function pathExists(
+  provider: FileSystemAdapter,
+  path: string,
+): Promise<boolean> {
+  if (provider.pathExists) {
+    return provider.pathExists(path);
+  }
+
+  try {
+    await provider.statPath(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function assertInsideRoots(
+  path: string,
+  roots: FileSystemRoot[],
+): void {
+  if (hasTraversalSegment(path)) {
+    throw new Error('Path must not contain traversal segments.');
+  }
+
+  const isInside = roots.some((root) => {
+    const rootPath = normalizeDirPath(root.path);
+    return path === rootPath || path.startsWith(rootPath);
+  });
+
+  if (!isInside) {
+    throw new Error('Path is outside the configured filesystem roots.');
+  }
+}
+
+export function assertSafeFileName(fileName: string): void {
+  if (
+    !fileName ||
+    fileName === '.' ||
+    fileName === '..' ||
+    fileName.includes('/') ||
+    fileName.includes('\\')
+  ) {
+    throw new Error('Imported file name must be a single file name.');
+  }
+}
+
+function hasTraversalSegment(path: string): boolean {
+  return path
+    .replace(/^file:\/\//, '')
+    .split('/')
+    .some((segment) => segment === '..');
+}

--- a/packages/file-system-plugin/src/react-native/useFileSystemAgentTools.ts
+++ b/packages/file-system-plugin/src/react-native/useFileSystemAgentTools.ts
@@ -4,16 +4,21 @@ import type {
   FileSystemAdapter,
   UseFileSystemDevToolsOptions,
 } from './fileSystemProvider';
-import { resolveFileSystemAdapter } from './fileSystemProvider';
+import {
+  resolveAgentFileTransferCapabilities,
+  resolveFileSystemAdapter,
+} from './fileSystemProvider';
+import { exportFileTransfer, importFileTransfer } from './fileTransfer';
 import {
   FILE_SYSTEM_AGENT_PLUGIN_ID,
   fileSystemToolDefinitions,
+  type FileSystemExportFileArgs,
+  type FileSystemImportFileArgs,
   type FileSystemListEntriesArgs,
   type FileSystemPathArgs,
   type FileSystemReadFileArgs,
 } from '../shared/agent-tools';
-
-export const fileSystemAgentTools = Object.values(fileSystemToolDefinitions);
+import type { FileSystemAgentTransferCapabilities } from '../shared/protocol';
 
 const getProviderOrThrow = async (
   resolveProvider: () => Promise<FileSystemAdapter | null>,
@@ -27,8 +32,46 @@ const getProviderOrThrow = async (
   return provider;
 };
 
+const createAttribution = (operation: 'export-file' | 'import-file') => ({
+  triggeredBy: 'agent' as const,
+  pluginId: FILE_SYSTEM_AGENT_PLUGIN_ID,
+  operation,
+});
+
+const assertAgentTransferEnabled = (
+  capabilities: FileSystemAgentTransferCapabilities,
+  operation: keyof FileSystemAgentTransferCapabilities,
+): void => {
+  if (!capabilities[operation]) {
+    throw new Error(
+      `Agent file ${operation} is disabled. Enable \`fileTransfer.agent.${operation}\` in \`useFileSystemDevTools()\`.`,
+    );
+  }
+};
+
+export const getFileSystemAgentTools = (
+  capabilities: FileSystemAgentTransferCapabilities = {
+    import: false,
+    export: false,
+  },
+) => [
+  fileSystemToolDefinitions.listRoots,
+  fileSystemToolDefinitions.listEntries,
+  fileSystemToolDefinitions.readEntry,
+  fileSystemToolDefinitions.readTextFile,
+  fileSystemToolDefinitions.readImageFile,
+  ...(capabilities.export ? [fileSystemToolDefinitions.exportFile] : []),
+  ...(capabilities.import ? [fileSystemToolDefinitions.importFile] : []),
+];
+
+export const fileSystemAgentTools = getFileSystemAgentTools();
+
 export const createFileSystemAgentHandlers = (
   resolveProvider: () => Promise<FileSystemAdapter | null>,
+  agentFileTransfer: FileSystemAgentTransferCapabilities = {
+    import: false,
+    export: false,
+  },
 ) => ({
   listRoots: async () => {
     const provider = await resolveProvider();
@@ -117,6 +160,38 @@ export const createFileSystemAgentHandlers = (
       dataUri: `data:${preview.mime};base64,${preview.base64}`,
     };
   },
+
+  exportFile: async ({ path }: FileSystemExportFileArgs) => {
+    assertAgentTransferEnabled(agentFileTransfer, 'export');
+    const provider = await getProviderOrThrow(resolveProvider);
+    const result = await exportFileTransfer(provider, path);
+
+    return {
+      ...result,
+      attribution: createAttribution('export-file'),
+    };
+  },
+
+  importFile: async ({
+    directoryPath,
+    fileName,
+    base64,
+    overwrite,
+  }: FileSystemImportFileArgs) => {
+    assertAgentTransferEnabled(agentFileTransfer, 'import');
+    const provider = await getProviderOrThrow(resolveProvider);
+    const result = await importFileTransfer(provider, {
+      directoryPath,
+      fileName,
+      base64,
+      overwrite,
+    });
+
+    return {
+      ...result,
+      attribution: createAttribution('import-file'),
+    };
+  },
 });
 
 export const useFileSystemAgentTools = (
@@ -126,8 +201,12 @@ export const useFileSystemAgentTools = (
     () => resolveFileSystemAdapter(options),
     [options?.adapter, options?.expoFileSystem, options?.rnfs],
   );
+  const agentFileTransfer = resolveAgentFileTransferCapabilities(options);
 
-  const handlers = createFileSystemAgentHandlers(resolveProvider);
+  const handlers = createFileSystemAgentHandlers(
+    resolveProvider,
+    agentFileTransfer,
+  );
 
   useRozenitePluginAgentTool({
     pluginId: FILE_SYSTEM_AGENT_PLUGIN_ID,
@@ -157,5 +236,19 @@ export const useFileSystemAgentTools = (
     pluginId: FILE_SYSTEM_AGENT_PLUGIN_ID,
     tool: fileSystemToolDefinitions.readImageFile,
     handler: handlers.readImageFile,
+  });
+
+  useRozenitePluginAgentTool({
+    pluginId: FILE_SYSTEM_AGENT_PLUGIN_ID,
+    tool: fileSystemToolDefinitions.exportFile,
+    handler: handlers.exportFile,
+    enabled: agentFileTransfer.export,
+  });
+
+  useRozenitePluginAgentTool({
+    pluginId: FILE_SYSTEM_AGENT_PLUGIN_ID,
+    tool: fileSystemToolDefinitions.importFile,
+    handler: handlers.importFile,
+    enabled: agentFileTransfer.import,
   });
 };

--- a/packages/file-system-plugin/src/react-native/useFileSystemDevTools.ts
+++ b/packages/file-system-plugin/src/react-native/useFileSystemDevTools.ts
@@ -2,9 +2,13 @@ import { useEffect, useRef } from 'react';
 import { useRozeniteDevToolsClient } from '@rozenite/plugin-bridge';
 import type { FileSystemEventMap } from '../shared/protocol';
 import { PLUGIN_ID } from '../shared/protocol';
+import { joinPath, normalizeDirPath } from '../shared/path';
 import {
   resolveFileSystemAdapter,
+  resolveFileTransferCapabilities,
   safeError,
+  type FileSystemAdapter,
+  type FileSystemRoot,
   type UseFileSystemDevToolsOptions,
 } from './fileSystemProvider';
 import { useFileSystemAgentTools } from './useFileSystemAgentTools';
@@ -15,6 +19,7 @@ export const useFileSystemDevTools = (
   options?: UseFileSystemDevToolsOptions,
 ) => {
   useFileSystemAgentTools(options);
+  const fileTransfer = resolveFileTransferCapabilities(options);
 
   const client = useRozeniteDevToolsClient<FileSystemEventMap>({
     pluginId: PLUGIN_ID,
@@ -35,6 +40,7 @@ export const useFileSystemDevTools = (
             client.send('fs:get-roots:result', {
               requestId,
               provider: 'none',
+              fileTransfer,
               roots: [],
               error:
                 'No filesystem provider detected. Pass `adapter: createExpoFileSystemAdapter(FileSystem)` or `adapter: createRNFSAdapter(RNFS)` to `useFileSystemDevTools()`.',
@@ -46,12 +52,14 @@ export const useFileSystemDevTools = (
           client.send('fs:get-roots:result', {
             requestId,
             provider: provider.provider,
+            fileTransfer,
             roots,
           });
         } catch (e) {
           client.send('fs:get-roots:result', {
             requestId,
             provider: 'none',
+            fileTransfer,
             roots: [],
             error: safeError(e),
           });
@@ -177,9 +185,212 @@ export const useFileSystemDevTools = (
       ),
     );
 
+    subsRef.current.push(
+      client.onMessage('fs:export-file', async ({ requestId, path }) => {
+        try {
+          if (!fileTransfer.export) {
+            client.send('fs:export-file:result', {
+              requestId,
+              provider: 'none',
+              path,
+              error:
+                'File export is disabled. Enable `fileTransfer.export` in `useFileSystemDevTools()`.',
+            });
+            return;
+          }
+
+          const provider = await resolveFileSystemAdapter(options);
+          if (!provider) {
+            client.send('fs:export-file:result', {
+              requestId,
+              provider: 'none',
+              path,
+              error:
+                'No filesystem provider detected. Pass `adapter: createExpoFileSystemAdapter(FileSystem)` or `adapter: createRNFSAdapter(RNFS)` to `useFileSystemDevTools()`.',
+            });
+            return;
+          }
+
+          if (!provider.readFileBase64) {
+            client.send('fs:export-file:result', {
+              requestId,
+              provider: provider.provider,
+              path,
+              error: 'The active filesystem adapter does not support export.',
+            });
+            return;
+          }
+
+          const roots = await provider.getRoots();
+          assertInsideRoots(path, roots);
+          const entry = await provider.statPath(path);
+          if (entry.isDirectory) {
+            throw new Error(`Path "${entry.path}" is a directory, not a file.`);
+          }
+
+          const file = await provider.readFileBase64(entry.path);
+          client.send('fs:export-file:result', {
+            requestId,
+            provider: provider.provider,
+            path: entry.path,
+            fileName: file.fileName,
+            mime: file.mime,
+            size: file.size,
+            base64: file.base64,
+          });
+        } catch (e) {
+          const provider = await resolveFileSystemAdapter(options);
+          client.send('fs:export-file:result', {
+            requestId,
+            provider: provider?.provider ?? 'none',
+            path,
+            error: safeError(e),
+          });
+        }
+      }),
+    );
+
+    subsRef.current.push(
+      client.onMessage(
+        'fs:import-file',
+        async ({ requestId, directoryPath, fileName, base64, overwrite }) => {
+          try {
+            if (!fileTransfer.import) {
+              client.send('fs:import-file:result', {
+                requestId,
+                provider: 'none',
+                directoryPath,
+                error:
+                  'File import is disabled. Enable `fileTransfer.import` in `useFileSystemDevTools()`.',
+              });
+              return;
+            }
+
+            const provider = await resolveFileSystemAdapter(options);
+            if (!provider) {
+              client.send('fs:import-file:result', {
+                requestId,
+                provider: 'none',
+                directoryPath,
+                error:
+                  'No filesystem provider detected. Pass `adapter: createExpoFileSystemAdapter(FileSystem)` or `adapter: createRNFSAdapter(RNFS)` to `useFileSystemDevTools()`.',
+              });
+              return;
+            }
+
+            if (!provider.writeFileBase64) {
+              client.send('fs:import-file:result', {
+                requestId,
+                provider: provider.provider,
+                directoryPath,
+                error: 'The active filesystem adapter does not support import.',
+              });
+              return;
+            }
+
+            assertSafeFileName(fileName);
+            const roots = await provider.getRoots();
+            const normalizedDirectoryPath = normalizeDirPath(directoryPath);
+            assertInsideRoots(normalizedDirectoryPath, roots);
+
+            const directory = await provider.statPath(normalizedDirectoryPath);
+            if (!directory.isDirectory) {
+              throw new Error(
+                `Path "${directory.path}" is not a directory.`,
+              );
+            }
+
+            const destinationPath = joinPath(directory.path, fileName);
+            assertInsideRoots(destinationPath, roots);
+
+            if (!overwrite && (await pathExists(provider, destinationPath))) {
+              client.send('fs:import-file:result', {
+                requestId,
+                provider: provider.provider,
+                directoryPath: directory.path,
+                path: destinationPath,
+                overwriteRequired: true,
+              });
+              return;
+            }
+
+            const entry = await provider.writeFileBase64(
+              destinationPath,
+              base64,
+            );
+            client.send('fs:import-file:result', {
+              requestId,
+              provider: provider.provider,
+              directoryPath: directory.path,
+              path: entry.path,
+              entry,
+            });
+          } catch (e) {
+            const provider = await resolveFileSystemAdapter(options);
+            client.send('fs:import-file:result', {
+              requestId,
+              provider: provider?.provider ?? 'none',
+              directoryPath,
+              error: safeError(e),
+            });
+          }
+        },
+      ),
+    );
+
     return () => {
       subsRef.current.forEach((s) => s.remove());
       subsRef.current = [];
     };
-  }, [client, options]);
+  }, [client, fileTransfer.export, fileTransfer.import, options]);
 };
+
+async function pathExists(
+  provider: FileSystemAdapter,
+  path: string,
+): Promise<boolean> {
+  if (provider.pathExists) {
+    return provider.pathExists(path);
+  }
+
+  try {
+    await provider.statPath(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function assertInsideRoots(path: string, roots: FileSystemRoot[]): void {
+  if (hasTraversalSegment(path)) {
+    throw new Error('Path must not contain traversal segments.');
+  }
+
+  const isInside = roots.some((root) => {
+    const rootPath = normalizeDirPath(root.path);
+    return path === rootPath || path.startsWith(rootPath);
+  });
+
+  if (!isInside) {
+    throw new Error('Path is outside the configured filesystem roots.');
+  }
+}
+
+function hasTraversalSegment(path: string): boolean {
+  return path
+    .replace(/^file:\/\//, '')
+    .split('/')
+    .some((segment) => segment === '..');
+}
+
+function assertSafeFileName(fileName: string): void {
+  if (
+    !fileName ||
+    fileName === '.' ||
+    fileName === '..' ||
+    fileName.includes('/') ||
+    fileName.includes('\\')
+  ) {
+    throw new Error('Imported file name must be a single file name.');
+  }
+}

--- a/packages/file-system-plugin/src/react-native/useFileSystemDevTools.ts
+++ b/packages/file-system-plugin/src/react-native/useFileSystemDevTools.ts
@@ -2,15 +2,13 @@ import { useEffect, useRef } from 'react';
 import { useRozeniteDevToolsClient } from '@rozenite/plugin-bridge';
 import type { FileSystemEventMap } from '../shared/protocol';
 import { PLUGIN_ID } from '../shared/protocol';
-import { joinPath, normalizeDirPath } from '../shared/path';
 import {
   resolveFileSystemAdapter,
   resolveFileTransferCapabilities,
   safeError,
-  type FileSystemAdapter,
-  type FileSystemRoot,
   type UseFileSystemDevToolsOptions,
 } from './fileSystemProvider';
+import { exportFileTransfer, importFileTransfer } from './fileTransfer';
 import { useFileSystemAgentTools } from './useFileSystemAgentTools';
 
 export type { UseFileSystemDevToolsOptions } from './fileSystemProvider';
@@ -211,28 +209,11 @@ export const useFileSystemDevTools = (
             return;
           }
 
-          if (!provider.readFileBase64) {
-            client.send('fs:export-file:result', {
-              requestId,
-              provider: provider.provider,
-              path,
-              error: 'The active filesystem adapter does not support export.',
-            });
-            return;
-          }
-
-          const roots = await provider.getRoots();
-          assertInsideRoots(path, roots);
-          const entry = await provider.statPath(path);
-          if (entry.isDirectory) {
-            throw new Error(`Path "${entry.path}" is a directory, not a file.`);
-          }
-
-          const file = await provider.readFileBase64(entry.path);
+          const file = await exportFileTransfer(provider, path);
           client.send('fs:export-file:result', {
             requestId,
-            provider: provider.provider,
-            path: entry.path,
+            provider: file.provider,
+            path: file.path,
             fileName: file.fileName,
             mime: file.mime,
             size: file.size,
@@ -278,52 +259,30 @@ export const useFileSystemDevTools = (
               return;
             }
 
-            if (!provider.writeFileBase64) {
+            const result = await importFileTransfer(provider, {
+              directoryPath,
+              fileName,
+              base64,
+              overwrite,
+            });
+
+            if (result.overwriteRequired) {
               client.send('fs:import-file:result', {
                 requestId,
-                provider: provider.provider,
-                directoryPath,
-                error: 'The active filesystem adapter does not support import.',
-              });
-              return;
-            }
-
-            assertSafeFileName(fileName);
-            const roots = await provider.getRoots();
-            const normalizedDirectoryPath = normalizeDirPath(directoryPath);
-            assertInsideRoots(normalizedDirectoryPath, roots);
-
-            const directory = await provider.statPath(normalizedDirectoryPath);
-            if (!directory.isDirectory) {
-              throw new Error(
-                `Path "${directory.path}" is not a directory.`,
-              );
-            }
-
-            const destinationPath = joinPath(directory.path, fileName);
-            assertInsideRoots(destinationPath, roots);
-
-            if (!overwrite && (await pathExists(provider, destinationPath))) {
-              client.send('fs:import-file:result', {
-                requestId,
-                provider: provider.provider,
-                directoryPath: directory.path,
-                path: destinationPath,
+                provider: result.provider,
+                directoryPath: result.directoryPath,
+                path: result.path,
                 overwriteRequired: true,
               });
               return;
             }
 
-            const entry = await provider.writeFileBase64(
-              destinationPath,
-              base64,
-            );
             client.send('fs:import-file:result', {
               requestId,
-              provider: provider.provider,
-              directoryPath: directory.path,
-              path: entry.path,
-              entry,
+              provider: result.provider,
+              directoryPath: result.directoryPath,
+              path: result.path,
+              entry: result.entry,
             });
           } catch (e) {
             const provider = await resolveFileSystemAdapter(options);
@@ -344,53 +303,3 @@ export const useFileSystemDevTools = (
     };
   }, [client, fileTransfer.export, fileTransfer.import, options]);
 };
-
-async function pathExists(
-  provider: FileSystemAdapter,
-  path: string,
-): Promise<boolean> {
-  if (provider.pathExists) {
-    return provider.pathExists(path);
-  }
-
-  try {
-    await provider.statPath(path);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function assertInsideRoots(path: string, roots: FileSystemRoot[]): void {
-  if (hasTraversalSegment(path)) {
-    throw new Error('Path must not contain traversal segments.');
-  }
-
-  const isInside = roots.some((root) => {
-    const rootPath = normalizeDirPath(root.path);
-    return path === rootPath || path.startsWith(rootPath);
-  });
-
-  if (!isInside) {
-    throw new Error('Path is outside the configured filesystem roots.');
-  }
-}
-
-function hasTraversalSegment(path: string): boolean {
-  return path
-    .replace(/^file:\/\//, '')
-    .split('/')
-    .some((segment) => segment === '..');
-}
-
-function assertSafeFileName(fileName: string): void {
-  if (
-    !fileName ||
-    fileName === '.' ||
-    fileName === '..' ||
-    fileName.includes('/') ||
-    fileName.includes('\\')
-  ) {
-    throw new Error('Imported file name must be a single file name.');
-  }
-}

--- a/packages/file-system-plugin/src/shared/agent-tools.ts
+++ b/packages/file-system-plugin/src/shared/agent-tools.ts
@@ -64,6 +64,40 @@ export type FileSystemReadImageFileResult = {
   dataUri: string;
 };
 
+export type FileSystemAgentTransferAttribution = {
+  triggeredBy: 'agent';
+  pluginId: typeof FILE_SYSTEM_AGENT_PLUGIN_ID;
+  operation: 'export-file' | 'import-file';
+};
+
+export type FileSystemExportFileArgs = FileSystemPathArgs;
+
+export type FileSystemExportFileResult = {
+  provider: FileSystemProvider;
+  path: string;
+  fileName: string;
+  mime: string;
+  size: number | null;
+  base64: string;
+  attribution: FileSystemAgentTransferAttribution;
+};
+
+export type FileSystemImportFileArgs = {
+  directoryPath: string;
+  fileName: string;
+  base64: string;
+  overwrite?: boolean;
+};
+
+export type FileSystemImportFileResult = {
+  provider: FileSystemProvider;
+  directoryPath: string;
+  path?: string;
+  entry?: FsEntry;
+  overwriteRequired?: boolean;
+  attribution: FileSystemAgentTransferAttribution;
+};
+
 export const fileSystemToolDefinitions = {
   listRoots: defineAgentToolContract<
     FileSystemListRootsArgs,
@@ -164,6 +198,57 @@ export const fileSystemToolDefinitions = {
         },
       },
       required: ['path'],
+    },
+  }),
+  exportFile: defineAgentToolContract<
+    FileSystemExportFileArgs,
+    FileSystemExportFileResult
+  >({
+    name: 'export-file',
+    description:
+      'Agent-triggered raw file export. Reads a single file under a configured filesystem root and returns exact base64 contents. This tool is registered only when agent export is explicitly enabled.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+          description: 'Absolute or provider-root-qualified file path.',
+        },
+      },
+      required: ['path'],
+    },
+  }),
+  importFile: defineAgentToolContract<
+    FileSystemImportFileArgs,
+    FileSystemImportFileResult
+  >({
+    name: 'import-file',
+    description:
+      'Agent-triggered raw file import. Writes a single base64-encoded file into an existing directory under a configured filesystem root. This tool is registered only when agent import is explicitly enabled.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        directoryPath: {
+          type: 'string',
+          description:
+            'Absolute or provider-root-qualified existing directory path.',
+        },
+        fileName: {
+          type: 'string',
+          description:
+            'Destination file name only. Path separators and traversal are rejected.',
+        },
+        base64: {
+          type: 'string',
+          description: 'Exact file contents encoded as base64.',
+        },
+        overwrite: {
+          type: 'boolean',
+          description:
+            'Set to true to overwrite an existing destination file after an overwriteRequired response.',
+        },
+      },
+      required: ['directoryPath', 'fileName', 'base64'],
     },
   }),
 } as const satisfies Record<string, AgentToolContract<unknown, unknown>>;

--- a/packages/file-system-plugin/src/shared/optional-modules.d.ts
+++ b/packages/file-system-plugin/src/shared/optional-modules.d.ts
@@ -20,6 +20,11 @@ declare module 'expo-file-system' {
     uri: string,
     options?: { encoding?: 'base64' | 'utf8' },
   ): Promise<string>;
+  export function writeAsStringAsync(
+    uri: string,
+    contents: string,
+    options?: { encoding?: 'base64' | 'utf8' },
+  ): Promise<void>;
 }
 
 declare module 'react-native-fs' {
@@ -49,6 +54,12 @@ declare module 'react-native-fs' {
     path: string,
     encoding: 'base64' | 'utf8',
   ): Promise<string>;
+  export function writeFile(
+    path: string,
+    contents: string,
+    encoding: 'base64' | 'utf8',
+  ): Promise<void>;
+  export function exists(path: string): Promise<boolean>;
 }
 
 declare module '@birdofpreyru/react-native-fs' {

--- a/packages/file-system-plugin/src/shared/protocol.ts
+++ b/packages/file-system-plugin/src/shared/protocol.ts
@@ -24,6 +24,12 @@ export type FsRoots = {
 export type FileSystemTransferCapabilities = {
   import: boolean;
   export: boolean;
+  agent: FileSystemAgentTransferCapabilities;
+};
+
+export type FileSystemAgentTransferCapabilities = {
+  import: boolean;
+  export: boolean;
 };
 
 export type FileSystemEventMap = {

--- a/packages/file-system-plugin/src/shared/protocol.ts
+++ b/packages/file-system-plugin/src/shared/protocol.ts
@@ -13,11 +13,17 @@ export type FsEntry = {
 
 export type FsRoots = {
   provider: FileSystemProvider;
+  fileTransfer?: FileSystemTransferCapabilities;
   roots: Array<{
     id: string;
     label: string;
     path: string;
   }>;
+};
+
+export type FileSystemTransferCapabilities = {
+  import: boolean;
+  export: boolean;
 };
 
 export type FileSystemEventMap = {
@@ -59,6 +65,38 @@ export type FileSystemEventMap = {
     provider: FileSystemProvider;
     path: string;
     content?: string;
+    error?: string;
+  };
+
+  "fs:export-file": {
+    requestId: string;
+    path: string;
+  };
+  "fs:export-file:result": {
+    requestId: string;
+    provider: FileSystemProvider;
+    path: string;
+    fileName?: string;
+    mime?: string;
+    size?: number | null;
+    base64?: string;
+    error?: string;
+  };
+
+  "fs:import-file": {
+    requestId: string;
+    directoryPath: string;
+    fileName: string;
+    base64: string;
+    overwrite?: boolean;
+  };
+  "fs:import-file:result": {
+    requestId: string;
+    provider: FileSystemProvider;
+    directoryPath: string;
+    path?: string;
+    entry?: FsEntry;
+    overwriteRequired?: boolean;
     error?: string;
   };
 };

--- a/packages/file-system-plugin/src/ui/DetailPanel.tsx
+++ b/packages/file-system-plugin/src/ui/DetailPanel.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import {
   ActivityIndicator,
   Image,
+  Pressable,
   ScrollView,
   StyleSheet,
   Text,
@@ -14,19 +15,26 @@ import { formatTextPreview } from '../formatters';
 import { DetailLine } from './DetailLine';
 import { PathDisplay } from './PathDisplay';
 import type { useFileSystemRequests } from '../use-file-system-requests';
+import type { WebPressableState } from '../types';
 
 type FileSystemRequests = ReturnType<typeof useFileSystemRequests>;
 
 type DetailPanelProps = {
   selected: FsEntry | null;
+  canExport: boolean;
+  exportLoading: boolean;
   requestImagePreview: FileSystemRequests['requestImagePreview'];
   requestTextPreview: FileSystemRequests['requestTextPreview'];
+  onExport: (entry: FsEntry) => void;
 };
 
 export function DetailPanel({
   selected,
+  canExport,
+  exportLoading,
   requestImagePreview,
   requestTextPreview,
+  onExport,
 }: DetailPanelProps) {
   const [imagePreviewUri, setImagePreviewUri] = useState<string | null>(null);
   const [imagePreviewError, setImagePreviewError] = useState<string | null>(
@@ -113,6 +121,22 @@ export function DetailPanel({
           <Text style={styles.detailName} numberOfLines={2}>
             {selected.name}
           </Text>
+          <Pressable
+            style={(state: WebPressableState) => [
+              styles.exportButton,
+              state.hovered &&
+                canExport &&
+                !exportLoading &&
+                styles.exportButtonHovered,
+              (!canExport || exportLoading) && styles.exportButtonDisabled,
+            ]}
+            onPress={() => onExport(selected)}
+            disabled={!canExport || exportLoading}
+          >
+            <Text style={styles.exportButtonText}>
+              {exportLoading ? 'Exporting…' : 'Export'}
+            </Text>
+          </Pressable>
           <PathDisplay path={selected.path} />
           <View style={styles.detailGrid}>
             <DetailLine
@@ -212,6 +236,26 @@ const styles = StyleSheet.create({
   detailName: {
     color: '#f2f2f2',
     fontSize: 13,
+    fontWeight: '700',
+  },
+  exportButton: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: 10,
+    paddingVertical: 7,
+    borderRadius: 8,
+    backgroundColor: '#1b1c25',
+    borderWidth: 1,
+    borderColor: '#2a2b37',
+  },
+  exportButtonHovered: {
+    backgroundColor: '#252633',
+  },
+  exportButtonDisabled: {
+    opacity: 0.45,
+  },
+  exportButtonText: {
+    color: '#e9e9ee',
+    fontSize: 12,
     fontWeight: '700',
   },
   detailGrid: {

--- a/packages/file-system-plugin/src/use-file-system-navigation.ts
+++ b/packages/file-system-plugin/src/use-file-system-navigation.ts
@@ -21,6 +21,10 @@ export function useFileSystemNavigation(
     useState<FileSystemTransferCapabilities>({
       import: false,
       export: false,
+      agent: {
+        import: false,
+        export: false,
+      },
     });
   const [roots, setRoots] = useState<FsRoots['roots']>([]);
   const [pathInput, setPathInput] = useState('');
@@ -35,7 +39,16 @@ export function useFileSystemNavigation(
     const res = await requests.requestRoots();
     if (!res) return;
     setProvider(res.provider);
-    setFileTransfer(res.fileTransfer ?? { import: false, export: false });
+    setFileTransfer(
+      res.fileTransfer ?? {
+        import: false,
+        export: false,
+        agent: {
+          import: false,
+          export: false,
+        },
+      },
+    );
     if (res.error) {
       setRoots([]);
       setError(res.error);
@@ -96,7 +109,14 @@ export function useFileSystemNavigation(
     const subReady = client.onMessage('fs:ready', async () => {
       // Reset UI state on reconnect
       setProvider('none');
-      setFileTransfer({ import: false, export: false });
+      setFileTransfer({
+        import: false,
+        export: false,
+        agent: {
+          import: false,
+          export: false,
+        },
+      });
       setRoots([]);
       setEntries([]);
       setError(null);

--- a/packages/file-system-plugin/src/use-file-system-navigation.ts
+++ b/packages/file-system-plugin/src/use-file-system-navigation.ts
@@ -3,6 +3,7 @@ import type { RozeniteDevToolsClient } from '@rozenite/plugin-bridge';
 import type {
   FileSystemEventMap,
   FileSystemProvider,
+  FileSystemTransferCapabilities,
   FsEntry,
   FsRoots,
 } from './shared/protocol';
@@ -16,6 +17,11 @@ export function useFileSystemNavigation(
   requests: FileSystemRequests,
 ) {
   const [provider, setProvider] = useState<FileSystemProvider>('none');
+  const [fileTransfer, setFileTransfer] =
+    useState<FileSystemTransferCapabilities>({
+      import: false,
+      export: false,
+    });
   const [roots, setRoots] = useState<FsRoots['roots']>([]);
   const [pathInput, setPathInput] = useState('');
   const [currentPath, setCurrentPath] = useState('');
@@ -29,6 +35,7 @@ export function useFileSystemNavigation(
     const res = await requests.requestRoots();
     if (!res) return;
     setProvider(res.provider);
+    setFileTransfer(res.fileTransfer ?? { import: false, export: false });
     if (res.error) {
       setRoots([]);
       setError(res.error);
@@ -89,6 +96,7 @@ export function useFileSystemNavigation(
     const subReady = client.onMessage('fs:ready', async () => {
       // Reset UI state on reconnect
       setProvider('none');
+      setFileTransfer({ import: false, export: false });
       setRoots([]);
       setEntries([]);
       setError(null);
@@ -140,6 +148,7 @@ export function useFileSystemNavigation(
 
   return {
     provider,
+    fileTransfer,
     roots,
     pathInput,
     setPathInput,

--- a/packages/file-system-plugin/src/use-file-system-requests.ts
+++ b/packages/file-system-plugin/src/use-file-system-requests.ts
@@ -17,6 +17,14 @@ type PendingResolvers = {
     string,
     (payload: FileSystemEventMap['fs:read-file:result']) => void
   >;
+  exportFile: Map<
+    string,
+    (payload: FileSystemEventMap['fs:export-file:result']) => void
+  >;
+  importFile: Map<
+    string,
+    (payload: FileSystemEventMap['fs:import-file:result']) => void
+  >;
 };
 
 export function useFileSystemRequests(
@@ -27,6 +35,8 @@ export function useFileSystemRequests(
     list: new Map(),
     image: new Map(),
     file: new Map(),
+    exportFile: new Map(),
+    importFile: new Map(),
   });
 
   useEffect(() => {
@@ -64,11 +74,35 @@ export function useFileSystemRequests(
       }
     });
 
+    const subExportFile = client.onMessage(
+      'fs:export-file:result',
+      (payload) => {
+        const resolve = pendingRef.current.exportFile.get(payload.requestId);
+        if (resolve) {
+          pendingRef.current.exportFile.delete(payload.requestId);
+          resolve(payload);
+        }
+      },
+    );
+
+    const subImportFile = client.onMessage(
+      'fs:import-file:result',
+      (payload) => {
+        const resolve = pendingRef.current.importFile.get(payload.requestId);
+        if (resolve) {
+          pendingRef.current.importFile.delete(payload.requestId);
+          resolve(payload);
+        }
+      },
+    );
+
     return () => {
       subRoots.remove();
       subList.remove();
       subImage.remove();
       subFile.remove();
+      subExportFile.remove();
+      subImportFile.remove();
     };
   }, [client]);
 
@@ -127,5 +161,53 @@ export function useFileSystemRequests(
     [client],
   );
 
-  return { requestRoots, requestList, requestImagePreview, requestTextPreview };
+  const requestExportFile = useCallback(
+    async (path: string) => {
+      if (!client) return null;
+      const requestId = newRequestId();
+      const p = new Promise<FileSystemEventMap['fs:export-file:result']>(
+        (resolve) => {
+          pendingRef.current.exportFile.set(requestId, resolve);
+        },
+      );
+      client.send('fs:export-file', { requestId, path });
+      return await withTimeout(p, 30000, 'Timeout exporting file');
+    },
+    [client],
+  );
+
+  const requestImportFile = useCallback(
+    async (
+      directoryPath: string,
+      fileName: string,
+      base64: string,
+      overwrite = false,
+    ) => {
+      if (!client) return null;
+      const requestId = newRequestId();
+      const p = new Promise<FileSystemEventMap['fs:import-file:result']>(
+        (resolve) => {
+          pendingRef.current.importFile.set(requestId, resolve);
+        },
+      );
+      client.send('fs:import-file', {
+        requestId,
+        directoryPath,
+        fileName,
+        base64,
+        overwrite,
+      });
+      return await withTimeout(p, 30000, 'Timeout importing file');
+    },
+    [client],
+  );
+
+  return {
+    requestRoots,
+    requestList,
+    requestImagePreview,
+    requestTextPreview,
+    requestExportFile,
+    requestImportFile,
+  };
 }

--- a/packages/file-system-plugin/src/utils.ts
+++ b/packages/file-system-plugin/src/utils.ts
@@ -60,3 +60,50 @@ export function copyToClipboard(text: string): boolean {
     return false;
   }
 }
+
+export function downloadBase64File(
+  fileName: string,
+  base64: string,
+  mime = 'application/octet-stream',
+): boolean {
+  try {
+    const blob = new Blob([base64ToBytes(base64)], { type: mime });
+    const objectUrl = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = objectUrl;
+    anchor.download = fileName;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(objectUrl);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function readFileAsBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(new Error('Failed to read selected file.'));
+    reader.onload = () => {
+      const result = reader.result;
+      if (typeof result !== 'string') {
+        reject(new Error('Failed to read selected file.'));
+        return;
+      }
+      const commaIndex = result.indexOf(',');
+      resolve(commaIndex >= 0 ? result.slice(commaIndex + 1) : result);
+    };
+    reader.readAsDataURL(file);
+  });
+}
+
+function base64ToBytes(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+}

--- a/website/src/docs/official-plugins/file-system.mdx
+++ b/website/src/docs/official-plugins/file-system.mdx
@@ -13,6 +13,7 @@ The File System plugin helps you browse the files your app can access at runtime
 - **Text Preview**: Open text files directly in DevTools
 - **Image Preview**: Preview image files inline
 - **Binary Fallback Preview**: Show a hex-style dump when a file cannot be decoded as text
+- **File Transfer**: Import and export single files through explicit opt-in workflows
 - **Path Navigation**: Jump between roots, navigate nested folders, and move back through history
 
 ## Installation
@@ -23,7 +24,7 @@ Install the File System plugin:
 
 <PackageManagerTabs command="install -D @rozenite/file-system-plugin" />
 
-a Install one supported filesystem provider in your app:
+Install one supported filesystem provider in your app:
 
 <PackageManagerTabs command="install -D expo-file-system" />
 
@@ -69,6 +70,38 @@ function App() {
 
 Once configured, the plugin appears in React Native DevTools as "File System".
 
+## File Transfer
+
+File import and export are disabled by default. Enable them explicitly with the `fileTransfer` option when you want the DevTools panel to move raw files in or out of app-accessible directories.
+
+```ts title="App.tsx"
+useFileSystemDevTools({
+  adapter: createRNFSAdapter(RNFS),
+  fileTransfer: {
+    import: true,
+    export: true,
+  },
+});
+```
+
+When enabled, the File System panel lets you import a single file into the currently viewed directory and export a selected file. Imports keep the original filename and ask before overwriting an existing file.
+
+Agent-triggered file transfer is controlled separately. Enable it only when agents should be allowed to import or export exact file contents through Rozenite for Agents.
+
+```ts title="App.tsx"
+useFileSystemDevTools({
+  adapter: createRNFSAdapter(RNFS),
+  fileTransfer: {
+    import: true,
+    export: true,
+    agent: {
+      import: true,
+      export: true,
+    },
+  },
+});
+```
+
 ## Available Roots
 
 ### Expo FileSystem
@@ -103,6 +136,7 @@ File previews are size-limited to keep DevTools responsive. Very large files may
 - `createRNFSAdapter` wraps `react-native-fs` and `@dr.pogodin/react-native-fs`.
 - Text previews fall back to a binary hex-style dump when UTF-8 decoding fails.
 - Expo and RNFS expose slightly different root directories depending on platform and runtime environment.
+- File transfer supports single files only and is restricted to visible filesystem roots.
 
 ## Agent Tools (LLM Integration)
 
@@ -115,6 +149,8 @@ Available tools:
 - `read-entry`
 - `read-text-file`
 - `read-image-file`
+- `export-file` when `fileTransfer.agent.export` is enabled
+- `import-file` when `fileTransfer.agent.import` is enabled
 
 This makes the plugin usable from Rozenite for Agents workflows in Codex, Cursor, and other coding agents that speak to the `rozenite agent` CLI.
 


### PR DESCRIPTION
Issue: https://github.com/callstackincubator/rozenite/issues/252

## Summary

- Adds opt-in single-file **Import** and **Export** controls to the file system panel.
- Extends the file system protocol with `fs:export-file` / `fs:import-file` request-result events.
- Adds raw base64 read/write support to Expo FileSystem and RNFS adapters.
- Keeps file transfer disabled by default; consumers must enable `fileTransfer.import` and/or `fileTransfer.export`.
- Import targets the currently viewed directory, rejects unsafe file names, prevents root escape/traversal, and asks before overwriting.
- Export is available only for files, not directories, and downloads the selected file with its detected MIME type.
- Wires the playground with file transfer enabled for manual testing.
- Docs: README notes the opt-in behavior and single-file scope.
- Adds separately gated agent transfer tools: `export-file` and `import-file`.
- Keeps agent file transfer disabled by default via `fileTransfer.agent.import/export`.
- Adds shared transfer helpers used by both DevTools UI requests and agent tools.
- Agent transfer results include explicit attribution and remain bounded to plugin-visible roots.

## Test plan

Automated:

- [x] `pnpm --filter @rozenite/file-system-plugin test` — 40/40 passing.
- [x] `pnpm --filter @rozenite/file-system-plugin typecheck` — clean.
- [x] `pnpm --filter @rozenite/file-system-plugin lint` — clean.

Manual:

- [x] Import a new file into an app-accessible directory.
- [x] Import over an existing file and confirm overwrite prompt behavior.
- [x] Cancel overwrite and verify no write occurs.
- [x] Export a file and verify downloaded bytes/name/MIME.
- [x] Verify Import/Export controls stay disabled when `fileTransfer` is not enabled.
- [x] Verify directories cannot be exported.
- [x] Verify agent tools list includes `@rozenite/file-system-plugin.export-file` and `@rozenite/file-system-plugin.import-file` only after `fileTransfer.agent` opt-in.
- [x] Call agent `import-file` and confirm the file appears in the File System tab.
- [x] Call agent `export-file` and confirm the returned base64 matches the imported file.

## Out of scope

- Directory import/export.
- Bulk transfer.
- Recursive zips/archive formats.
- Delete/replace-all semantics.
- Transfer progress for large files.