### PR TITLE
fix(middleware): set debugger websocket origin

### DIFF
--- a/.changeset/agent-debugger-origin.md
+++ b/.changeset/agent-debugger-origin.md
@@ -1,0 +1,5 @@
+---
+'@rozenite/middleware': patch
+---
+
+Set the debugger WebSocket origin to `http://localhost:<port>` for better compatibility with local dev servers.

--- a/packages/middleware/src/__tests__/agent-session.test.ts
+++ b/packages/middleware/src/__tests__/agent-session.test.ts
@@ -44,11 +44,13 @@ const mocks = vi.hoisted(() => {
     static readonly CLOSED = 3;
 
     readonly url: string;
+    readonly options: unknown;
     readyState = MockWebSocket.CONNECTING;
     private listeners = new Map<string, Set<(...args: unknown[]) => void>>();
 
-    constructor(url: string) {
+    constructor(url: string, options?: unknown) {
       this.url = url;
+      this.options = options;
       wsInstances.push(this);
     }
 
@@ -321,6 +323,17 @@ describe('agent session', () => {
 
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  it('sets a localhost origin header for the debugger websocket', () => {
+    const { socket } = createStartedSession();
+
+    expect(socket.url).toBe(TARGET.webSocketDebuggerUrl);
+    expect(socket.options).toEqual({
+      headers: {
+        Origin: 'http://localhost:8081',
+      },
+    });
   });
 
   it('does not resolve start before the bootstrap delay elapses', async () => {

--- a/packages/middleware/src/agent/session.ts
+++ b/packages/middleware/src/agent/session.ts
@@ -30,6 +30,10 @@ const DISPATCHER_INIT_RETRY_MS = 250;
 const PLUGIN_READINESS_QUIET_WINDOW_MS = 50;
 const PLUGIN_READINESS_MAX_WAIT_MS = 250;
 
+const getDebuggerWebSocketOrigin = (port: number): string => {
+  return `http://localhost:${port}`;
+};
+
 type PendingCommand = {
   resolve: (value: Record<string, unknown>) => void;
   reject: (error: Error) => void;
@@ -604,7 +608,11 @@ export const createAgentSession = (options: {
     status = 'connecting';
 
     await new Promise<void>((resolve, reject) => {
-      const socket = new WebSocket(options.target.webSocketDebuggerUrl);
+      const socket = new WebSocket(options.target.webSocketDebuggerUrl, {
+        headers: {
+          Origin: getDebuggerWebSocketOrigin(options.port),
+        },
+      });
       let settled = false;
       ws = socket;
 


### PR DESCRIPTION
## What is this?

This PR fixes Rozenite for Agents failing to create a session against React Native 0.85 Metro servers. React Native dev-middleware now validates the `Origin` header on debugger WebSocket upgrades, and Rozenite was opening the CDP socket without one, which caused the upgrade to be rejected with HTTP 401.

Fixes #296.

## How does it work?

When the agent session opens the target `webSocketDebuggerUrl`, it now passes a WebSocket header with `Origin: http://localhost:<metroPort>`. `localhost` is accepted by React Native dev-middleware's debugger WebSocket origin allow-list, so the connection can pass the upgrade check before Rozenite continues its normal CDP bootstrap flow.

The session test WebSocket mock now records constructor options, and the middleware session test asserts that the debugger socket is created with the expected localhost Origin header.

## Why is this useful?

This restores the first step of `rozenite agent session create` for React Native 0.85 projects, where plain HTTP target discovery succeeds but the debugger WebSocket connection is rejected before the agent can bootstrap. The change is narrow to the agent's CDP connection path and keeps compatibility with the existing Metro host and port tracking used by the middleware.
