### PR TITLE
fix(file-system-plugin): support Expo bundle asset listings

### DIFF
--- a/.changeset/fuzzy-assets-drum.md
+++ b/.changeset/fuzzy-assets-drum.md
@@ -1,0 +1,5 @@
+---
+"@rozenite/file-system-plugin": patch
+---
+
+Fix modern Expo FileSystem bundle directory inspection on Android by listing `asset://` entries without statting packaged asset files.

--- a/packages/file-system-plugin/src/__tests__/fileSystemProvider.test.ts
+++ b/packages/file-system-plugin/src/__tests__/fileSystemProvider.test.ts
@@ -65,7 +65,10 @@ const createExpoFileSystem = (): ExpoFileSystemLike => ({
         return options?.encoding === 'base64' ? 'aGVsbG8=' : 'hello';
       }
 
-      if (path === 'file:///documents/binary.bin' && options?.encoding === 'utf8') {
+      if (
+        path === 'file:///documents/binary.bin' &&
+        options?.encoding === 'utf8'
+      ) {
         throw new Error('Invalid UTF-8');
       }
 
@@ -75,8 +78,16 @@ const createExpoFileSystem = (): ExpoFileSystemLike => ({
   writeAsStringAsync: vi.fn(async () => {}),
 });
 
-const createExpoModernFileSystem = (): ExpoFileSystemLike => {
+const createExpoModernFileSystem = (
+  options: { bundleUri?: string } = {},
+): ExpoFileSystemLike => {
+  const bundleUri = options.bundleUri ?? 'file:///bundle';
+
   const pathInfo = vi.fn(async (path: string) => {
+    if (!path.startsWith('file://')) {
+      throw new Error('URI scheme is not "file"');
+    }
+
     if (path === 'file:///documents' || path === 'file:///documents/') {
       return { exists: true, isDirectory: true };
     }
@@ -105,15 +116,29 @@ const createExpoModernFileSystem = (): ExpoFileSystemLike => {
       this.name = trimmed.slice(trimmed.lastIndexOf('/') + 1);
     }
     async info() {
+      const uri = this.uri.endsWith('/') ? this.uri.slice(0, -1) : this.uri;
+      if (/\.(bin|json|png|txt)$/.test(uri)) {
+        throw new Error('Invalid directory type');
+      }
+
       return {
         exists: true,
         modificationTime: 100,
       };
     }
     async list() {
-      return [
-        new MockFile('file:///documents/hello.txt'),
-      ];
+      if (this.uri.startsWith('asset://')) {
+        return [
+          new MockDirectory('file:///images'),
+          new MockFile('file:///app.json'),
+        ];
+      }
+
+      if (this.uri === 'file:///restricted/') {
+        return [new MockFile('file:///restricted/app.json')];
+      }
+
+      return [new MockFile('file:///documents/hello.txt')];
     }
   }
 
@@ -131,6 +156,16 @@ const createExpoModernFileSystem = (): ExpoFileSystemLike => {
       this.modificationTime = 101000;
     }
     async info() {
+      if (
+        this.uri.startsWith('asset://') ||
+        this.uri === 'file:///app.json' ||
+        this.uri.startsWith('file:///restricted/')
+      ) {
+        throw new Error(
+          "Call to function 'FileSystemFile.info' has been rejected.\n→ Caused by: Missing 'READ' permission for accessing the file.",
+        );
+      }
+
       return {
         exists: true,
         size: this.size,
@@ -155,7 +190,7 @@ const createExpoModernFileSystem = (): ExpoFileSystemLike => {
     Paths: {
       document: { uri: 'file:///documents' },
       cache: { uri: 'file:///cache' },
-      bundle: { uri: 'file:///bundle' },
+      bundle: { uri: bundleUri },
       info: pathInfo,
     },
     // Modern Expo still exposes deprecated functions that throw at runtime.
@@ -212,14 +247,16 @@ const createCustomAdapter = (): FileSystemAdapter => ({
   provider: 'rnfs',
   getRoots: vi.fn(async () => []),
   listDir: vi.fn(async () => []),
-  statPath: vi.fn(async (path: string): Promise<FsEntry> => ({
-    name: path,
-    path,
-    isDirectory: false,
-    size: 0,
-    modifiedAtMs: null,
-    mimeTypeHint: null,
-  })),
+  statPath: vi.fn(
+    async (path: string): Promise<FsEntry> => ({
+      name: path,
+      path,
+      isDirectory: false,
+      size: 0,
+      modifiedAtMs: null,
+      mimeTypeHint: null,
+    }),
+  ),
   readImageBase64: vi.fn(async () => ({
     mime: 'image/png',
     base64: 'ZmFrZQ==',
@@ -412,13 +449,63 @@ describe('createExpoFileSystemAdapter', () => {
       },
     ]);
 
-    await expect(adapter.readTextFile('file:///documents/hello.txt', 10)).resolves.toBe(
-      'hello',
-    );
+    await expect(
+      adapter.readTextFile('file:///documents/hello.txt', 10),
+    ).resolves.toBe('hello');
 
     await expect(
       adapter.readTextFile('file:///documents/binary.bin', 10),
     ).resolves.toContain('[Binary file - 4 bytes]');
+  });
+
+  it('lists modern Expo Android bundle assets without using Paths.info', async () => {
+    const expoFileSystem = createExpoModernFileSystem({
+      bundleUri: 'asset:///',
+    });
+    const adapter = createExpoFileSystemAdapter(expoFileSystem);
+
+    await expect(adapter.getRoots()).resolves.toContainEqual({
+      id: 'expo.bundleDirectory',
+      label: 'Bundle Directory',
+      path: 'asset:///',
+    });
+
+    await expect(adapter.listDir('asset:///')).resolves.toEqual([
+      {
+        name: 'images',
+        path: 'asset:///images/',
+        isDirectory: true,
+        size: null,
+        modifiedAtMs: null,
+        mimeTypeHint: null,
+      },
+      {
+        name: 'app.json',
+        path: 'asset:///app.json',
+        isDirectory: false,
+        size: null,
+        modifiedAtMs: null,
+        mimeTypeHint: null,
+      },
+    ]);
+
+    expect(expoFileSystem.Paths.info).not.toHaveBeenCalled();
+  });
+
+  it('falls back to list item metadata when Expo file info is permission denied', async () => {
+    const expoFileSystem = createExpoModernFileSystem();
+    const adapter = createExpoFileSystemAdapter(expoFileSystem);
+
+    await expect(adapter.listDir('file:///restricted')).resolves.toEqual([
+      {
+        name: 'app.json',
+        path: 'file:///restricted/app.json',
+        isDirectory: false,
+        size: null,
+        modifiedAtMs: null,
+        mimeTypeHint: null,
+      },
+    ]);
   });
 
   it('writes raw files through the modern Expo File API', async () => {
@@ -499,14 +586,14 @@ describe('createRNFSAdapter', () => {
     const rnfs = createRNFS();
     const adapter = createRNFSAdapter(rnfs);
 
-    await expect(adapter.readFileBase64?.('/documents/binary.bin')).resolves.toEqual(
-      {
-        fileName: 'binary.bin',
-        mime: 'application/octet-stream',
-        size: 4,
-        base64: 'AAECAw==',
-      },
-    );
+    await expect(
+      adapter.readFileBase64?.('/documents/binary.bin'),
+    ).resolves.toEqual({
+      fileName: 'binary.bin',
+      mime: 'application/octet-stream',
+      size: 4,
+      base64: 'AAECAw==',
+    });
 
     await expect(
       adapter.writeFileBase64?.('/documents/import.bin', 'AAECAw=='),

--- a/packages/file-system-plugin/src/react-native/fileSystemProvider.ts
+++ b/packages/file-system-plugin/src/react-native/fileSystemProvider.ts
@@ -284,42 +284,138 @@ function createExpoModernFileSystemAdapter(
 ): FileSystemAdapter {
   const FileSystem = fileSystem?.default ?? fileSystem;
 
-  const buildEntry = async (rawPath: string): Promise<FsEntry> => {
-    const pathInfo = await FileSystem.Paths.info(rawPath);
+  const isAssetUri = (uri: string): boolean => uri.startsWith('asset://');
 
-    if (!pathInfo?.exists) {
-      throw new Error(`Path "${rawPath}" does not exist.`);
-    }
-
-    const isDirectory = Boolean(pathInfo.isDirectory);
-    const target = isDirectory
-      ? new FileSystem.Directory(rawPath)
-      : new FileSystem.File(rawPath);
-    const info = await target.info();
+  const buildEntryFromMetadata = (
+    target: any,
+    isDirectory: boolean,
+    info?: any,
+    options: { includeTargetStats?: boolean; path?: string } = {},
+  ): FsEntry => {
+    const path = options.path ?? target.uri;
     const normalizedPath = isDirectory
-      ? normalizeDirPath(target.uri)
-      : target.uri;
+      ? normalizeDirPath(path)
+      : path;
+    const includeTargetStats = options.includeTargetStats ?? true;
 
     return {
-      name: target.name ?? basename(rawPath),
+      name: target.name ?? basename(path),
       path: normalizedPath,
       isDirectory,
       size:
-        typeof info?.size === 'number'
-          ? info.size
-          : typeof target?.size === 'number'
-            ? target.size
-            : null,
+        isDirectory
+          ? null
+          : typeof info?.size === 'number'
+            ? info.size
+            : includeTargetStats && typeof target?.size === 'number'
+              ? target.size
+              : null,
       modifiedAtMs:
         typeof info?.modificationTime === 'number'
           ? info.modificationTime
-          : typeof target?.modificationTime === 'number'
+          : includeTargetStats && typeof target?.modificationTime === 'number'
             ? target.modificationTime
             : null,
       mimeTypeHint: isDirectory
         ? null
-        : target.type || mimeTypeFromName(normalizedPath),
+        : (includeTargetStats ? target.type : null) ||
+          mimeTypeFromName(normalizedPath),
     };
+  };
+
+  const buildEntryFromTarget = async (
+    target: any,
+    isDirectory: boolean,
+  ): Promise<FsEntry> => {
+    const info = await target.info();
+
+    if (!info?.exists) {
+      throw new Error(`Path "${target.uri}" does not exist.`);
+    }
+
+    return buildEntryFromMetadata(target, isDirectory, info);
+  };
+
+  const isDirectoryLike = (target: any): boolean =>
+    typeof target?.list === 'function' ||
+    typeof target?.createFile === 'function' ||
+    typeof target?.createDirectory === 'function';
+
+  const resolveListItemPath = (
+    parentDir: string,
+    target: any,
+    isDirectory: boolean,
+  ): string => {
+    if (!isAssetUri(parentDir)) return target.uri;
+    if (isAssetUri(target.uri)) return target.uri;
+
+    const name = target.name ?? basename(target.uri);
+    const path = joinPath(parentDir, name);
+    return isDirectory ? normalizeDirPath(path) : path;
+  };
+
+  const isReadPermissionError = (error: unknown): boolean => {
+    const message = safeError(error);
+    return (
+      message.includes('Missing') &&
+      message.includes('READ') &&
+      message.includes('permission')
+    );
+  };
+
+  const buildEntryFromListItem = (
+    target: any,
+    parentDir: string,
+  ): Promise<FsEntry> => {
+    const isDirectory = isDirectoryLike(target);
+    const path = resolveListItemPath(parentDir, target, isDirectory);
+    const parentIsAssetUri = isAssetUri(parentDir);
+
+    if (parentIsAssetUri || isAssetUri(target.uri)) {
+      return Promise.resolve(
+        buildEntryFromMetadata(target, isDirectory, undefined, {
+          includeTargetStats: false,
+          path,
+        }),
+      );
+    }
+
+    return buildEntryFromTarget(target, isDirectory).catch((error) => {
+      if (isReadPermissionError(error)) {
+        return buildEntryFromMetadata(target, isDirectory, undefined, {
+          includeTargetStats: false,
+          path,
+        });
+      }
+
+      throw error;
+    });
+  };
+
+  const buildEntry = async (rawPath: string): Promise<FsEntry> => {
+    try {
+      return await buildEntryFromTarget(
+        new FileSystem.Directory(rawPath),
+        true,
+      );
+    } catch (directoryError) {
+      try {
+        return await buildEntryFromTarget(new FileSystem.File(rawPath), false);
+      } catch {
+        if (isAssetUri(rawPath)) {
+          return buildEntryFromMetadata(
+            new FileSystem.File(rawPath),
+            false,
+            undefined,
+            {
+              includeTargetStats: false,
+            },
+          );
+        }
+
+        throw directoryError;
+      }
+    }
   };
 
   const getRootUri = (candidate: any) => {
@@ -367,7 +463,7 @@ function createExpoModernFileSystemAdapter(
       const MAX_ENTRIES = 400;
       const limited = rawItems.slice(0, MAX_ENTRIES);
       const entries = await Promise.all(
-        limited.map(async (item: any) => buildEntry(item.uri)),
+        limited.map(async (item: any) => buildEntryFromListItem(item, dir)),
       );
 
       if (rawItems.length > MAX_ENTRIES) {
@@ -443,8 +539,12 @@ function createExpoModernFileSystemAdapter(
       return buildEntry(file.uri ?? path);
     },
     async pathExists(path) {
-      const pathInfo = await FileSystem.Paths.info(path);
-      return Boolean(pathInfo?.exists);
+      try {
+        await buildEntry(path);
+        return true;
+      } catch {
+        return false;
+      }
     },
   };
 }


### PR DESCRIPTION
## Description

  Fixes modern Expo FileSystem bundle directory inspection on Android. The
  adapter now handles asset:// bundle roots without statting packaged asset
  entries, which avoids Expo FileSystemFile.info / FileSystemDirectory.info READ
  permission failures.

  ## Related Issue

  Fixes https://github.com/callstackincubator/rozenite/issues/280

  ## Context

  On Android, modern Expo FileSystem exposes the bundle root as asset:///, but
  Directory.list() returns children with file:///... URIs. Calling info() on
  those packaged asset entries can fail with a missing READ permission error.

  This change treats entries listed from an asset:// parent as bundle assets,
  normalizes their paths back under the asset:/// root, and builds metadata from
  the returned File / Directory object instead of calling info(). Normal
  filesystem paths still use info() for size and modified metadata.

  ## Testing

  - pnpm --filter @rozenite/file-system-plugin test
  - pnpm --filter @rozenite/file-system-plugin typecheck
  - pnpm --filter @rozenite/playground typecheck
  - Manually verified in the playground on Android that File System → Bundle
    Directory opens without the Missing 'READ' permission error.