### PR TITLE
fix(vite-plugin): improve dev host layout on smaller viewports

### DIFF
--- a/.changeset/improve-vite-plugin-dev-host-layout.md
+++ b/.changeset/improve-vite-plugin-dev-host-layout.md
@@ -1,0 +1,5 @@
+---
+'@rozenite/vite-plugin': patch
+---
+
+Improve the Rozenite plugin dev app layout on smaller viewports so panels, navigation, and message details remain usable without horizontal overflow.

--- a/packages/vite-plugin/src/dev-host/App.tsx
+++ b/packages/vite-plugin/src/dev-host/App.tsx
@@ -14,6 +14,7 @@ import {
   MIN_DETAILS_WIDTH,
   MIN_DEVTOOLS_HEIGHT,
   MIN_IFRAME_HEIGHT,
+  MIN_NARROW_IFRAME_HEIGHT,
   SPLITTER_SIZE,
 } from './constants.js';
 import type {
@@ -41,6 +42,7 @@ import {
 import { MessageLogPane } from './components/MessageLogPane.js';
 import { PanelTabs } from './components/PanelTabs.js';
 import { ResizeHandle } from './components/ResizeHandle.js';
+import { ToggleGroup } from './components/ui/ToggleGroup.js';
 import { RozeniteLogo } from './components/icons.js';
 
 type CSSVariables = CSSProperties & Record<`--${string}`, string>;
@@ -49,6 +51,8 @@ type AppProps = DevHostState & {
   flows: DevHostFlowEntry[];
   presets: DevHostPresetEntry[];
 };
+
+type MobileDevtoolsTab = 'log' | 'actions';
 
 const getViewportMatch = () => {
   return window.matchMedia('(max-width: 960px)').matches;
@@ -68,6 +72,7 @@ export const App = ({ packageName, packageDescription, panels, flows, presets }:
   const [detailsWidth, setDetailsWidth] = useState(DETAILS_PANEL_WIDTH);
   const [activeResizeHandle, setActiveResizeHandle] = useState<ResizeHandleId | null>(null);
   const [isNarrowViewport, setIsNarrowViewport] = useState(getViewportMatch);
+  const [activeMobileTab, setActiveMobileTab] = useState<MobileDevtoolsTab>('log');
   const [iframeLoadNonce, setIframeLoadNonce] = useState(0);
   const workspaceRef = useRef<HTMLElement | null>(null);
   const logWorkspaceRef = useRef<HTMLDivElement | null>(null);
@@ -115,6 +120,8 @@ export const App = ({ packageName, packageDescription, panels, flows, presets }:
   })();
   const canDispatch = hasCommandType && hasValidCommandPayload;
   const panelDescription = packageDescription.trim();
+  const isDetailsVisible = isDetailsOpen && selectedMessage !== null;
+  const iframeMinHeight = isNarrowViewport ? MIN_NARROW_IFRAME_HEIGHT : MIN_IFRAME_HEIGHT;
 
   useEffect(() => {
     document.title = `${packageName} Dev Host`;
@@ -153,6 +160,26 @@ export const App = ({ packageName, packageDescription, panels, flows, presets }:
     };
   }, []);
 
+  useEffect(() => {
+    const workspace = workspaceRef.current;
+    if (!workspace) {
+      return;
+    }
+
+    const bounds = workspace.getBoundingClientRect();
+    const maxHeight = Math.max(MIN_DEVTOOLS_HEIGHT, bounds.height - iframeMinHeight - 12);
+
+    setDevToolsHeight((current) => clamp(current, MIN_DEVTOOLS_HEIGHT, maxHeight));
+  }, [iframeMinHeight]);
+
+  useEffect(() => {
+    if (!isNarrowViewport) {
+      return;
+    }
+
+    setActiveMobileTab('log');
+  }, [isNarrowViewport]);
+
   const selectPanel = (value: string) => {
     const nextPanel = panels.find((panel) => panel.source === value);
     if (!nextPanel) {
@@ -170,8 +197,6 @@ export const App = ({ packageName, packageDescription, panels, flows, presets }:
 
     registerMessage(nextEntry);
     setMessages((current) => [nextEntry, ...current]);
-    setSelectedMessageId(nextEntry.id);
-    setIsDetailsOpen(true);
   };
 
   useEffect(() => {
@@ -271,6 +296,7 @@ export const App = ({ packageName, packageDescription, panels, flows, presets }:
     setMessages([]);
     setSelectedMessageId(null);
     setIsDetailsOpen(false);
+    setActiveMobileTab('log');
   };
 
   const resizeDevtoolsHeight = (event: PointerEvent) => {
@@ -281,7 +307,7 @@ export const App = ({ packageName, packageDescription, panels, flows, presets }:
 
     const bounds = workspace.getBoundingClientRect();
     const nextHeight = bounds.bottom - event.clientY;
-    const maxHeight = Math.max(MIN_DEVTOOLS_HEIGHT, bounds.height - MIN_IFRAME_HEIGHT - 12);
+    const maxHeight = Math.max(MIN_DEVTOOLS_HEIGHT, bounds.height - iframeMinHeight - 12);
 
     setDevToolsHeight(clamp(nextHeight, MIN_DEVTOOLS_HEIGHT, maxHeight));
   };
@@ -293,9 +319,7 @@ export const App = ({ packageName, packageDescription, panels, flows, presets }:
     }
 
     const bounds = devtools.getBoundingClientRect();
-    const nextWidth = isNarrowViewport
-      ? bounds.bottom - event.clientY
-      : bounds.right - event.clientX;
+    const nextWidth = bounds.right - event.clientX;
     const maxWidth = Math.max(MIN_COMMAND_WIDTH, bounds.width - 280);
 
     setCommandWidth(clamp(nextWidth, MIN_COMMAND_WIDTH, maxWidth));
@@ -303,17 +327,37 @@ export const App = ({ packageName, packageDescription, panels, flows, presets }:
 
   const resizeDetailsPane = (event: PointerEvent) => {
     const logWorkspace = logWorkspaceRef.current;
-    if (!logWorkspace || !isDetailsOpen || !selectedMessage) {
+    if (!logWorkspace || !isDetailsVisible || isNarrowViewport) {
       return;
     }
 
     const bounds = logWorkspace.getBoundingClientRect();
-    const nextWidth = isNarrowViewport
-      ? bounds.bottom - event.clientY
-      : bounds.right - event.clientX;
+    const nextWidth = bounds.right - event.clientX;
     const maxWidth = Math.max(MIN_DETAILS_WIDTH, bounds.width - 280 - SPLITTER_SIZE);
 
     setDetailsWidth(clamp(nextWidth, MIN_DETAILS_WIDTH, maxWidth));
+  };
+
+  const handleMessageSelect = (messageId: string) => {
+    setSelectedMessageId(messageId);
+    setIsDetailsOpen(true);
+
+    if (isNarrowViewport) {
+      setActiveMobileTab('log');
+    }
+  };
+
+  const handleDetailsClose = () => {
+    setIsDetailsOpen(false);
+
+    if (isNarrowViewport) {
+      setActiveMobileTab('log');
+    }
+  };
+
+  const handleMobileTabChange = (value: string) => {
+    const nextTab = value as MobileDevtoolsTab;
+    setActiveMobileTab(nextTab);
   };
 
   const handleDispatch = (event: FormEvent<HTMLFormElement>) => {
@@ -386,78 +430,137 @@ export const App = ({ packageName, packageDescription, panels, flows, presets }:
           onPointerDown={(event) => startResize('devtools-height', event, resizeDevtoolsHeight)}
         />
 
-        <section
-          ref={devtoolsRef}
-          className="rz-devtools"
-          style={
-            {
-              '--rz-command-width': `${commandWidth}px`,
-              '--rz-command-splitter-width': `${SPLITTER_SIZE}px`,
-            } as CSSVariables
-          }
-        >
-          <div
-            ref={logWorkspaceRef}
-            className="rz-log-workspace"
+        {isNarrowViewport ? (
+          <section ref={devtoolsRef} className="rz-devtools-mobile">
+            <div className="rz-devtools-mobile-tabs">
+              <div className="rz-devtools-mobile-toggle">
+                <ToggleGroup
+                  aria-label="DevTools sections"
+                  value={activeMobileTab}
+                  onChange={handleMobileTabChange}
+                  options={[
+                    { key: 'log', label: 'Log' },
+                    { key: 'actions', label: 'Actions' },
+                  ]}
+                />
+              </div>
+
+              <div className="rz-devtools-mobile-panel">
+                {activeMobileTab === 'log' ? (
+                  isDetailsVisible ? (
+                    <MessageDetailsPane
+                      selectedMessage={selectedMessage}
+                      isOpen={true}
+                      isNarrowViewport={true}
+                      activeResizeHandle={activeResizeHandle}
+                      onClose={handleDetailsClose}
+                      onUseMessage={(message) => {
+                        const nextValues = getDispatcherValuesFromMessage(message);
+                        setCommandType(nextValues.commandType);
+                        setCommandPayload(nextValues.commandPayload);
+                        setIsDetailsOpen(false);
+                        setActiveMobileTab('actions');
+                      }}
+                      onResizeStart={(event) => startResize('details-width', event, resizeDetailsPane)}
+                    />
+                  ) : (
+                    <MessageLogPane
+                      messages={messages}
+                      selectedMessageId={selectedMessageId}
+                      onSelectMessage={handleMessageSelect}
+                      onClearMessages={clearMessages}
+                    />
+                  )
+                ) : (
+                  <DispatchForm
+                    commandType={commandType}
+                    commandPayload={commandPayload}
+                    flows={flows}
+                    flowRuns={flowRuns}
+                    hasRunningFlow={hasRunningFlow}
+                    presets={presets}
+                    canDispatch={canDispatch}
+                    onRunFlow={runFlow}
+                    onStopFlow={stopFlow}
+                    onCommandTypeChange={setCommandType}
+                    onCommandPayloadChange={setCommandPayload}
+                    onApplyPreset={applyPreset}
+                    onReset={resetForm}
+                    onSubmit={handleDispatch}
+                  />
+                )}
+              </div>
+            </div>
+          </section>
+        ) : (
+          <section
+            ref={devtoolsRef}
+            className="rz-devtools"
             style={
               {
-                '--rz-details-width':
-                  isDetailsOpen && selectedMessage ? `${detailsWidth}px` : '0px',
-                '--rz-details-splitter-width':
-                  isDetailsOpen && selectedMessage ? `${SPLITTER_SIZE}px` : '0px',
+                '--rz-command-width': `${commandWidth}px`,
+                '--rz-command-splitter-width': `${SPLITTER_SIZE}px`,
               } as CSSVariables
             }
           >
-            <MessageLogPane
-              messages={messages}
-              selectedMessageId={selectedMessageId}
-              onSelectMessage={(messageId) => {
-                setSelectedMessageId(messageId);
-                setIsDetailsOpen(true);
-              }}
-              onClearMessages={clearMessages}
+            <div
+              ref={logWorkspaceRef}
+              className="rz-log-workspace"
+              style={
+                {
+                  '--rz-details-width': isDetailsVisible ? `${detailsWidth}px` : '0px',
+                  '--rz-details-splitter-width': isDetailsVisible ? `${SPLITTER_SIZE}px` : '0px',
+                } as CSSVariables
+              }
+            >
+              <MessageLogPane
+                messages={messages}
+                selectedMessageId={selectedMessageId}
+                onSelectMessage={handleMessageSelect}
+                onClearMessages={clearMessages}
+              />
+
+              <MessageDetailsPane
+                selectedMessage={selectedMessage}
+                isOpen={isDetailsOpen}
+                isNarrowViewport={false}
+                activeResizeHandle={activeResizeHandle}
+                onClose={handleDetailsClose}
+                onUseMessage={(message) => {
+                  const nextValues = getDispatcherValuesFromMessage(message);
+                  setCommandType(nextValues.commandType);
+                  setCommandPayload(nextValues.commandPayload);
+                }}
+                onResizeStart={(event) => startResize('details-width', event, resizeDetailsPane)}
+              />
+            </div>
+
+            <ResizeHandle
+              className="rz-column-resize-handle"
+              isDragging={activeResizeHandle === 'command-width'}
+              orientation="vertical"
+              label="Resize command dispatcher"
+              onPointerDown={(event) => startResize('command-width', event, resizeCommandPane)}
             />
 
-            <MessageDetailsPane
-              selectedMessage={selectedMessage}
-              isOpen={isDetailsOpen}
-              isNarrowViewport={isNarrowViewport}
-              activeResizeHandle={activeResizeHandle}
-              onClose={() => setIsDetailsOpen(false)}
-              onUseMessage={(message) => {
-                const nextValues = getDispatcherValuesFromMessage(message);
-                setCommandType(nextValues.commandType);
-                setCommandPayload(nextValues.commandPayload);
-              }}
-              onResizeStart={(event) => startResize('details-width', event, resizeDetailsPane)}
+            <DispatchForm
+              commandType={commandType}
+              commandPayload={commandPayload}
+              flows={flows}
+              flowRuns={flowRuns}
+              hasRunningFlow={hasRunningFlow}
+              presets={presets}
+              canDispatch={canDispatch}
+              onRunFlow={runFlow}
+              onStopFlow={stopFlow}
+              onCommandTypeChange={setCommandType}
+              onCommandPayloadChange={setCommandPayload}
+              onApplyPreset={applyPreset}
+              onReset={resetForm}
+              onSubmit={handleDispatch}
             />
-          </div>
-
-          <ResizeHandle
-            className="rz-column-resize-handle"
-            isDragging={activeResizeHandle === 'command-width'}
-            orientation={isNarrowViewport ? 'horizontal' : 'vertical'}
-            label="Resize command dispatcher"
-            onPointerDown={(event) => startResize('command-width', event, resizeCommandPane)}
-          />
-
-          <DispatchForm
-            commandType={commandType}
-            commandPayload={commandPayload}
-            flows={flows}
-            flowRuns={flowRuns}
-            hasRunningFlow={hasRunningFlow}
-            presets={presets}
-            canDispatch={canDispatch}
-            onRunFlow={runFlow}
-            onStopFlow={stopFlow}
-            onCommandTypeChange={setCommandType}
-            onCommandPayloadChange={setCommandPayload}
-            onApplyPreset={applyPreset}
-            onReset={resetForm}
-            onSubmit={handleDispatch}
-          />
-        </section>
+          </section>
+        )}
       </main>
     </div>
   );

--- a/packages/vite-plugin/src/dev-host/components/MessageDetailsPane.tsx
+++ b/packages/vite-plugin/src/dev-host/components/MessageDetailsPane.tsx
@@ -30,14 +30,16 @@ export const MessageDetailsPane = ({
 
   return (
     <>
-      <ResizeHandle
-        className="rz-column-resize-handle"
-        isDragging={activeResizeHandle === 'details-width'}
-        isHidden={isHidden}
-        orientation={isNarrowViewport ? 'horizontal' : 'vertical'}
-        label="Resize message details"
-        onPointerDown={onResizeStart}
-      />
+      {!isNarrowViewport ? (
+        <ResizeHandle
+          className="rz-column-resize-handle"
+          isDragging={activeResizeHandle === 'details-width'}
+          isHidden={isHidden}
+          orientation="vertical"
+          label="Resize message details"
+          onPointerDown={onResizeStart}
+        />
+      ) : null}
 
       <div className="rz-pane" data-hidden={isHidden} aria-hidden={isHidden}>
         <div className="rz-sidebar">

--- a/packages/vite-plugin/src/dev-host/constants.ts
+++ b/packages/vite-plugin/src/dev-host/constants.ts
@@ -4,6 +4,7 @@ export const DEV_HOST_CONFIG_GLOBAL_KEY = '__rozenite-dev-config__';
 export const DEFAULT_DEVTOOLS_HEIGHT = 288;
 export const MIN_DEVTOOLS_HEIGHT = 180;
 export const MIN_IFRAME_HEIGHT = 220;
+export const MIN_NARROW_IFRAME_HEIGHT = 140;
 export const DETAILS_PANEL_WIDTH = 360;
 export const MIN_DETAILS_WIDTH = 280;
 export const DEFAULT_COMMAND_WIDTH = 320;

--- a/packages/vite-plugin/src/dev-host/styles.css
+++ b/packages/vite-plugin/src/dev-host/styles.css
@@ -103,9 +103,18 @@ select {
   grid-template-columns: minmax(0, 1fr) var(--rz-command-splitter-width, 6px) minmax(260px, var(--rz-command-width, 320px));
 }
 
+.rz-devtools-mobile {
+  display: flex;
+  min-height: 0;
+  height: 100%;
+  width: 100%;
+  overflow: hidden;
+}
+
 .rz-log-workspace {
   display: grid;
   min-height: 0;
+  position: relative;
   grid-template-columns: minmax(0, 1fr) var(--rz-details-splitter-width, 0px) var(--rz-details-width, 0px);
 }
 
@@ -197,6 +206,34 @@ select {
 .rz-pane[data-hidden='true'],
 .rz-column-resize-handle[data-hidden='true'] {
   display: none;
+}
+
+.rz-devtools-mobile-tabs {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  gap: 8px;
+  min-height: 0;
+  height: 100%;
+  width: 100%;
+  padding-top: 8px;
+}
+
+.rz-devtools-mobile-toggle {
+  display: flex;
+  align-items: flex-start;
+  padding: 0 8px;
+}
+
+.rz-devtools-mobile-panel {
+  display: flex;
+  min-height: 0;
+  width: 100%;
+  overflow: hidden;
+}
+
+.rz-devtools-mobile-panel > .rz-pane {
+  flex: 1;
+  width: 100%;
 }
 
 .rz-tabs-root {
@@ -884,19 +921,8 @@ select {
     grid-template-rows: minmax(0, 1fr) 12px minmax(180px, var(--rz-devtools-height, 272px));
   }
 
-  .rz-devtools {
-    grid-template-columns: minmax(0, 1fr);
-    grid-template-rows: minmax(0, 1fr) var(--rz-command-splitter-width, 6px) minmax(240px, var(--rz-command-width, 320px));
-  }
-
-  .rz-log-workspace {
-    grid-template-columns: minmax(0, 1fr);
-    grid-template-rows: minmax(0, 1fr) var(--rz-details-splitter-width, 0px) var(--rz-details-width, 0px);
-  }
-
-  .rz-pane + .rz-pane {
-    border-left: 0;
-    border-top: 1px solid rgba(255, 255, 255, 0.08);
+  .rz-devtools-mobile-tabs {
+    padding-top: 8px;
   }
 
   .rz-column-resize-handle {
@@ -922,5 +948,22 @@ select {
   .rz-column-resize-handle:hover::after {
     border-top-color: rgba(255, 255, 255, 0.08);
     border-bottom-color: rgba(255, 255, 255, 0.08);
+  }
+
+  .rz-action-tabs-header {
+    flex-wrap: wrap;
+    align-items: flex-start;
+  }
+}
+
+@media (max-width: 640px) {
+  .rz-message-list-header,
+  .rz-message-row {
+    grid-template-columns: 36px 136px minmax(92px, 136px) minmax(0, 1fr);
+  }
+
+  .rz-message-header-cell,
+  .rz-message-cell {
+    padding: 8px 10px;
   }
 }


### PR DESCRIPTION
## Summary
- improve the vite-plugin dev host layout for smaller viewports
- add a mobile-specific bottom section flow so log and actions remain usable without overlapping panes
- keep the message log as the default view and make the mobile panes fill the available space

## Testing
- pnpm --filter @rozenite/vite-plugin typecheck
- pnpm --filter @rozenite/vite-plugin lint
- pnpm --filter @rozenite/vite-plugin build