### PR TITLE
feat(controls-plugin): compose sections across hook instances

### DIFF
--- a/.changeset/controls-plugin-compose-sections.md
+++ b/.changeset/controls-plugin-compose-sections.md
@@ -1,0 +1,5 @@
+---
+'@rozenite/controls-plugin': minor
+---
+
+Allow multiple `useRozeniteControlsPlugin` hook instances to contribute controls sections to one combined panel.

--- a/packages/agent-bridge/src/useRozeniteAgentTool.test.tsx
+++ b/packages/agent-bridge/src/useRozeniteAgentTool.test.tsx
@@ -210,4 +210,20 @@ describe('useRozeniteAgentTool', () => {
 
     await unmountTool(root, container);
   });
+
+  it('does not handle tool calls when disabled', async () => {
+    const { root, container } = await renderTool(false);
+
+    await act(async () => {
+      mocks.emit('tool-call', {
+        toolName: 'app.test-tool',
+        callId: 'call-1',
+        arguments: { value: 1 },
+      });
+    });
+
+    expect(mocks.client.send).not.toHaveBeenCalled();
+
+    await unmountTool(root, container);
+  });
 });

--- a/packages/agent-bridge/src/useRozeniteAgentTool.ts
+++ b/packages/agent-bridge/src/useRozeniteAgentTool.ts
@@ -126,7 +126,7 @@ function useRozeniteDomainAgentTool(
     const toolCallSubscription = client.onMessage(
       'tool-call',
       async (payload) => {
-        if (payload.toolName !== toolName) {
+        if (!enabled || payload.toolName !== toolName) {
           return;
         }
 

--- a/packages/controls-plugin/README.md
+++ b/packages/controls-plugin/README.md
@@ -86,6 +86,39 @@ function App() {
 }
 ```
 
+You can also call the hook from multiple components. Each active hook instance contributes sections to the same panel:
+
+```ts
+function LocaleControls() {
+  useRozeniteControlsPlugin((previousOptions) => ({
+    sections: [
+      ...previousOptions.sections,
+      createSection({
+        id: 'locale',
+        title: 'Locale',
+        items: [
+          {
+            id: 'language',
+            type: 'select',
+            title: 'Language',
+            value: 'en',
+            options: [
+              { label: 'English', value: 'en' },
+              { label: 'Polish', value: 'pl' },
+            ],
+            onUpdate: (language) => {
+              i18n.changeLanguage(language);
+            },
+          },
+        ],
+      }),
+    ],
+  }));
+
+  return null;
+}
+```
+
 ## Supported Controls
 
 - `text`: Show read-only runtime values such as current environment, build label, or connection status.

--- a/packages/controls-plugin/package.json
+++ b/packages/controls-plugin/package.json
@@ -18,7 +18,8 @@
     "build": "rozenite build",
     "dev": "rozenite dev",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "vitest --run --passWithNoTests"
   },
   "dependencies": {
     "@rozenite/agent-shared": "workspace:*",

--- a/packages/controls-plugin/react-native.d.ts
+++ b/packages/controls-plugin/react-native.d.ts
@@ -8,12 +8,16 @@ export {
   type ControlsSection,
   type ControlsTextItem,
   type ControlsToggleItem,
+  type RozeniteControlsPluginOptionsInput,
   type ControlsValidationResult,
   type RozeniteControlsPluginOptions,
+  type RozeniteControlsPluginOptionsUpdater,
 } from './src/shared/types';
 
 export declare const useRozeniteControlsPlugin: (
-  options: import('./src/shared/types').RozeniteControlsPluginOptions
-) => import('@rozenite/plugin-bridge').RozeniteDevToolsClient<
-  import('./src/shared/messaging').ControlsEventMap
-> | null;
+  options: import('./src/shared/types').RozeniteControlsPluginOptionsInput,
+) =>
+  | import('@rozenite/plugin-bridge').RozeniteDevToolsClient<
+      import('./src/shared/messaging').ControlsEventMap
+    >
+  | null;

--- a/packages/controls-plugin/react-native.ts
+++ b/packages/controls-plugin/react-native.ts
@@ -8,8 +8,10 @@ export {
   type ControlsSection,
   type ControlsTextItem,
   type ControlsToggleItem,
+  type RozeniteControlsPluginOptionsInput,
   type ControlsValidationResult,
   type RozeniteControlsPluginOptions,
+  type RozeniteControlsPluginOptionsUpdater,
 } from './src/shared/types';
 
 export let useRozeniteControlsPlugin: typeof import('./src/react-native/useRozeniteControlsPlugin').useRozeniteControlsPlugin;

--- a/packages/controls-plugin/src/react-native/__tests__/controlsRegistry.test.ts
+++ b/packages/controls-plugin/src/react-native/__tests__/controlsRegistry.test.ts
@@ -73,10 +73,19 @@ describe('controlsRegistry', () => {
     const second = Symbol('second');
 
     registry.subscribe(listener);
+    expect(registry.getSnapshot()).toBe(0);
+
     registry.set(first, { sections: [section('app')] });
+    expect(registry.getSnapshot()).toBe(1);
+
     registry.set(second, { sections: [section('locale')] });
+    expect(registry.getSnapshot()).toBe(1);
+
     registry.delete(second);
+    expect(registry.getSnapshot()).toBe(2);
+
     registry.delete(first);
+    expect(registry.getSnapshot()).toBe(3);
 
     expect(listener).toHaveBeenCalledTimes(3);
   });

--- a/packages/controls-plugin/src/react-native/__tests__/controlsRegistry.test.ts
+++ b/packages/controls-plugin/src/react-native/__tests__/controlsRegistry.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createControlsRegistry } from '../controlsRegistry';
+import type { ControlsSection } from '../../shared/types';
+
+const section = (id: string): ControlsSection => ({
+  id,
+  title: id,
+  items: [],
+});
+
+describe('controlsRegistry', () => {
+  it('combines section registrations in registration order', () => {
+    const registry = createControlsRegistry();
+    const first = Symbol('first');
+    const second = Symbol('second');
+
+    registry.set(first, { sections: [section('app')] });
+    registry.set(second, { sections: [section('locale')] });
+
+    expect(registry.getOptions().sections.map(({ id }) => id)).toEqual([
+      'app',
+      'locale',
+    ]);
+  });
+
+  it('lets updater registrations derive from previous options', () => {
+    const registry = createControlsRegistry();
+    const first = Symbol('first');
+    const second = Symbol('second');
+
+    registry.set(first, { sections: [section('app')] });
+    registry.set(second, (previousOptions) => ({
+      sections: [...previousOptions.sections, section('locale')],
+    }));
+
+    expect(registry.getOptions().sections.map(({ id }) => id)).toEqual([
+      'app',
+      'locale',
+    ]);
+  });
+
+  it('lets updater registrations replace previous options when needed', () => {
+    const registry = createControlsRegistry();
+    const first = Symbol('first');
+    const second = Symbol('second');
+
+    registry.set(first, { sections: [section('app')] });
+    registry.set(second, () => ({
+      sections: [section('replacement')],
+    }));
+
+    expect(registry.getOptions().sections.map(({ id }) => id)).toEqual([
+      'replacement',
+    ]);
+  });
+
+  it('can include the current render input before the effect registers it', () => {
+    const registry = createControlsRegistry();
+    const id = Symbol('pending');
+
+    expect(
+      registry
+        .getOptions({ id, input: { sections: [section('pending')] } })
+        .sections.map((registeredSection) => registeredSection.id),
+    ).toEqual(['pending']);
+    expect(registry.isOwner(id, { id, input: { sections: [] } })).toBe(true);
+  });
+
+  it('notifies subscribers when ownership changes or registrations are removed', () => {
+    const registry = createControlsRegistry();
+    const listener = vi.fn();
+    const first = Symbol('first');
+    const second = Symbol('second');
+
+    registry.subscribe(listener);
+    registry.set(first, { sections: [section('app')] });
+    registry.set(second, { sections: [section('locale')] });
+    registry.delete(second);
+    registry.delete(first);
+
+    expect(listener).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/controls-plugin/src/react-native/__tests__/useRozeniteControlsPlugin.test.tsx
+++ b/packages/controls-plugin/src/react-native/__tests__/useRozeniteControlsPlugin.test.tsx
@@ -1,0 +1,211 @@
+// @vitest-environment jsdom
+
+import { act, type ReactNode } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createSection } from '../../shared/types';
+import type { ControlsEventMap } from '../../shared/messaging';
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean | undefined;
+}
+
+type Listener = (payload: unknown) => void;
+
+const mocks = vi.hoisted(() => {
+  const listeners = new Map<string, Set<Listener>>();
+  const send = vi.fn();
+  const onMessage = vi.fn((type: string, listener: Listener) => {
+    const typeListeners = listeners.get(type) ?? new Set<Listener>();
+    typeListeners.add(listener);
+    listeners.set(type, typeListeners);
+
+    return {
+      remove: () => {
+        typeListeners.delete(listener);
+      },
+    };
+  });
+
+  return {
+    client: {
+      send,
+      onMessage,
+    },
+    emit: (type: keyof ControlsEventMap, payload: unknown) => {
+      listeners.get(type)?.forEach((listener) => {
+        listener(payload);
+      });
+    },
+    reset: () => {
+      listeners.clear();
+      send.mockReset();
+      onMessage.mockClear();
+    },
+  };
+});
+
+vi.mock('@rozenite/plugin-bridge', () => ({
+  useRozeniteDevToolsClient: () => mocks.client,
+}));
+
+vi.mock('../useControlsAgentTools', () => ({
+  useControlsAgentTools: vi.fn(),
+}));
+
+import { useRozeniteControlsPlugin } from '../useRozeniteControlsPlugin';
+
+const appSection = createSection({
+  id: 'app',
+  title: 'App',
+  items: [],
+});
+
+const localeSection = (onUpdate: (value: string) => void = vi.fn()) =>
+  createSection({
+    id: 'locale',
+    title: 'Locale',
+    items: [
+      {
+        id: 'language',
+        type: 'select',
+        title: 'Language',
+        value: 'en',
+        options: [
+          { label: 'English', value: 'en' },
+          { label: 'Polish', value: 'pl' },
+        ],
+        onUpdate,
+      },
+    ],
+  });
+
+function AppControls() {
+  useRozeniteControlsPlugin({
+    sections: [appSection],
+  });
+
+  return null;
+}
+
+function LocaleControls({
+  onUpdate = vi.fn(),
+}: {
+  onUpdate?: (value: string) => void;
+}) {
+  useRozeniteControlsPlugin((previousOptions) => ({
+    sections: [...previousOptions.sections, localeSection(onUpdate)],
+  }));
+
+  return null;
+}
+
+function TestApp({
+  showLocale = true,
+  onUpdate,
+}: {
+  showLocale?: boolean;
+  onUpdate?: (value: string) => void;
+}) {
+  return (
+    <>
+      <AppControls />
+      {showLocale ? <LocaleControls onUpdate={onUpdate} /> : null}
+    </>
+  );
+}
+
+const renderControls = async (
+  element: ReactNode,
+): Promise<{
+  root: Root;
+  container: HTMLDivElement;
+}> => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(element);
+  });
+
+  return { root, container };
+};
+
+const unmountControls = async (root: Root, container: HTMLDivElement) => {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+};
+
+const getLastSnapshotSectionIds = () => {
+  const snapshots = mocks.client.send.mock.calls.filter(
+    ([type]) => type === 'snapshot',
+  );
+  const lastSnapshot = snapshots.at(-1)?.[1] as
+    | ControlsEventMap['snapshot']
+    | undefined;
+
+  return lastSnapshot?.sections.map((section) => section.id);
+};
+
+describe('useRozeniteControlsPlugin', () => {
+  beforeEach(() => {
+    mocks.reset();
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    delete globalThis.IS_REACT_ACT_ENVIRONMENT;
+  });
+
+  it('publishes a combined snapshot from multiple hook instances', async () => {
+    const { root, container } = await renderControls(<TestApp />);
+
+    expect(getLastSnapshotSectionIds()).toEqual(['app', 'locale']);
+
+    await unmountControls(root, container);
+  });
+
+  it('removes sections when their hook instance unmounts', async () => {
+    const { root, container } = await renderControls(<TestApp />);
+
+    await act(async () => {
+      root.render(<TestApp showLocale={false} />);
+    });
+
+    expect(getLastSnapshotSectionIds()).toEqual(['app']);
+
+    await unmountControls(root, container);
+  });
+
+  it('routes updates to sections registered by another hook instance', async () => {
+    const onUpdate = vi.fn();
+    const { root, container } = await renderControls(
+      <TestApp onUpdate={onUpdate} />,
+    );
+
+    await act(async () => {
+      mocks.emit('update-request', {
+        type: 'update-request',
+        requestId: 'request-1',
+        sectionId: 'locale',
+        itemId: 'language',
+        value: 'pl',
+      });
+    });
+
+    expect(onUpdate).toHaveBeenCalledWith('pl');
+    expect(mocks.client.send).toHaveBeenCalledWith('update-result', {
+      type: 'update-result',
+      requestId: 'request-1',
+      sectionId: 'locale',
+      itemId: 'language',
+      status: 'ok',
+    });
+
+    await unmountControls(root, container);
+  });
+});

--- a/packages/controls-plugin/src/react-native/controlsRegistry.ts
+++ b/packages/controls-plugin/src/react-native/controlsRegistry.ts
@@ -1,0 +1,96 @@
+import type {
+  RozeniteControlsPluginOptions,
+  RozeniteControlsPluginOptionsInput,
+} from '../shared/types';
+
+type ControlsRegistryListener = () => void;
+type ControlsRegistryOverride = {
+  id: symbol;
+  input: RozeniteControlsPluginOptionsInput;
+};
+
+const EMPTY_OPTIONS: RozeniteControlsPluginOptions = {
+  sections: [],
+};
+
+const resolveOptionsInput = (
+  previousOptions: RozeniteControlsPluginOptions,
+  input: RozeniteControlsPluginOptionsInput,
+): RozeniteControlsPluginOptions => {
+  if (typeof input === 'function') {
+    return input(previousOptions);
+  }
+
+  return {
+    ...previousOptions,
+    ...input,
+    sections: [...previousOptions.sections, ...input.sections],
+  };
+};
+
+export const createControlsRegistry = () => {
+  const registrations = new Map<symbol, RozeniteControlsPluginOptionsInput>();
+  const listeners = new Set<ControlsRegistryListener>();
+
+  const getOwnerId = () => registrations.keys().next().value;
+
+  const notify = () => {
+    listeners.forEach((listener) => listener());
+  };
+
+  const getRegistrationEntries = (override?: ControlsRegistryOverride) => {
+    const entries = Array.from(registrations.entries());
+
+    if (!override) {
+      return entries;
+    }
+
+    const overrideIndex = entries.findIndex(([id]) => id === override.id);
+
+    if (overrideIndex === -1) {
+      return [...entries, [override.id, override.input] as const];
+    }
+
+    return entries.map(([id, input]) =>
+      id === override.id
+        ? ([id, override.input] as const)
+        : ([id, input] as const),
+    );
+  };
+
+  return {
+    set(id: symbol, input: RozeniteControlsPluginOptionsInput) {
+      const previousOwnerId = getOwnerId();
+      registrations.set(id, input);
+
+      if (previousOwnerId !== getOwnerId()) {
+        notify();
+      }
+    },
+    delete(id: symbol) {
+      registrations.delete(id);
+      notify();
+    },
+    getOptions(
+      override?: ControlsRegistryOverride,
+    ): RozeniteControlsPluginOptions {
+      return getRegistrationEntries(override)
+        .map(([, input]) => input)
+        .reduce(resolveOptionsInput, EMPTY_OPTIONS);
+    },
+    isOwner(id: symbol, override?: ControlsRegistryOverride) {
+      const ownerEntry = getRegistrationEntries(override)[0];
+
+      return ownerEntry?.[0] === id;
+    },
+    subscribe(listener: ControlsRegistryListener) {
+      listeners.add(listener);
+
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+  };
+};
+
+export const controlsRegistry = createControlsRegistry();

--- a/packages/controls-plugin/src/react-native/controlsRegistry.ts
+++ b/packages/controls-plugin/src/react-native/controlsRegistry.ts
@@ -31,10 +31,12 @@ const resolveOptionsInput = (
 export const createControlsRegistry = () => {
   const registrations = new Map<symbol, RozeniteControlsPluginOptionsInput>();
   const listeners = new Set<ControlsRegistryListener>();
+  let snapshot = 0;
 
   const getOwnerId = () => registrations.keys().next().value;
 
   const notify = () => {
+    snapshot += 1;
     listeners.forEach((listener) => listener());
   };
 
@@ -82,6 +84,9 @@ export const createControlsRegistry = () => {
       const ownerEntry = getRegistrationEntries(override)[0];
 
       return ownerEntry?.[0] === id;
+    },
+    getSnapshot() {
+      return snapshot;
     },
     subscribe(listener: ControlsRegistryListener) {
       listeners.add(listener);

--- a/packages/controls-plugin/src/react-native/useControlsAgentTools.ts
+++ b/packages/controls-plugin/src/react-native/useControlsAgentTools.ts
@@ -8,14 +8,14 @@ import type { ControlsSection } from '../shared/types';
 const resolveItem = (
   sections: ControlsSection[],
   sectionId: string,
-  itemId: string
+  itemId: string,
 ) => {
   const section = sections.find((s) => s.id === sectionId);
 
   if (!section) {
     const available = sections.map((s) => s.id).join(', ');
     throw new Error(
-      `Section "${sectionId}" not found. Available: ${available || '(none)'}`
+      `Section "${sectionId}" not found. Available: ${available || '(none)'}`,
     );
   }
 
@@ -24,19 +24,23 @@ const resolveItem = (
   if (!item) {
     const available = section.items.map((i) => i.id).join(', ');
     throw new Error(
-      `Item "${itemId}" not found in section "${sectionId}". Available: ${available || '(none)'}`
+      `Item "${itemId}" not found in section "${sectionId}". Available: ${available || '(none)'}`,
     );
   }
 
   return { section, item };
 };
 
-export const useControlsAgentTools = (sections: ControlsSection[]) => {
+export const useControlsAgentTools = (
+  getSections: () => ControlsSection[],
+  enabled = true,
+) => {
   useRozenitePluginAgentTool({
     pluginId: CONTROLS_AGENT_PLUGIN_ID,
     tool: controlsToolDefinitions.listSections,
+    enabled,
     handler: () => ({
-      sections: sections.map((section) => ({
+      sections: getSections().map((section) => ({
         id: section.id,
         title: section.title,
         description: section.description,
@@ -53,8 +57,9 @@ export const useControlsAgentTools = (sections: ControlsSection[]) => {
   useRozenitePluginAgentTool({
     pluginId: CONTROLS_AGENT_PLUGIN_ID,
     tool: controlsToolDefinitions.getItem,
+    enabled,
     handler: ({ sectionId, itemId }) => {
-      const { item } = resolveItem(sections, sectionId, itemId);
+      const { item } = resolveItem(getSections(), sectionId, itemId);
 
       if (item.type === 'text') {
         return {
@@ -131,18 +136,19 @@ export const useControlsAgentTools = (sections: ControlsSection[]) => {
   useRozenitePluginAgentTool({
     pluginId: CONTROLS_AGENT_PLUGIN_ID,
     tool: controlsToolDefinitions.setValue,
+    enabled,
     handler: async ({ sectionId, itemId, value }) => {
-      const { item } = resolveItem(sections, sectionId, itemId);
+      const { item } = resolveItem(getSections(), sectionId, itemId);
 
       if (item.type === 'text') {
         throw new Error(
-          `Item "${itemId}" is a read-only text item and cannot be updated.`
+          `Item "${itemId}" is a read-only text item and cannot be updated.`,
         );
       }
 
       if (item.type === 'button') {
         throw new Error(
-          `Item "${itemId}" is a button. Use press-button to trigger its action.`
+          `Item "${itemId}" is a button. Use press-button to trigger its action.`,
         );
       }
 
@@ -153,7 +159,7 @@ export const useControlsAgentTools = (sections: ControlsSection[]) => {
       if (item.type === 'toggle') {
         if (typeof value !== 'boolean') {
           throw new Error(
-            `Expected boolean value for toggle item "${itemId}".`
+            `Expected boolean value for toggle item "${itemId}".`,
           );
         }
 
@@ -170,7 +176,7 @@ export const useControlsAgentTools = (sections: ControlsSection[]) => {
 
       if (typeof value !== 'string') {
         throw new Error(
-          `Expected string value for ${item.type} item "${itemId}".`
+          `Expected string value for ${item.type} item "${itemId}".`,
         );
       }
 
@@ -178,7 +184,7 @@ export const useControlsAgentTools = (sections: ControlsSection[]) => {
         const validOptions = item.options.map((o) => o.value);
         if (!validOptions.includes(value)) {
           throw new Error(
-            `Invalid option "${value}" for item "${itemId}". Valid options: ${validOptions.join(', ')}`
+            `Invalid option "${value}" for item "${itemId}". Valid options: ${validOptions.join(', ')}`,
           );
         }
       }
@@ -198,12 +204,13 @@ export const useControlsAgentTools = (sections: ControlsSection[]) => {
   useRozenitePluginAgentTool({
     pluginId: CONTROLS_AGENT_PLUGIN_ID,
     tool: controlsToolDefinitions.pressButton,
+    enabled,
     handler: async ({ sectionId, itemId }) => {
-      const { item } = resolveItem(sections, sectionId, itemId);
+      const { item } = resolveItem(getSections(), sectionId, itemId);
 
       if (item.type !== 'button') {
         throw new Error(
-          `Item "${itemId}" is not a button (type: ${item.type}). Use set-value to update its value.`
+          `Item "${itemId}" is not a button (type: ${item.type}). Use set-value to update its value.`,
         );
       }
 

--- a/packages/controls-plugin/src/react-native/useRozeniteControlsPlugin.ts
+++ b/packages/controls-plugin/src/react-native/useRozeniteControlsPlugin.ts
@@ -1,5 +1,5 @@
 import { useRozeniteDevToolsClient } from '@rozenite/plugin-bridge';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useSyncExternalStore } from 'react';
 import type {
   ControlsEventMap,
   ControlsInvokeActionEvent,
@@ -22,18 +22,12 @@ export const useRozeniteControlsPlugin = (
     pluginId: '@rozenite/controls-plugin',
   });
   const registrationIdRef = useRef<symbol>(Symbol('rozenite-controls'));
-  const [ownerVersion, setOwnerVersion] = useState(0);
   const registrationId = registrationIdRef.current;
-
-  useEffect(() => {
-    const unsubscribe = controlsRegistry.subscribe(() => {
-      setOwnerVersion((version) => version + 1);
-    });
-
-    setOwnerVersion((version) => version + 1);
-
-    return unsubscribe;
-  }, []);
+  const registrySnapshot = useSyncExternalStore(
+    controlsRegistry.subscribe,
+    controlsRegistry.getSnapshot,
+    controlsRegistry.getSnapshot,
+  );
 
   useEffect(() => {
     return () => {
@@ -51,7 +45,7 @@ export const useRozeniteControlsPlugin = (
         id: registrationId,
         input: optionsInput,
       }),
-    [optionsInput, ownerVersion, registrationId],
+    [optionsInput, registrySnapshot, registrationId],
   );
 
   useControlsAgentTools(
@@ -68,7 +62,7 @@ export const useRozeniteControlsPlugin = (
       type: 'snapshot',
       sections: serializeSections(controlsRegistry.getOptions().sections),
     });
-  }, [client, optionsInput, ownerVersion]);
+  }, [client, optionsInput, registrySnapshot]);
 
   useEffect(() => {
     if (!client || !isRegistryOwner) {

--- a/packages/controls-plugin/src/react-native/useRozeniteControlsPlugin.ts
+++ b/packages/controls-plugin/src/react-native/useRozeniteControlsPlugin.ts
@@ -1,11 +1,11 @@
 import { useRozeniteDevToolsClient } from '@rozenite/plugin-bridge';
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type {
   ControlsEventMap,
   ControlsInvokeActionEvent,
   ControlsUpdateRequestEvent,
 } from '../shared/messaging';
-import type { RozeniteControlsPluginOptions } from '../shared/types';
+import type { RozeniteControlsPluginOptionsInput } from '../shared/types';
 import {
   buildActionRegistry,
   getActionRegistryKey,
@@ -13,23 +13,51 @@ import {
   validateValue,
 } from '../shared/serialization';
 import { useControlsAgentTools } from './useControlsAgentTools';
+import { controlsRegistry } from './controlsRegistry';
 
-export const useRozeniteControlsPlugin = ({
-  sections,
-}: RozeniteControlsPluginOptions) => {
+export const useRozeniteControlsPlugin = (
+  optionsInput: RozeniteControlsPluginOptionsInput,
+) => {
   const client = useRozeniteDevToolsClient<ControlsEventMap>({
     pluginId: '@rozenite/controls-plugin',
   });
-
-  useControlsAgentTools(sections);
-
-  const snapshot = useMemo(() => serializeSections(sections), [sections]);
-  const actionRegistry = useMemo(() => buildActionRegistry(sections), [sections]);
-  const actionRegistryRef = useRef(actionRegistry);
+  const registrationIdRef = useRef<symbol>(Symbol('rozenite-controls'));
+  const [ownerVersion, setOwnerVersion] = useState(0);
+  const registrationId = registrationIdRef.current;
 
   useEffect(() => {
-    actionRegistryRef.current = actionRegistry;
-  }, [actionRegistry]);
+    const unsubscribe = controlsRegistry.subscribe(() => {
+      setOwnerVersion((version) => version + 1);
+    });
+
+    setOwnerVersion((version) => version + 1);
+
+    return unsubscribe;
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      controlsRegistry.delete(registrationId);
+    };
+  }, [registrationId]);
+
+  useEffect(() => {
+    controlsRegistry.set(registrationId, optionsInput);
+  }, [optionsInput, registrationId]);
+
+  const isRegistryOwner = useMemo(
+    () =>
+      controlsRegistry.isOwner(registrationId, {
+        id: registrationId,
+        input: optionsInput,
+      }),
+    [optionsInput, ownerVersion, registrationId],
+  );
+
+  useControlsAgentTools(
+    () => controlsRegistry.getOptions().sections,
+    isRegistryOwner,
+  );
 
   useEffect(() => {
     if (!client) {
@@ -38,12 +66,12 @@ export const useRozeniteControlsPlugin = ({
 
     client.send('snapshot', {
       type: 'snapshot',
-      sections: snapshot,
+      sections: serializeSections(controlsRegistry.getOptions().sections),
     });
-  }, [client, snapshot]);
+  }, [client, optionsInput, ownerVersion]);
 
   useEffect(() => {
-    if (!client) {
+    if (!client || !isRegistryOwner) {
       return;
     }
 
@@ -54,7 +82,9 @@ export const useRozeniteControlsPlugin = ({
       value,
     }: ControlsUpdateRequestEvent) => {
       const key = getActionRegistryKey(sectionId, itemId);
-      const entry = actionRegistryRef.current.get(key);
+      const entry = buildActionRegistry(
+        controlsRegistry.getOptions().sections,
+      ).get(key);
 
       if (!entry || entry.type === 'button') {
         client.send('update-result', {
@@ -142,7 +172,7 @@ export const useRozeniteControlsPlugin = ({
       } catch (error) {
         console.warn(
           `[Rozenite] Controls Plugin: Update failed for ${sectionId}/${itemId}.`,
-          error
+          error,
         );
         client.send('update-result', {
           type: 'update-result',
@@ -162,17 +192,19 @@ export const useRozeniteControlsPlugin = ({
     }: ControlsInvokeActionEvent) => {
       if (action !== 'press') {
         console.warn(
-          `[Rozenite] Controls Plugin: Unsupported action "${action}" for ${sectionId}/${itemId}.`
+          `[Rozenite] Controls Plugin: Unsupported action "${action}" for ${sectionId}/${itemId}.`,
         );
         return;
       }
 
       const key = getActionRegistryKey(sectionId, itemId);
-      const entry = actionRegistryRef.current.get(key);
+      const entry = buildActionRegistry(
+        controlsRegistry.getOptions().sections,
+      ).get(key);
 
       if (!entry) {
         console.warn(
-          `[Rozenite] Controls Plugin: Action target not found for ${sectionId}/${itemId}.`
+          `[Rozenite] Controls Plugin: Action target not found for ${sectionId}/${itemId}.`,
         );
         return;
       }
@@ -180,7 +212,7 @@ export const useRozeniteControlsPlugin = ({
       try {
         if (entry.type !== 'button') {
           console.warn(
-            `[Rozenite] Controls Plugin: Invalid press action payload for ${sectionId}/${itemId}.`
+            `[Rozenite] Controls Plugin: Invalid press action payload for ${sectionId}/${itemId}.`,
           );
           return;
         }
@@ -189,7 +221,7 @@ export const useRozeniteControlsPlugin = ({
       } catch (error) {
         console.warn(
           `[Rozenite] Controls Plugin: Action failed for ${sectionId}/${itemId}.`,
-          error
+          error,
         );
       }
     };
@@ -198,12 +230,15 @@ export const useRozeniteControlsPlugin = ({
       client.onMessage('get-snapshot', () => {
         client.send('snapshot', {
           type: 'snapshot',
-          sections: snapshot,
+          sections: serializeSections(controlsRegistry.getOptions().sections),
         });
       }),
-      client.onMessage('update-request', (event: ControlsUpdateRequestEvent) => {
-        void handleUpdateRequest(event);
-      }),
+      client.onMessage(
+        'update-request',
+        (event: ControlsUpdateRequestEvent) => {
+          void handleUpdateRequest(event);
+        },
+      ),
       client.onMessage('invoke-action', (event: ControlsInvokeActionEvent) => {
         void handleInvokeAction(event);
       }),
@@ -212,7 +247,7 @@ export const useRozeniteControlsPlugin = ({
     return () => {
       subscriptions.forEach((subscription) => subscription.remove());
     };
-  }, [client, snapshot]);
+  }, [client, isRegistryOwner]);
 
   return client;
 };

--- a/packages/controls-plugin/src/shared/types.ts
+++ b/packages/controls-plugin/src/shared/types.ts
@@ -98,6 +98,14 @@ export type RozeniteControlsPluginOptions = {
   sections: ControlsSection[];
 };
 
+export type RozeniteControlsPluginOptionsUpdater = (
+  previousOptions: RozeniteControlsPluginOptions,
+) => RozeniteControlsPluginOptions;
+
+export type RozeniteControlsPluginOptionsInput =
+  | RozeniteControlsPluginOptions
+  | RozeniteControlsPluginOptionsUpdater;
+
 export const createSection = <TSection extends ControlsSection>(
-  section: TSection
+  section: TSection,
 ): TSection => section;

--- a/plugin-directory.json
+++ b/plugin-directory.json
@@ -74,5 +74,13 @@
   {
     "npmUrl": "https://www.npmjs.com/package/rozenite-growthbook-plugin",
     "githubUrl": "https://github.com/valeriobelli/rozenite-growthbook-plugin"
+  },
+  {
+    "npmUrl": "https://www.npmjs.com/package/rozenite-zustand-devtools",
+    "githubUrl": "https://github.com/IronTony/rozenite-zustand-devtools"
+  },
+  {
+    "npmUrl": "https://www.npmjs.com/package/rozenite-navigation-inspector",
+    "githubUrl": "https://github.com/IronTony/rozenite-navigation-inspector"
   }
 ]


### PR DESCRIPTION
## Description

  Adds support for composing Controls Plugin sections from multiple `useRozeniteControlsPlugin`
  hook instances. The hook now accepts either options or an updater function, so components can
  extend previously registered sections instead of replacing them.

  ## Related Issue

  Fixes #284

  ## Context

  Previously, each hook instance sent its own full snapshot, so the last mounted/updated
  component could overwrite controls registered elsewhere. This change adds a shared registry
  that combines active registrations and keeps UI, updates, actions, and agent tools resolved
  against the composed section list.

  ## Testing
  - Manual playground check with a second hook instance registering `Extra Section`; confirmed
  both original controls and extra section appear and the extra toggle works.