### PR TITLE
fix(redux-devtools-plugin): avoid duplicate snapshot on panel connect

### DIFF
--- a/.changeset/redux-devtools-duplicate-snapshot.md
+++ b/.changeset/redux-devtools-duplicate-snapshot.md
@@ -1,0 +1,5 @@
+---
+'@rozenite/redux-devtools-plugin': patch
+---
+
+Stop sending a redundant state snapshot when the Redux DevTools panel connects. Document `maxAge` memory usage and out-of-memory risks on React Native.

--- a/packages/redux-devtools-plugin/README.md
+++ b/packages/redux-devtools-plugin/README.md
@@ -73,10 +73,18 @@ const appStoreEnhancer = rozeniteDevToolsEnhancer({ name: 'app-store' });
 const sessionStoreEnhancer = rozeniteDevToolsEnhancer({ name: 'session-store' });
 ```
 
-To see more actions in the Redux DevTools, increase `maxAge`:
+`maxAge` controls how many actions Redux DevTools keeps in history. The default is `50`.
+
+On React Native, state is serialized and sent to DevTools over the device bridge. Large stores combined with a high `maxAge` can use a lot of memory — on Android this may cause an out-of-memory crash when opening the Redux DevTools panel. If your store is large (for example, it includes RTK Query caches or big entity maps), keep `maxAge` low and consider using Redux DevTools [`stateSanitizer`](https://github.com/reduxjs/redux-devtools/blob/main/extension/docs/API/Arguments.md#statesanitizer-state--state) to strip bulky slices before they are recorded.
 
 ```ts
-rozeniteDevToolsEnhancer({ maxAge: 150 }) // Default is 50
+rozeniteDevToolsEnhancer({
+  maxAge: 20,
+  stateSanitizer: (state) => ({
+    ...state,
+    api: '[omitted]',
+  }),
+})
 ```
 
 ### 3. Access DevTools

--- a/packages/redux-devtools-plugin/src/ui/redux-devtools.tsx
+++ b/packages/redux-devtools-plugin/src/ui/redux-devtools.tsx
@@ -76,7 +76,6 @@ export const ReduxDevTools = () => {
     );
 
     client.send('panel-command', { type: 'start' });
-    client.send('panel-command', { type: 'request-state' });
 
     return () => {
       subscription.remove();

--- a/website/src/docs/official-plugins/redux-devtools.mdx
+++ b/website/src/docs/official-plugins/redux-devtools.mdx
@@ -136,10 +136,18 @@ const appStoreEnhancer = rozeniteDevToolsEnhancer({ name: 'app-store' });
 const sessionStoreEnhancer = rozeniteDevToolsEnhancer({ name: 'session-store' });
 ```
 
-To see more actions in Redux DevTools, increase `maxAge`:
+`maxAge` controls how many actions Redux DevTools keeps in history. The default is `50`.
+
+On React Native, state is serialized and sent to DevTools over the device bridge. Large stores combined with a high `maxAge` can use a lot of memory — on Android this may cause an out-of-memory crash when opening the Redux DevTools panel. If your store is large (for example, it includes RTK Query caches or big entity maps), keep `maxAge` low and consider using Redux DevTools [`stateSanitizer`](https://github.com/reduxjs/redux-devtools/blob/main/extension/docs/API/Arguments.md#statesanitizer-state--state) to strip bulky slices before they are recorded.
 
 ```ts
-rozeniteDevToolsEnhancer({ maxAge: 150 }) // Default is 50
+rozeniteDevToolsEnhancer({
+  maxAge: 20,
+  stateSanitizer: (state) => ({
+    ...state,
+    api: '[omitted]',
+  }),
+})
 ```
 
 ## Contributing


### PR DESCRIPTION
## Summary
- Remove redundant `request-state` panel command on connect; `start` already enables monitoring and sends the initial lifted-state snapshot.
- Document `maxAge` memory implications and Android OOM risk for large Redux stores in the plugin README and website docs.

Fixes callstackincubator/rozenite#287 (partially — reduces peak memory on panel open; large stores may still need lower `maxAge` or `stateSanitizer`).

## Test plan
- [x] `pnpm --filter @rozenite/redux-devtools-plugin typecheck`
- [x] `pnpm --filter @rozenite/redux-devtools-plugin lint`
- [x] `pnpm exec vitest run --config packages/redux-devtools-plugin/vite.config.ts`
- [ ] Open Redux DevTools panel against playground and confirm state loads with a single snapshot
- [ ] Verify multi-store playground still lists both instances after connect