### PR TITLE
fix(vite-plugin): include source files for development export

### DIFF
--- a/.changeset/include-vite-plugin-source.md
+++ b/.changeset/include-vite-plugin-source.md
@@ -1,0 +1,5 @@
+---
+"@rozenite/vite-plugin": patch
+---
+
+Include source files in the published package so the advertised `development` export resolves.

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
+    "src",
     "templates"
   ],
   "keywords": [


### PR DESCRIPTION
## Summary

`@rozenite/vite-plugin` exposes a `development` condition that points at `./src/index.ts`, but the package `files` list only publishes `dist` and `templates`. That means consumers or tooling that resolve the `development` condition from the published package can select a file that is not present in the npm tarball.

This adds `src` to the published files so the advertised development export resolves.

## Validation

- `git diff --check`
- Parsed `packages/vite-plugin/package.json` as JSON
- Verified `exports["."].development` points to an existing file covered by the package `files` list
- Confirmed the current published `@rozenite/vite-plugin@1.12.0` tarball does not include `src/index.ts`

I could not run the full pnpm build/test suite in this environment because `pnpm`/`corepack` are not installed.
