### PR TITLE
feat(network-activity-plugin): virtualize large code blocks

### DIFF
--- a/.changeset/quiet-pandas-virtualize.md
+++ b/.changeset/quiet-pandas-virtualize.md
@@ -1,0 +1,7 @@
+---
+'@rozenite/network-activity-plugin': minor
+---
+
+Virtualize large code blocks in the Network Activity panel.
+
+Text response bodies above 50,000 characters now render inside a virtualized 500 px scrollable window instead of an unbounded `<pre>` element. Smaller bodies and tree views (JSON, XML) are unaffected. This keeps the panel snappy on multi-megabyte responses (pretty-printed JSON, minified bundles served as text, large logs) without truncating any content.

--- a/apps/playground/src/app/screens/NetworkTestScreen.tsx
+++ b/apps/playground/src/app/screens/NetworkTestScreen.tsx
@@ -576,6 +576,107 @@ const XmlResponseTestComponent: React.FC = () => {
   );
 };
 
+type LargeTextTestCase = {
+  label: string;
+  url: string;
+  hint?: string;
+};
+
+const LARGE_TEXT_TEST_CASES: LargeTextTestCase[] = [
+  {
+    label: 'Alice in Wonderland (~174 KB)',
+    url: 'https://www.gutenberg.org/cache/epub/11/pg11.txt',
+    hint: 'text/plain — exceeds the 50 KB threshold, Raw view virtualizes into a 500 px scrollable window',
+  },
+  {
+    label: 'GPL-3 license (~35 KB)',
+    url: 'https://www.gnu.org/licenses/gpl-3.0.txt',
+    hint: 'text/plain — under the threshold, renders as a flat <pre> for comparison',
+  },
+];
+
+const LargeTextResponseTestComponent: React.FC = () => {
+  const [loadingLabel, setLoadingLabel] = React.useState<string | null>(null);
+  const [lastResult, setLastResult] = React.useState<string | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const fetchLargeText = React.useCallback(
+    async (testCase: LargeTextTestCase) => {
+      setLoadingLabel(testCase.label);
+      setError(null);
+      setLastResult(null);
+      try {
+        const response = await fetch(testCase.url);
+        const text = await response.text();
+        setLastResult(
+          `${testCase.label}: HTTP ${response.status} • ${
+            response.headers.get('content-type') ?? 'unknown'
+          } • ${text.length.toLocaleString()} chars`,
+        );
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        setLoadingLabel(null);
+      }
+    },
+    [],
+  );
+
+  return (
+    <ScrollView contentContainerStyle={styles.listContainer}>
+      <View style={styles.card}>
+        <Text style={styles.cardTitle}>Large Text Response Test</Text>
+        <Text style={styles.cardBody}>
+          Triggers large plain-text responses so the Network Activity
+          panel&apos;s code-block viewer can be exercised on both sides of the
+          50 KB virtualization threshold. Tap a button, then open the captured
+          request in DevTools — bodies above 50 KB scroll inside a 500 px window
+          via Virtuoso; bodies below render as a flat &lt;pre&gt;.
+        </Text>
+
+        <View style={styles.nitroButtonGrid}>
+          {LARGE_TEXT_TEST_CASES.map((testCase) => (
+            <TouchableOpacity
+              key={testCase.label}
+              style={[
+                styles.nitroButton,
+                loadingLabel !== null && styles.refetchButtonDisabled,
+              ]}
+              disabled={loadingLabel !== null}
+              onPress={() => fetchLargeText(testCase)}
+            >
+              <Text style={styles.nitroButtonText}>
+                {loadingLabel === testCase.label ? 'Fetching…' : testCase.label}
+              </Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+
+        <View style={styles.imageHintList}>
+          {LARGE_TEXT_TEST_CASES.map((testCase) =>
+            testCase.hint ? (
+              <Text key={testCase.label} style={styles.imageHintText}>
+                • {testCase.label}: {testCase.hint}
+              </Text>
+            ) : null,
+          )}
+        </View>
+
+        {loadingLabel && (
+          <View style={styles.nitroStatusRow}>
+            <ActivityIndicator size="small" color="#ffffff" />
+            <Text style={styles.nitroStatusText}>Fetching {loadingLabel}…</Text>
+          </View>
+        )}
+
+        {error && <Text style={styles.errorText}>Error: {error}</Text>}
+
+        {lastResult && <Text style={styles.successText}>{lastResult}</Text>}
+      </View>
+    </ScrollView>
+  );
+};
+
 const NitroHTTPTestComponent: React.FC = () => {
   const [isRunning, setIsRunning] = React.useState(false);
   const [result, setResult] = React.useState<NitroDemoResult | null>(null);
@@ -1677,6 +1778,7 @@ export const NetworkTestScreen: React.FC = () => {
     | 'binary'
     | 'html'
     | 'xml'
+    | 'large-text'
     | 'request-body'
   >('http');
 
@@ -1706,6 +1808,7 @@ export const NetworkTestScreen: React.FC = () => {
           { key: 'binary', label: 'Binary' },
           { key: 'html', label: 'HTML' },
           { key: 'xml', label: 'XML' },
+          { key: 'large-text', label: 'Large text' },
         ].map((tab) => (
           <TouchableOpacity
             key={tab.key}
@@ -1724,7 +1827,8 @@ export const NetworkTestScreen: React.FC = () => {
                   | 'images'
                   | 'binary'
                   | 'html'
-                  | 'xml',
+                  | 'xml'
+                  | 'large-text',
               )
             }
           >
@@ -1761,6 +1865,8 @@ export const NetworkTestScreen: React.FC = () => {
         <HtmlResponseTestComponent />
       ) : activeTest === 'xml' ? (
         <XmlResponseTestComponent />
+      ) : activeTest === 'large-text' ? (
+        <LargeTextResponseTestComponent />
       ) : (
         <SSETestComponent />
       )}

--- a/packages/network-activity-plugin/src/ui/components/CodeBlock.tsx
+++ b/packages/network-activity-plugin/src/ui/components/CodeBlock.tsx
@@ -1,7 +1,14 @@
-import { HTMLProps } from 'react';
+import { HTMLProps, useMemo } from 'react';
+import { Virtuoso } from 'react-virtuoso';
 import { cn } from '../utils/cn';
 
 export type CodeBlockProps = HTMLProps<HTMLPreElement>;
+
+// Above this character count, string content renders through Virtuoso
+// instead of a flat <pre>. Tuned so typical responses (<20KB) stay on
+// the simple path, while pathological payloads (large pretty-printed
+// JSON / minified bundles served as text / huge logs) virtualize.
+const VIRTUALIZATION_THRESHOLD = 50_000;
 
 const codeBlockClassNames =
   'text-sm font-mono text-gray-300 whitespace-pre-wrap bg-gray-800 p-3 rounded-md border border-gray-700 overflow-x-auto wrap-anywhere';
@@ -11,9 +18,46 @@ export const CodeBlock = ({
   className,
   ...props
 }: CodeBlockProps) => {
+  // Only string children are eligible for virtualization. Component
+  // children (JsonTree / XmlTree / etc.) manage their own rendering;
+  // CodeBlock here just provides the monospace-on-dark frame.
+  if (
+    typeof children === 'string' &&
+    children.length > VIRTUALIZATION_THRESHOLD
+  ) {
+    return <VirtualizedCodeBlock text={children} className={className} />;
+  }
+
   return (
     <pre className={cn(codeBlockClassNames, className)} {...props}>
       {children}
     </pre>
+  );
+};
+
+type VirtualizedCodeBlockProps = {
+  text: string;
+  className?: string;
+};
+
+const VirtualizedCodeBlock = ({
+  text,
+  className,
+}: VirtualizedCodeBlockProps) => {
+  const lines = useMemo(() => text.split('\n'), [text]);
+
+  // Content with no newlines collapses to a single row containing the
+  // entire payload. Browser wrapping (whitespace-pre-wrap, wrap-anywhere)
+  // still keeps layout sane, but there's no real virtualization benefit
+  // for that shape — the size win shows up once the body has many lines.
+  return (
+    <Virtuoso
+      style={{ height: 500 }}
+      totalCount={lines.length}
+      itemContent={(idx) => (
+        <div className="whitespace-pre-wrap wrap-anywhere">{lines[idx]}</div>
+      )}
+      className={cn(codeBlockClassNames, className)}
+    />
   );
 };

--- a/packages/network-activity-plugin/src/ui/components/__tests__/CodeBlock.test.tsx
+++ b/packages/network-activity-plugin/src/ui/components/__tests__/CodeBlock.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { CodeBlock } from '../CodeBlock';
+
+describe('CodeBlock', () => {
+  it('renders small string content as a <pre> (no virtualization)', () => {
+    const { container } = render(<CodeBlock>{'a'.repeat(100)}</CodeBlock>);
+    expect(container.querySelector('pre')).toBeInTheDocument();
+    expect(screen.queryByTestId('virtuoso-mock')).toBeNull();
+  });
+
+  it('stays flat at exactly the 50_000-character boundary (inclusive)', () => {
+    // The branch condition is `> 50_000`, so length === 50_000 must
+    // still render as <pre>. Locks the inclusive-boundary semantics.
+    const { container } = render(<CodeBlock>{'a'.repeat(50_000)}</CodeBlock>);
+    expect(container.querySelector('pre')).toBeInTheDocument();
+    expect(screen.queryByTestId('virtuoso-mock')).toBeNull();
+  });
+
+  it('switches to virtualized rendering at 50_001 characters', () => {
+    const { container } = render(<CodeBlock>{'a'.repeat(50_001)}</CodeBlock>);
+    expect(screen.getByTestId('virtuoso-mock')).toBeInTheDocument();
+    // No <pre> emitted by CodeBlock when on the virtualized path.
+    expect(container.querySelector('pre')).toBeNull();
+  });
+
+  it('preserves the body content across the virtualization threshold', () => {
+    // Build a body whose head and tail are recognizable tokens. The
+    // vi.mock passthrough renders every row, so both ends should be
+    // visible in the DOM after virtualization kicks in.
+    const filler = 'x'.repeat(50_000);
+    const body = `START\n${filler}\nEND`;
+    render(<CodeBlock>{body}</CodeBlock>);
+    expect(screen.getByTestId('virtuoso-mock')).toBeInTheDocument();
+    expect(screen.getByText('START')).toBeInTheDocument();
+    expect(screen.getByText('END')).toBeInTheDocument();
+  });
+
+  it('splits virtualized content into one row per newline', () => {
+    const lines = ['line-a', 'line-b', 'line-c'];
+    // Pad with a single long line so total length crosses the threshold,
+    // keeping the lines themselves short and matchable.
+    const body = `${lines.join('\n')}\n${'y'.repeat(50_001)}`;
+    render(<CodeBlock>{body}</CodeBlock>);
+    expect(screen.getByText('line-a')).toBeInTheDocument();
+    expect(screen.getByText('line-b')).toBeInTheDocument();
+    expect(screen.getByText('line-c')).toBeInTheDocument();
+  });
+
+  it('renders React-element children unchanged regardless of nested content size', () => {
+    // typeof children !== 'string' MUST take precedence — even if the
+    // wrapped element contains an enormous string internally, CodeBlock
+    // should stay on the flat <pre> path because the children prop
+    // itself is a React element, not a string.
+    const huge = 'z'.repeat(50_001);
+    const { container } = render(
+      <CodeBlock>
+        <div data-testid="custom-child">{huge}</div>
+      </CodeBlock>,
+    );
+    expect(container.querySelector('pre')).toBeInTheDocument();
+    expect(screen.queryByTestId('virtuoso-mock')).toBeNull();
+    expect(screen.getByTestId('custom-child')).toBeInTheDocument();
+  });
+
+  it('forwards className to the flat <pre> branch', () => {
+    const { container } = render(
+      <CodeBlock className="extra-class">{'short'}</CodeBlock>,
+    );
+    const pre = container.querySelector('pre');
+    expect(pre).toBeInTheDocument();
+    expect(pre?.className).toContain('extra-class');
+  });
+
+  it('forwards className to the virtualized branch via Virtuoso', () => {
+    const { container } = render(
+      <CodeBlock className="extra-class">{'a'.repeat(50_001)}</CodeBlock>,
+    );
+    const mockRoot = container.querySelector('[data-testid="virtuoso-mock"]');
+    expect(mockRoot).toBeInTheDocument();
+    // The vi.mock passthrough forwards `className` onto the wrapper so
+    // we can assert the prop reached Virtuoso. The real Virtuoso applies
+    // it to its outer scroll container, giving the same dark-bg /
+    // monospace / border styling as the flat <pre> branch.
+    expect(mockRoot?.className).toContain('extra-class');
+  });
+});

--- a/packages/network-activity-plugin/vitest.setup.ts
+++ b/packages/network-activity-plugin/vitest.setup.ts
@@ -15,13 +15,15 @@ vi.mock('react-virtuoso', () => ({
   Virtuoso: ({
     totalCount,
     itemContent,
+    className,
   }: {
     totalCount: number;
     itemContent: (index: number) => React.ReactNode;
+    className?: string;
   }) =>
     React.createElement(
       'div',
-      { 'data-testid': 'virtuoso-mock' },
+      { 'data-testid': 'virtuoso-mock', className },
       ...Array.from({ length: totalCount }, (_, i) =>
         React.createElement('div', { key: i }, itemContent(i)),
       ),

--- a/website/src/docs/official-plugins/network-activity.mdx
+++ b/website/src/docs/official-plugins/network-activity.mdx
@@ -92,6 +92,8 @@ The response body view adapts to the format of each captured response and expose
 
 The Preview / Raw toggle remembers your choice across requests in a panel session — once you toggle to Raw, subsequent responses whose renderer supports Raw stay on Raw. Formats with only one meaningful view hide the toggle entirely.
 
+Text response bodies above 50 KB render inside a virtualized 500 px scrollable window so the panel stays responsive on multi-megabyte payloads (pretty-printed JSON, minified bundles served as text, large logs). Smaller bodies render as a flat block. No content is truncated.
+
 #### Downloading bytes
 
 Every binary response (image, PDF, font, audio, ...) ships with a Download button on its metadata card. The filename is derived in three tiers:


### PR DESCRIPTION
Part of #244 — "Improve response viewing in Network Activity." Makes the response panel's CodeBlock threshold-aware so multi-megabyte text bodies don't pin hundreds of thousands of DOM nodes.

## Summary

- **`CodeBlock` becomes threshold-aware.** When `children` is a string longer than 50,000 characters, the body renders inside a `react-virtuoso` `<Virtuoso>` and only the rows currently visible inside a 500 px window stay in the DOM. Below the threshold (and for any non-string children — `<JsonTree>`, `<XmlTree>` wrapped in CodeBlock for the monospace-on-dark frame), rendering is unchanged: a flat `<pre>`. The dispatch is a runtime `typeof children === 'string'` branch — zero changes required at any of the 11+ existing CodeBlock call sites (json / xml / svg / text-fallback renderers, malformed-fallback paths, RequestBody).
- **Virtuoso configuration.** Fixed `style={{ height: 500 }}` matches the visual scale of HexView and the iframe elsewhere in the response panel. `<div>` rows (Virtuoso positions rows absolutely and needs block-level items). Per-row `whitespace-pre-wrap wrap-anywhere` preserves today's wrapping UX so long URLs / base64 / minified-on-one-line content wrap visually instead of forcing horizontal scroll. Outer styling reuses the existing `codeBlockClassNames` constant so the dark bg / monospace / border / padding are identical between the two branches.
- **Known shape limitation.** A 50 KB body with no newlines virtualizes to a single row containing the entire payload. Browser-level wrapping keeps the layout sane but there's no real virtualization benefit for that shape — the perf win shows up once the body has many lines.
- **UX trade-off worth knowing.** Today's `<pre>` expands to content (height grows with body length). After this change, content above 50 KB scrolls inside a 500 px window. Deliberate, for snappy rendering on multi-megabyte responses.
- **Adds `react-virtuoso ^4.6.0`** to `@rozenite/network-activity-plugin`'s `dependencies`.
- **Playground.** A new "Large text" main-tab on `NetworkTestScreen` with two pre-verified URLs straddling the threshold so reviewers can see both branches: Alice in Wonderland from Gutenberg (~174 KB, virtualizes) and the GPL-3 license text (~35 KB, stays flat).

## Test plan

- [ ] `pnpm --filter @rozenite/network-activity-plugin test` — all tests pass (8 new in `CodeBlock.test.tsx`).
- [ ] `pnpm --filter @rozenite/network-activity-plugin typecheck` — clean.
- [ ] `pnpm --filter @rozenite/network-activity-plugin lint` — clean.
- [ ] `npx prettier --check` on changed files — clean.
- [ ] Playground (`pnpm --filter @rozenite/playground ios` or `:android`) → Network Test → Large text tab:
  - [ ] **Alice in Wonderland (~174 KB)** — Response body scrolls inside a 500 px window. NOT an unbounded `<pre>`. Scrolling is smooth at the end of the ~3300-line file. Dark bg / monospace / border look identical to a small `<pre>`.
  - [ ] **GPL-3 license (~35 KB)** — Response body renders as a flat `<pre>`, height grows with content, no internal scrolling. (Control: confirms the threshold gating works.)
- [ ] **JSON tree responses unchanged** — open any JSON response (HTTP Test → User-list). Renders as JsonTree wrapped in CodeBlock as before. No virtualization (children is a React element, not a string).
- [ ] **SVG Raw view unchanged** — Images tab → SVG → toggle to Raw. Renders as flat `<pre>` with SVG source (SVG bodies are well under threshold).
- [ ] **Toggle behavior unchanged** — sticky Preview/Raw preference, override button presence, content-type label all work as before.

## New test surface

`components/__tests__/CodeBlock.test.tsx` (8 tests):

- Small string content renders as `<pre>` with no virtuoso-mock present.
- Exactly 50,000 chars stays on the flat path (inclusive-boundary semantics — the branch condition is `>`, not `>=`).
- 50,001 chars switches to the virtualized rendering.
- Content survives the threshold split (recognizable head and tail tokens both visible in the DOM after virtualization).
- Newlines in virtualized content produce one row per line.
- React-element children stay on the `<pre>` path even when the wrapped element contains a 50,001-char string internally (the `typeof children === 'string'` check takes precedence).
- `className` forwarding on both the flat and virtualized branches.

`vitest.setup.ts` adds a `vi.mock('react-virtuoso')` passthrough so jsdom-based tests can assert content correctness. jsdom can't drive Virtuoso's resize observation otherwise — without the stub any test importing a virtualizing component fails to render rows. Production code is unaffected.

## Followups (deliberately not in this PR)

- Search inside virtualized content.
- Truncation modes.
- Virtualizing trees (`JsonTree`, `XmlTree`) — would require forking `react-json-tree` or rewriting from scratch.
- Per-row line numbers in the virtualized branch.
- Syntax highlighting (cross-cutting feature; would also benefit XML / JSON / HTML Raw views).
- Programmatic line-wrapping for single-line content longer than the threshold (would require choosing a column width).

## Coordination notes

- **`react-virtuoso` dep + `vi.mock('react-virtuoso')` test stub** are also added by #274 (binary hex viewer, ready for review). The lines are identical on both branches; whichever lands second will see a clean auto-merge (or a one-line trivial conflict on the dependencies block).
- **`network-activity.mdx`** Response Viewing section is also edited by #275 (HTML) and #277 (XML + JSON Raw). This PR appends a separate paragraph at the end of the section rather than touching their bullets — additive, no overlap.