### PR TITLE
fix(network-activity-plugin): filter internal initiator frames

### DIFF
--- a/.changeset/filter-hermes-symbolication.md
+++ b/.changeset/filter-hermes-symbolication.md
@@ -1,0 +1,5 @@
+---
+"@rozenite/network-activity-plugin": patch
+---
+
+Filter Hermes internal bytecode frames out of Network Activity initiator symbolication requests so Metro no longer tries to read pseudo-files like `address at InternalBytecode.js`.

--- a/packages/network-activity-plugin/src/ui/utils/__tests__/symbolication.test.ts
+++ b/packages/network-activity-plugin/src/ui/utils/__tests__/symbolication.test.ts
@@ -126,6 +126,79 @@ describe('symbolication', () => {
     });
   });
 
+  it('keeps internal Hermes frames out of the Metro symbolication request', async () => {
+    const initiator: Initiator = {
+      type: 'script',
+      generatedUrl: 'address at InternalBytecode.js',
+      generatedLineNumber: 1,
+      generatedColumnNumber: 12345,
+      symbolicationStatus: 'pending',
+      stack: [
+        {
+          functionName: 'anonymous',
+          generatedUrl: 'address at InternalBytecode.js',
+          generatedLineNumber: 1,
+          generatedColumnNumber: 12345,
+        },
+        {
+          functionName: 'loadUsers',
+          generatedUrl: 'http://localhost:8081/index.bundle',
+          generatedLineNumber: 1,
+          generatedColumnNumber: 200,
+        },
+      ],
+    };
+    const symbolicateStackTrace = vi.fn().mockResolvedValue({
+      stack: [
+        {
+          methodName: 'loadUsers',
+          file: 'apps/playground/src/app/api.ts',
+          lineNumber: 30,
+          column: 6,
+        },
+      ],
+    });
+
+    const symbolicatedInitiator = await symbolicateInitiator(
+      initiator,
+      symbolicateStackTrace,
+    );
+
+    expect(symbolicateStackTrace).toHaveBeenCalledWith([
+      {
+        methodName: 'loadUsers',
+        file: 'http://localhost:8081/index.bundle',
+        lineNumber: 1,
+        column: 200,
+      },
+    ]);
+    expect(symbolicatedInitiator).toMatchObject({
+      type: 'script',
+      functionName: 'loadUsers',
+      url: 'apps/playground/src/app/api.ts',
+      lineNumber: 30,
+      columnNumber: 6,
+      symbolicationStatus: 'complete',
+      stack: [
+        {
+          functionName: 'anonymous',
+          generatedUrl: 'address at InternalBytecode.js',
+          generatedLineNumber: 1,
+          generatedColumnNumber: 12345,
+        },
+        {
+          functionName: 'loadUsers',
+          url: 'apps/playground/src/app/api.ts',
+          lineNumber: 30,
+          columnNumber: 6,
+          generatedUrl: 'http://localhost:8081/index.bundle',
+          generatedLineNumber: 1,
+          generatedColumnNumber: 200,
+        },
+      ],
+    });
+  });
+
   it('reports symbolication failures on the initiator', async () => {
     const initiator: Initiator = {
       type: 'script',

--- a/packages/network-activity-plugin/src/ui/utils/symbolication.ts
+++ b/packages/network-activity-plugin/src/ui/utils/symbolication.ts
@@ -37,9 +37,12 @@ const getGeneratedFrameLocation = (frame: InitiatorStackFrame) => ({
 const isGeneratedBundleUrl = (url: string) =>
   /[^/]+\.bundle(?:[/?#]|$)/.test(url);
 
+const isMetroSymbolicatableUrl = (url?: string) =>
+  url?.startsWith('http') ?? false;
+
 const canSymbolicateStack = (stack?: InitiatorStackFrame[]) =>
   stack?.some((frame) =>
-    getGeneratedFrameLocation(frame).url?.startsWith('http'),
+    isMetroSymbolicatableUrl(getGeneratedFrameLocation(frame).url),
   ) ?? false;
 
 const toReactNativeStackFrame = (
@@ -47,7 +50,7 @@ const toReactNativeStackFrame = (
 ): ReactNativeStackFrame | null => {
   const generatedLocation = getGeneratedFrameLocation(frame);
 
-  if (!generatedLocation.url) {
+  if (!isMetroSymbolicatableUrl(generatedLocation.url)) {
     return null;
   }
 
@@ -195,21 +198,45 @@ export const symbolicateInitiator = async (
     return null;
   }
 
-  const generatedStackFrames =
-    initiator.stack
-      ?.map(toReactNativeStackFrame)
-      .filter((frame): frame is ReactNativeStackFrame => frame !== null) ?? [];
+  const originalStack = initiator.stack ?? [];
+  const generatedStackFrames = originalStack.flatMap(
+    (originalFrame, originalIndex) => {
+      const frame = toReactNativeStackFrame(originalFrame);
+      return frame ? [{ frame, originalIndex }] : [];
+    },
+  );
 
   if (generatedStackFrames.length === 0) {
     return null;
   }
 
   try {
-    const symbolicatedStackTrace =
-      await symbolicateStackTrace(generatedStackFrames);
+    const symbolicatedStackTrace = await symbolicateStackTrace(
+      generatedStackFrames.map((entry) => entry.frame),
+    );
 
-    const symbolicatedStack = symbolicatedStackTrace.stack.map((frame, index) =>
-      fromSymbolicatedStackFrame(frame, initiator.stack?.[index]),
+    const symbolicatedFramesByOriginalIndex = new Map<
+      number,
+      InitiatorStackFrame
+    >();
+
+    symbolicatedStackTrace.stack.forEach((frame, index) => {
+      const generatedFrame = generatedStackFrames[index];
+      if (!generatedFrame) {
+        return;
+      }
+
+      symbolicatedFramesByOriginalIndex.set(
+        generatedFrame.originalIndex,
+        fromSymbolicatedStackFrame(
+          frame,
+          originalStack[generatedFrame.originalIndex],
+        ),
+      );
+    });
+
+    const symbolicatedStack = originalStack.map(
+      (frame, index) => symbolicatedFramesByOriginalIndex.get(index) ?? frame,
     );
     const sourceFrame = getPreferredSourceFrame(
       symbolicatedStack,


### PR DESCRIPTION
## What is this?

This PR fixes Network Activity initiator symbolication for Hermes stacks that include internal bytecode frames. Mixed stacks could previously send pseudo-files like `address at InternalBytecode.js` to Metro, which made Metro try to read them as project files during code-frame generation.

Fixes #294.

## How does it work?

The initiator symbolication helper now sends only Metro-symbolicatable generated frames to `/symbolicate`, currently the frames backed by HTTP bundle URLs. It keeps track of each submitted frame's original stack index, then merges the symbolicated result back into the original initiator stack so internal Hermes frames remain available as generated context without being treated as source files.

## Why is this useful?

Network Activity keeps source-mapped request initiator details for real app frames while avoiding noisy Metro file-read failures for Hermes internals. The fix is narrow to symbolication payload construction, so existing initiator display behavior stays intact for valid Metro bundle frames.