### PR TITLE
feat(redux-devtools-plugin): sanitize and stream state snapshots

### DIFF
--- a/.changeset/redux-devtools-sanitized-partial-state.md
+++ b/.changeset/redux-devtools-sanitized-partial-state.md
@@ -1,0 +1,5 @@
+---
+'@rozenite/redux-devtools-plugin': minor
+---
+
+Add Redux state/action sanitizers and stream initial DevTools history with partial state updates to reduce large snapshot pressure.

--- a/packages/redux-devtools-plugin/README.md
+++ b/packages/redux-devtools-plugin/README.md
@@ -75,14 +75,18 @@ const sessionStoreEnhancer = rozeniteDevToolsEnhancer({ name: 'session-store' })
 
 `maxAge` controls how many actions Redux DevTools keeps in history. The default is `50`.
 
-On React Native, state is serialized and sent to DevTools over the device bridge. Large stores combined with a high `maxAge` can use a lot of memory — on Android this may cause an out-of-memory crash when opening the Redux DevTools panel. If your store is large (for example, it includes RTK Query caches or big entity maps), keep `maxAge` low and consider using Redux DevTools [`stateSanitizer`](https://github.com/reduxjs/redux-devtools/blob/main/extension/docs/API/Arguments.md#statesanitizer-state--state) to strip bulky slices before they are recorded.
+On React Native, state is serialized and sent to DevTools over the device bridge. Large stores combined with a high `maxAge` can use a lot of memory — on Android this may cause an out-of-memory crash when opening the Redux DevTools panel. If your store is large (for example, it includes RTK Query caches or big entity maps), keep `maxAge` low and use `stateSanitizer` or `actionSanitizer` to strip bulky slices before they are sent to DevTools.
 
 ```ts
 rozeniteDevToolsEnhancer({
   maxAge: 20,
-  stateSanitizer: (state) => ({
-    ...state,
+  stateSanitizer: (state, index) => ({
+    ...(state as Record<string, unknown>),
     api: '[omitted]',
+  }),
+  actionSanitizer: (action, id) => ({
+    ...action,
+    payload: action.type === 'large/payload' ? '[omitted]' : action.payload,
   }),
 })
 ```

--- a/packages/redux-devtools-plugin/src/__tests__/runtime.test.ts
+++ b/packages/redux-devtools-plugin/src/__tests__/runtime.test.ts
@@ -1,0 +1,244 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+// @ts-expect-error app-core does not publish declarations for built subpaths.
+import { UPDATE_STATE } from '@redux-devtools/app-core/lib/esm/constants/actionTypes.js';
+// @ts-expect-error app-core does not publish declarations for built subpaths.
+import { instances as reduceInstances } from '@redux-devtools/app-core/lib/esm/reducers/instances.js';
+import { parse } from 'jsan';
+import { createStore, type Action } from 'redux';
+import type {
+  ReduxDevToolsPanelCommand,
+  ReduxDevToolsRuntimeMessage,
+} from '../shared/protocol';
+
+type TestState = {
+  counter: number;
+  largeValue: string;
+};
+
+type TestAction = Action<string> & {
+  payload?: number;
+  largeValue?: string;
+};
+
+const initialState: TestState = {
+  counter: 0,
+  largeValue: 'initial-large-value',
+};
+
+const reducer = (
+  state: TestState = initialState,
+  action: TestAction
+): TestState => {
+  if (action.type === 'counter/add') {
+    return {
+      counter: state.counter + (action.payload ?? 0),
+      largeValue: action.largeValue ?? state.largeValue,
+    };
+  }
+
+  return state;
+};
+
+const setupRuntime = async () => {
+  vi.resetModules();
+
+  const sentMessages: ReduxDevToolsRuntimeMessage[] = [];
+  let panelCommandListener:
+    | ((command: ReduxDevToolsPanelCommand) => void)
+    | null = null;
+
+  vi.doMock('../runtime-bridge', () => ({
+    getRuntimeConnectionId: () => 'test-connection',
+    sendRuntimeMessage: (message: ReduxDevToolsRuntimeMessage) => {
+      sentMessages.push(message);
+    },
+    subscribeToPanelCommands: (
+      listener: (command: ReduxDevToolsPanelCommand) => void
+    ) => {
+      panelCommandListener = listener;
+
+      return () => {
+        panelCommandListener = null;
+      };
+    },
+  }));
+
+  const runtime = await import('../runtime');
+
+  const sendPanelCommand = (command: ReduxDevToolsPanelCommand) => {
+    if (!panelCommandListener) {
+      throw new Error('Panel command listener was not registered.');
+    }
+
+    panelCommandListener(command);
+  };
+
+  return {
+    ...runtime,
+    sentMessages,
+    sendPanelCommand,
+  };
+};
+
+const getStateUpdateRequests = (messages: ReduxDevToolsRuntimeMessage[]) => {
+  return messages
+    .filter((message) => message.type === 'state-update')
+    .map((message) => message.request);
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+describe('redux devtools runtime', () => {
+  it('streams sanitized lifted state snapshots through PARTIAL_STATE', async () => {
+    const {
+      rozeniteDevToolsEnhancer,
+      sentMessages,
+      sendPanelCommand,
+    } = await setupRuntime();
+
+    const store = createStore(
+      reducer,
+      rozeniteDevToolsEnhancer({
+        stateSanitizer: (state) => ({
+          counter: (state as TestState).counter,
+        }),
+        actionSanitizer: (action) => ({
+          type: (action as TestAction).type,
+        }),
+      })
+    );
+
+    store.dispatch({
+      type: 'counter/add',
+      payload: 1,
+      largeValue: 'action-large-value',
+    });
+
+    sendPanelCommand({ type: 'start' });
+
+    const requests = getStateUpdateRequests(sentMessages);
+    expect(requests.map((request) => request.type)).toEqual([
+      'STATE',
+      'PARTIAL_STATE',
+    ]);
+
+    const initialPayload = parse(requests[0].payload) as {
+      computedStates: Array<{ state: unknown }>;
+    };
+    const partialPayload = parse(requests[1].payload) as {
+      actionsById: Record<number, { action: unknown }>;
+      computedStates: Array<{ state: unknown }>;
+    };
+
+    expect(initialPayload.computedStates[0].state).toEqual({ counter: 0 });
+    expect(partialPayload.computedStates[0].state).toEqual({ counter: 1 });
+    expect(partialPayload.actionsById[1].action).toEqual({
+      type: 'counter/add',
+    });
+  });
+
+  it('sanitizes live action updates after monitoring starts', async () => {
+    const {
+      rozeniteDevToolsEnhancer,
+      sentMessages,
+      sendPanelCommand,
+    } = await setupRuntime();
+
+    const store = createStore(
+      reducer,
+      rozeniteDevToolsEnhancer({
+        stateSanitizer: (state) => ({
+          counter: (state as TestState).counter,
+        }),
+        actionSanitizer: (action) => ({
+          type: (action as TestAction).type,
+        }),
+      })
+    );
+
+    sendPanelCommand({ type: 'start' });
+    sentMessages.length = 0;
+
+    store.dispatch({
+      type: 'counter/add',
+      payload: 2,
+      largeValue: 'action-large-value',
+    });
+
+    const requests = getStateUpdateRequests(sentMessages);
+    expect(requests).toHaveLength(1);
+    expect(requests[0].type).toBe('ACTION');
+
+    if (requests[0].type !== 'ACTION') {
+      throw new Error('Expected ACTION request.');
+    }
+
+    expect(parse(requests[0].payload)).toEqual({ counter: 2 });
+    expect(parse(requests[0].action)).toEqual({
+      type: 'PERFORM_ACTION',
+      action: {
+        type: 'counter/add',
+      },
+      timestamp: expect.any(Number),
+    });
+  });
+
+  it('reconstructs maxAge-trimmed history in the Redux DevTools reducer', async () => {
+    const {
+      rozeniteDevToolsEnhancer,
+      sentMessages,
+      sendPanelCommand,
+    } = await setupRuntime();
+
+    const store = createStore(
+      reducer,
+      rozeniteDevToolsEnhancer({
+        maxAge: 2,
+        stateSanitizer: (state) => ({
+          counter: (state as TestState).counter,
+        }),
+        actionSanitizer: (action) => ({
+          type: action.type,
+        }),
+      })
+    );
+
+    store.dispatch({ type: 'counter/add', payload: 1 });
+    store.dispatch({ type: 'counter/add', payload: 1 });
+    store.dispatch({ type: 'counter/add', payload: 1 });
+
+    sendPanelCommand({ type: 'start' });
+
+    const requests = getStateUpdateRequests(sentMessages);
+    const state = requests.reduce(
+      (nextState, request) =>
+        reduceInstances(nextState, {
+          type: UPDATE_STATE,
+          request: request as never,
+          id: 'test-connection',
+        }),
+      undefined as Parameters<typeof reduceInstances>[0] | undefined
+    );
+
+    if (!state) {
+      throw new Error('Expected Redux DevTools instances state.');
+    }
+
+    const instanceState = state.states[requests[0].instanceId];
+
+    expect(requests.map((request) => request.type)).toEqual([
+      'STATE',
+      'PARTIAL_STATE',
+    ]);
+    expect(instanceState.committedState).toEqual({ counter: 2 });
+    expect(
+      instanceState.computedStates.map(
+        (entry: { state: unknown }) => entry.state
+      )
+    ).toEqual([{ counter: 2 }, { counter: 3 }]);
+    expect(instanceState.currentStateIndex).toBe(1);
+  });
+});

--- a/packages/redux-devtools-plugin/src/runtime.ts
+++ b/packages/redux-devtools-plugin/src/runtime.ts
@@ -25,7 +25,10 @@ import type {
 
 const getRandomId = () => Math.random().toString(36).slice(2);
 const MAX_QUEUED_COMMANDS = 50;
+const PARTIAL_STATE_CHUNK_SIZE = 1;
 const STORE_SENTINEL = Symbol.for('rozenite.redux-devtools.store-sentinel');
+
+type AnyAction = Action<string>;
 
 /**
  * Options for configuring Rozenite Redux DevTools
@@ -47,9 +50,19 @@ export interface RozeniteDevToolsOptions {
    * @default 50
    */
   maxAge?: number;
-}
 
-type AnyAction = Action<string>;
+  /**
+   * Sanitizes each Redux state snapshot before it is sent to DevTools.
+   * Useful for omitting large caches, entity maps, or sensitive values.
+   */
+  stateSanitizer?: (state: unknown, index: number) => unknown;
+
+  /**
+   * Sanitizes each Redux action before it is sent to DevTools.
+   * Useful for omitting large payloads or sensitive values.
+   */
+  actionSanitizer?: (action: AnyAction, id: number) => unknown;
+}
 
 type RuntimeController = {
   enhance: () => StoreEnhancer;
@@ -103,6 +116,7 @@ const createRuntimeController = (
   let monitored = false;
   let lastAction: string | undefined;
   const pendingCommands: ReduxDevToolsPanelCommand[] = [];
+  const reportedSanitizerErrors = new Set<string>();
 
   const enqueueCommand = (command: ReduxDevToolsPanelCommand) => {
     if (pendingCommands.length >= MAX_QUEUED_COMMANDS) {
@@ -127,6 +141,77 @@ const createRuntimeController = (
     });
   };
 
+  const reportSanitizerError = (kind: 'state' | 'action', error: unknown) => {
+    const message = (error as Error).message || String(error);
+    const key = `${kind}:${message}`;
+
+    if (reportedSanitizerErrors.has(key)) {
+      return;
+    }
+
+    reportedSanitizerErrors.add(key);
+    sendError(`Redux DevTools ${kind} sanitizer failed: ${message}`);
+  };
+
+  const sanitizeState = (state: unknown, index: number): unknown => {
+    if (!options.stateSanitizer) {
+      return state;
+    }
+
+    try {
+      return options.stateSanitizer(state, index);
+    } catch (error) {
+      reportSanitizerError('state', error);
+      return {
+        __rozeniteSanitizerError: 'State sanitizer failed.',
+      };
+    }
+  };
+
+  const sanitizeAction = (action: AnyAction, id: number): unknown => {
+    if (!options.actionSanitizer) {
+      return action;
+    }
+
+    try {
+      return options.actionSanitizer(action, id);
+    } catch (error) {
+      reportSanitizerError('action', error);
+      return {
+        type:
+          action &&
+          typeof action === 'object' &&
+          'type' in action &&
+          (action as { type?: unknown }).type != null
+            ? String((action as { type?: unknown }).type)
+            : '@@SANITIZER_ERROR',
+        __rozeniteSanitizerError: 'Action sanitizer failed.',
+      };
+    }
+  };
+
+  const sanitizeComputedState = (
+    entry: { state: unknown; error?: string },
+    index: number
+  ) => ({
+    ...entry,
+    state: sanitizeState(entry.state, index),
+  });
+
+  const sanitizeLiftedAction = (
+    liftedAction: PerformAction<AnyAction>,
+    actionId: number
+  ): PerformAction<AnyAction> => {
+    if (liftedAction.type !== 'PERFORM_ACTION') {
+      return liftedAction;
+    }
+
+    return {
+      ...liftedAction,
+      action: sanitizeAction(liftedAction.action, actionId) as AnyAction,
+    };
+  };
+
   const sendRequest = (request: ReduxDevToolsRequest): void => {
     sendRuntimeMessage({
       type: 'state-update',
@@ -142,12 +227,97 @@ const createRuntimeController = (
       return;
     }
 
+    const initialComputedState = liftedState.computedStates[0];
+    const initialStagedActionId = liftedState.stagedActionIds[0] ?? 0;
+    const initialAction = liftedState.actionsById[initialStagedActionId] as
+      | PerformAction<AnyAction>
+      | undefined;
+
     sendRequest({
       type: 'STATE',
       name: instanceName,
       instanceId: appInstanceId,
-      payload: stringify(liftedState),
+      payload: stringify({
+        actionsById: initialAction
+          ? {
+              [initialStagedActionId]: sanitizeLiftedAction(
+                initialAction,
+                initialStagedActionId
+              ),
+            }
+          : {},
+        computedStates: initialComputedState
+          ? [sanitizeComputedState(initialComputedState, 0)]
+          : [],
+        committedState: sanitizeState(liftedState.committedState, 0),
+        currentStateIndex: 0,
+        nextActionId: initialStagedActionId + 1,
+        skippedActionIds: [],
+        stagedActionIds: [initialStagedActionId],
+        isLocked: liftedState.isLocked,
+        isPaused: liftedState.isPaused,
+      }),
     });
+
+    for (
+      let startIndex = 1;
+      startIndex < liftedState.stagedActionIds.length;
+      startIndex += PARTIAL_STATE_CHUNK_SIZE
+    ) {
+      const endIndex = Math.min(
+        startIndex + PARTIAL_STATE_CHUNK_SIZE,
+        liftedState.stagedActionIds.length
+      );
+      const chunkStagedActionIds = liftedState.stagedActionIds.slice(
+        startIndex,
+        endIndex
+      );
+      const actionsById: Record<number, PerformAction<AnyAction>> = {};
+
+      chunkStagedActionIds.forEach((actionId) => {
+        const action = liftedState.actionsById[actionId] as
+          | PerformAction<AnyAction>
+          | undefined;
+
+        if (action) {
+          actionsById[actionId] = sanitizeLiftedAction(action, actionId);
+        }
+      });
+
+      const stagedActionIds = liftedState.stagedActionIds.slice(0, endIndex);
+      const lastActionId =
+        stagedActionIds[stagedActionIds.length - 1] ?? initialStagedActionId;
+
+      sendRequest({
+        type: 'PARTIAL_STATE',
+        name: instanceName,
+        instanceId: appInstanceId,
+        maxAge: Math.max(maxAge, liftedState.nextActionId),
+        committedState: sanitizeState(liftedState.committedState, 0),
+        payload: stringify({
+          actionsById,
+          computedStates: liftedState.computedStates
+            .slice(startIndex, endIndex)
+            .map((entry, index) =>
+              sanitizeComputedState(entry, startIndex + index)
+            ),
+          currentStateIndex: Math.min(
+            liftedState.currentStateIndex,
+            stagedActionIds.length - 1
+          ),
+          nextActionId:
+            endIndex === liftedState.stagedActionIds.length
+              ? liftedState.nextActionId
+              : lastActionId + 1,
+          skippedActionIds: liftedState.skippedActionIds.filter((actionId) =>
+            stagedActionIds.includes(actionId)
+          ),
+          stagedActionIds,
+          isLocked: liftedState.isLocked,
+          isPaused: liftedState.isPaused,
+        }),
+      });
+    }
   };
 
   const sendActionUpdate = (): void => {
@@ -174,8 +344,10 @@ const createRuntimeController = (
       type: 'ACTION',
       name: instanceName,
       instanceId: appInstanceId,
-      payload: stringify(store.getState()),
-      action: stringify(liftedAction),
+      payload: stringify(
+        sanitizeState(store.getState(), liftedState.currentStateIndex)
+      ),
+      action: stringify(sanitizeLiftedAction(liftedAction, nextActionId - 1)),
       nextActionId,
       maxAge,
       isExcess: liftedState.stagedActionIds.length >= maxAge,

--- a/packages/redux-devtools-plugin/src/shared/protocol.ts
+++ b/packages/redux-devtools-plugin/src/shared/protocol.ts
@@ -6,6 +6,14 @@ export type ReduxDevToolsRequest =
       name?: string;
     }
   | {
+      type: 'PARTIAL_STATE';
+      payload: string;
+      committedState?: unknown;
+      instanceId: string;
+      maxAge: number;
+      name?: string;
+    }
+  | {
       type: 'ACTION';
       payload: string;
       action: string;

--- a/website/src/docs/official-plugins/redux-devtools.mdx
+++ b/website/src/docs/official-plugins/redux-devtools.mdx
@@ -138,14 +138,18 @@ const sessionStoreEnhancer = rozeniteDevToolsEnhancer({ name: 'session-store' })
 
 `maxAge` controls how many actions Redux DevTools keeps in history. The default is `50`.
 
-On React Native, state is serialized and sent to DevTools over the device bridge. Large stores combined with a high `maxAge` can use a lot of memory — on Android this may cause an out-of-memory crash when opening the Redux DevTools panel. If your store is large (for example, it includes RTK Query caches or big entity maps), keep `maxAge` low and consider using Redux DevTools [`stateSanitizer`](https://github.com/reduxjs/redux-devtools/blob/main/extension/docs/API/Arguments.md#statesanitizer-state--state) to strip bulky slices before they are recorded.
+On React Native, state is serialized and sent to DevTools over the device bridge. Large stores combined with a high `maxAge` can use a lot of memory — on Android this may cause an out-of-memory crash when opening the Redux DevTools panel. If your store is large (for example, it includes RTK Query caches or big entity maps), keep `maxAge` low and use `stateSanitizer` or `actionSanitizer` to strip bulky slices before they are sent to DevTools.
 
 ```ts
 rozeniteDevToolsEnhancer({
   maxAge: 20,
-  stateSanitizer: (state) => ({
-    ...state,
+  stateSanitizer: (state, index) => ({
+    ...(state as Record<string, unknown>),
     api: '[omitted]',
+  }),
+  actionSanitizer: (action, id) => ({
+    ...action,
+    payload: action.type === 'large/payload' ? '[omitted]' : action.payload,
   }),
 })
 ```


### PR DESCRIPTION
## What is this?

This PR makes the Redux DevTools plugin safer to use with large Redux stores. It adds Rozenite-side `stateSanitizer` and `actionSanitizer` options so apps can omit bulky or sensitive data before it is sent to the DevTools panel.

It also changes the initial panel sync to avoid sending the whole lifted Redux DevTools history as one large `STATE` message. This helps with #287, where opening the Redux DevTools panel against a large store could crash or disconnect DevTools on Android.

## How does it work?

The enhancer now accepts sanitizers alongside the existing `name` and `maxAge` options. The state sanitizer runs for every Redux state snapshot before serialization, and the action sanitizer runs for every lifted action before it is sent to the embedded Redux DevTools UI.

On panel start, the runtime sends a small initial `STATE` message to create the DevTools instance, then streams the retained history through `PARTIAL_STATE` messages that the existing `@redux-devtools/app-core` reducer already understands. Live updates continue to use `ACTION`, but now pass through the same sanitizer path.

## Why is this useful?

Large stores often contain RTK Query caches, entity maps, persisted data, or action payloads that are expensive to serialize and move over the React Native DevTools bridge. This PR gives app authors a direct way to reduce that payload without changing their store shape.

Streaming the initial history also lowers the pressure caused by opening the panel, while keeping compatibility with the unmodified Redux DevTools UI. Review coverage exercises the runtime protocol and verifies that the embedded DevTools reducer can reconstruct streamed history.
