### PR TITLE
fix(vite-plugin): load dev config in dev host inline script

### DIFF
--- a/packages/network-activity-plugin/rozenite.config.ts
+++ b/packages/network-activity-plugin/rozenite.config.ts
@@ -5,4 +5,15 @@ export default {
       source: './src/ui/App.tsx',
     },
   ],
+  dev: {
+    flows: [
+      {
+        name: 'Start recording',
+        autoRun: true,
+        run({ send }) {
+          send('network-enable', {});
+        },
+      },
+    ],
+  },
 };

--- a/packages/network-activity-plugin/rozenite.config.ts
+++ b/packages/network-activity-plugin/rozenite.config.ts
@@ -5,15 +5,4 @@ export default {
       source: './src/ui/App.tsx',
     },
   ],
-  dev: {
-    flows: [
-      {
-        name: 'Start recording',
-        autoRun: true,
-        run({ send }) {
-          send('network-enable', {});
-        },
-      },
-    ],
-  },
 };

--- a/packages/vite-plugin/src/client-plugin.ts
+++ b/packages/vite-plugin/src/client-plugin.ts
@@ -264,7 +264,7 @@ export const rozeniteClientPlugin = (): Plugin => {
           attrs: {
             type: 'module',
           },
-          children: `import rozeniteConfig from ${JSON.stringify(ROZENITE_DEV_CONFIG_MODULE_ID)}; window[${JSON.stringify(DEV_HOST_CONFIG_GLOBAL_KEY)}] = rozeniteConfig.dev ?? {};`,
+          children: `import rozeniteConfig from ${JSON.stringify('/@id/' + ROZENITE_DEV_CONFIG_MODULE_ID)}; window[${JSON.stringify(DEV_HOST_CONFIG_GLOBAL_KEY)}] = rozeniteConfig.dev ?? {};`,
           injectTo: 'body',
         },
         {

--- a/packages/vite-plugin/src/dev-host/flow-runtime.ts
+++ b/packages/vite-plugin/src/dev-host/flow-runtime.ts
@@ -283,7 +283,7 @@ export const useFlowRunner = ({ sendMessage }: FlowRunnerOptions) => {
   };
 
   const hasRunningFlow = (flowName: string) => {
-    return [...activeRunsRef.current.values()].some((run) => run.flowName === flowName);
+    return flowRuns.some((run) => run.flowName === flowName && run.status === 'running');
   };
 
   return {


### PR DESCRIPTION
## Summary
- add a minimal dev flow to the network activity plugin dev config
- load the dev host config via the Vite `/@id/` path in the injected inline module script
- keep the rest of the dev host config plumbing unchanged

## Testing
- not run (not requested)