### PR TITLE
fix(middleware): handle abandoned CDP command rejections

### DIFF
--- a/.changeset/agent-cdp-close-rejections.md
+++ b/.changeset/agent-cdp-close-rejections.md
@@ -1,0 +1,5 @@
+---
+'@rozenite/middleware': patch
+---
+
+Avoid unhandled rejections when pending CDP commands are left behind during websocket teardown.

--- a/packages/middleware/src/__tests__/agent-session.test.ts
+++ b/packages/middleware/src/__tests__/agent-session.test.ts
@@ -36,6 +36,7 @@ const mocks = vi.hoisted(() => {
   }));
   const wsInstances: MockWebSocket[] = [];
   let bindingName = 'rozenite-binding';
+  let stalledRuntimeExpression: string | null = null;
 
   class MockWebSocket {
     static readonly CONNECTING = 0;
@@ -92,6 +93,16 @@ const mocks = vi.hoisted(() => {
         params: payload.params,
       });
       callback?.();
+
+      if (
+        payload.method === 'Runtime.evaluate' &&
+        stalledRuntimeExpression &&
+        String(payload.params?.expression ?? '').includes(
+          stalledRuntimeExpression,
+        )
+      ) {
+        return;
+      }
 
       queueMicrotask(() => {
         this.emit(
@@ -162,6 +173,9 @@ const mocks = vi.hoisted(() => {
     extractConsoleMessage: vi.fn(() => null),
     parseRozeniteBindingPayload: vi.fn(() => null),
     wsInstances,
+    stallRuntimeEvaluationContaining: (expression: string) => {
+      stalledRuntimeExpression = expression;
+    },
     reset: () => {
       commandLog.length = 0;
       loggerInfo.mockReset();
@@ -181,6 +195,7 @@ const mocks = vi.hoisted(() => {
         service.captureReactDevToolsMessage?.mockReset();
       });
       bindingName = 'rozenite-binding';
+      stalledRuntimeExpression = null;
       wsInstances.length = 0;
     },
   };
@@ -522,6 +537,40 @@ describe('agent session', () => {
     expect(mocks.loggerInfo).toHaveBeenCalledWith(
       'Rozenite for Agents disconnected from device iPhone 16 (device-1).',
     );
+  });
+
+  it('handles pending CDP command rejection for detached senders when the websocket closes', async () => {
+    const unhandledRejections: unknown[] = [];
+    const handleUnhandledRejection = (reason: unknown) => {
+      unhandledRejections.push(reason);
+    };
+    process.on('unhandledRejection', handleUnhandledRejection);
+
+    try {
+      const { socket } = await startSession();
+      mocks.stallRuntimeEvaluationContaining('detached-cdp-message');
+
+      const sender = mocks.handler.connectDevice.mock.calls[0]?.[2] as
+        | { sendMessage: (message: unknown) => void }
+        | undefined;
+      expect(sender).toBeDefined();
+
+      sender?.sendMessage({
+        marker: 'detached-cdp-message',
+      });
+      await flushMicrotasks();
+
+      socket.close();
+      await flushMicrotasks();
+      vi.useRealTimers();
+      await new Promise((resolve) => {
+        setImmediate(resolve);
+      });
+
+      expect(unhandledRejections).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', handleUnhandledRejection);
+    }
   });
 
   it('rejects startup if the websocket closes before bootstrap completes', async () => {

--- a/packages/middleware/src/agent/session.ts
+++ b/packages/middleware/src/agent/session.ts
@@ -57,6 +57,11 @@ type CDPEvaluateResponse = {
 
 export type AgentSession = ReturnType<typeof createAgentSession>;
 
+const markPromiseAsHandled = <T>(promise: Promise<T>): Promise<T> => {
+  void promise.catch(() => undefined);
+  return promise;
+};
+
 const getToolCount = (
   target: MetroTarget,
   handler: AgentMessageHandler,
@@ -246,19 +251,21 @@ export const createAgentSession = (options: {
     }
   };
 
-  const sendCommand = async (
+  const sendCommand = (
     method: string,
     params?: Record<string, unknown>,
   ): Promise<Record<string, unknown>> => {
     if (!ws || ws.readyState !== WebSocket.OPEN) {
-      throw new Error('CDP websocket is not connected');
+      return markPromiseAsHandled(
+        Promise.reject(new Error('CDP websocket is not connected')),
+      );
     }
 
     const commandId = nextCommandId++;
     const payload = JSON.stringify({ id: commandId, method, params });
     touch();
 
-    return await new Promise((resolve, reject) => {
+    const promise = new Promise<Record<string, unknown>>((resolve, reject) => {
       pendingCommands.set(commandId, { resolve, reject });
       ws!.send(payload, (error) => {
         if (!error) {
@@ -269,6 +276,11 @@ export const createAgentSession = (options: {
         reject(error);
       });
     });
+
+    // The pending command map owns the promise lifecycle. Attach a rejection
+    // handler immediately so detached callers cannot surface socket teardown as
+    // a process-level unhandled rejection.
+    return markPromiseAsHandled(promise);
   };
 
   const localServices: LocalAgentToolService[] = [
@@ -313,15 +325,17 @@ export const createAgentSession = (options: {
     }, BOOTSTRAP_DELAY_MS);
   };
 
-  const sendDomainMessage = async (
+  const sendDomainMessage = (
     domain: string,
     message: unknown,
   ): Promise<void> => {
     const serializedMessage = JSON.stringify(message);
     const escapedMessage = JSON.stringify(serializedMessage);
-    await sendCommand('Runtime.evaluate', {
-      expression: `${RUNTIME_GLOBAL}.sendMessage(${JSON.stringify(domain)}, ${escapedMessage})`,
-    });
+    return markPromiseAsHandled(
+      sendCommand('Runtime.evaluate', {
+        expression: `${RUNTIME_GLOBAL}.sendMessage(${JSON.stringify(domain)}, ${escapedMessage})`,
+      }).then(() => undefined),
+    );
   };
 
   const sendAgentSessionReady = async (): Promise<void> => {


### PR DESCRIPTION
## What is this?

This PR fixes a Rozenite for Agents crash where Metro could terminate after an agent session CDP socket closed while a command was still pending. The failure happened when socket teardown rejected an internally tracked command promise that no caller was still observing.

## How does it work?

The session CDP command path now marks internally managed command promises as handled as soon as they are created, while still returning the same promise so awaited callers receive the original rejection. Domain messages also return a handled promise because they derive a new promise from the underlying CDP command. A regression test keeps a detached `Runtime.evaluate` pending, closes the websocket, and verifies that no process-level unhandled rejection is emitted.

## Why is this useful?

Debugger disconnects, app reloads, and stopped agent sessions can now clean up pending CDP work without taking Metro down. This keeps Rozenite for Agents safer to use in shared Metro processes while preserving normal error behavior for callers that await command results.

Fixes #293