### PR TITLE
docs(plugin-directory): add zustand-devtools and navigation-inspector plugins

### DIFF
--- a/plugin-directory.json
+++ b/plugin-directory.json
@@ -74,5 +74,13 @@
   {
     "npmUrl": "https://www.npmjs.com/package/rozenite-growthbook-plugin",
     "githubUrl": "https://github.com/valeriobelli/rozenite-growthbook-plugin"
+  },
+  {
+    "npmUrl": "https://www.npmjs.com/package/rozenite-zustand-devtools",
+    "githubUrl": "https://github.com/IronTony/rozenite-zustand-devtools"
+  },
+  {
+    "npmUrl": "https://www.npmjs.com/package/rozenite-navigation-inspector",
+    "githubUrl": "https://github.com/IronTony/rozenite-navigation-inspector"
   }
 ]


### PR DESCRIPTION
## Description

Adds two community Rozenite plugins to the plugin directory:

- **rozenite-zustand-devtools**: DevTools plugin for inspecting Zustand store state in React Native apps (https://github.com/IronTony/rozenite-zustand-devtools)
- **rozenite-navigation-inspector**: DevTools plugin for inspecting navigation state in Expo Router / React Navigation apps (https://github.com/IronTony/rozenite-navigation-inspector)

Both entries were appended to `plugin-directory.json` with the standard `npmUrl` + `githubUrl` fields. Both packages are published on npm and both repositories are public.

## Related Issue

N/A, this follows the documented "open a pull request to contribute your plugin to this list" flow on the plugin directory page. Happy to open a tracking issue first if maintainers prefer.

## Context

`plugin-directory.json` is the source of truth for the directory; all other metadata (version, description, star count, official badge) is resolved at build time from the npm registry and GitHub API, so no extra fields are needed. Both plugins are community-scoped (not `@rozenite/`), so they render with `isOfficial=false`, consistent with existing community entries like `rozenite-growthbook-plugin` and `zorro`. GitHub URLs point to the repo roots, matching the convention for standalone community repos.

## Testing

- Validated `plugin-directory.json` parses cleanly (`node -e "JSON.parse(...)"`), no trailing-comma or syntax errors.
- Confirmed both npm package URLs resolve (rozenite-zustand-devtools v1.0.2, rozenite-navigation-inspector v1.1.1) and both GitHub repos are public.
- Verified the diff touches only `plugin-directory.json` (8 lines added).