### PR TITLE
feat: add React getComponent agent tool

### DIFF
--- a/.changeset/get-component-react-agent.md
+++ b/.changeset/get-component-react-agent.md
@@ -1,0 +1,6 @@
+---
+'@rozenite/middleware': patch
+'rozenite': patch
+---
+
+Add `getComponent` to the React agent so inspected component data can be fetched from a live session.

--- a/packages/agent-sdk/src/constants.ts
+++ b/packages/agent-sdk/src/constants.ts
@@ -42,6 +42,7 @@ export const STATIC_DOMAIN_TOOL_NAMES: Record<string, string[]> = {
   console: ['clearMessages', 'getMessages'],
   react: [
     'searchNodes',
+    'getComponent',
     'getNode',
     'getChildren',
     'getProps',

--- a/packages/cli/skills/rozenite-agent/domains/react.md
+++ b/packages/cli/skills/rozenite-agent/domains/react.md
@@ -3,6 +3,7 @@ Search and traverse the React component tree, read props, state, and hooks for a
 ## Tools
 
 - `searchNodes` -> `{"query":"<query>"}` | `{"query":"<query>","cursor":"<cursor>"}` | `{"query":"<query>","limit":20}`
+- `getComponent` -> `{"id":123}` | `{"nodeId":123}` | `{"id":123,"include":["props"]}`
 - `getNode` -> `{"nodeId":123}`
 - `getChildren` -> `{"nodeId":123}` | `{"nodeId":123,"cursor":"<cursor>"}` | `{"nodeId":123,"limit":20}`
 - `getProps` -> `{"nodeId":123}` | `{"nodeId":123,"cursor":"<cursor>"}` | `{"nodeId":123,"limit":20}`
@@ -16,7 +17,7 @@ Search and traverse the React component tree, read props, state, and hooks for a
 ## Flow
 
 Search and inspect:
-`searchNodes` -> `getNode` / `getChildren` -> `getProps` / `getState` / `getHooks`.
+`searchNodes` -> `getComponent` / `getNode` / `getChildren` -> `getProps` / `getState` / `getHooks`.
 
 Profile:
 `startProfiling` -> reproduce interaction -> `stopProfiling` -> `getRenderData`.

--- a/packages/middleware/src/agent/local-domains.ts
+++ b/packages/middleware/src/agent/local-domains.ts
@@ -649,6 +649,38 @@ export const createReactDomainService = (deps: {
 }): LocalAgentToolService => {
   const tools: AgentTool[] = [
     {
+      name: 'getComponent',
+      description:
+        'Get a React node summary plus inspected props, state, and hooks in one response.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'integer',
+            description: 'React DevTools node ID.',
+          },
+          nodeId: {
+            type: 'integer',
+            description: 'Deprecated alias for React DevTools node ID.',
+          },
+          include: {
+            type: 'array',
+            items: {
+              type: 'string',
+              enum: ['props', 'state', 'hooks'],
+            },
+            description:
+              'Optional sections to include. Defaults to props, state, and hooks.',
+          },
+          valueDepth: {
+            type: 'integer',
+            description: 'Max nested serialization depth. Default 4, max 8.',
+          },
+        },
+        anyOf: [{ required: ['id'] }, { required: ['nodeId'] }],
+      },
+    },
+    {
       name: 'getNode',
       description: 'Get a single React node summary by ID.',
       inputSchema: {
@@ -884,6 +916,8 @@ export const createReactDomainService = (deps: {
     getTools: () => tools,
     callTool: async (toolName, args) => {
       switch (toolName) {
+        case 'getComponent':
+          return store.getComponent(sessionDeviceId, args);
         case 'getNode':
           return store.getNode(sessionDeviceId, args);
         case 'getChildren':

--- a/packages/middleware/src/agent/runtime/react/__tests__/store.test.ts
+++ b/packages/middleware/src/agent/runtime/react/__tests__/store.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from 'vitest';
+import { createReactTreeStore } from '../store.js';
+
+const DEVICE_ID = 'device-1';
+
+const waitFor = async (predicate: () => boolean): Promise<void> => {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (predicate()) {
+      return;
+    }
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+  }
+
+  expect(predicate()).toBe(true);
+};
+
+const createStoreWithBridgeStub = (
+  sent: Array<{ event: string; payload: unknown }>,
+) => {
+  return createReactTreeStore({
+    createBridge: async (options) => ({
+      ingest: () => null,
+      send: (event, payload) => {
+        sent.push({ event, payload });
+        options?.sendMessage?.({ event, payload });
+      },
+      startProfiling: () => undefined,
+      stopProfiling: () => undefined,
+      reloadAndProfile: () => undefined,
+      getProfilingStatus: () => ({
+        supportsProfiling: true,
+        supportsReloadAndProfile: false,
+        isProfilingStarted: false,
+        isProcessingData: false,
+        hasProfilingData: false,
+        rootsWithData: 0,
+        rootsCount: 0,
+      }),
+      getProfilingDataSnapshot: () => null,
+      getCommitData: () => {
+        throw new Error('No commit data');
+      },
+    }),
+  });
+};
+
+const createStoreWithComponent = () => {
+  const sent: Array<{ event: string; payload: unknown }> = [];
+  const store = createStoreWithBridgeStub(sent);
+  store.registerDevice(DEVICE_ID, {
+    sendMessage: () => undefined,
+  });
+  store.syncTree(DEVICE_ID, {
+    roots: [1],
+    nodes: [
+      {
+        nodeId: 1,
+        displayName: 'Root',
+        elementType: 'root',
+        childIds: [2],
+      },
+      {
+        nodeId: 2,
+        displayName: 'App',
+        elementType: 'function',
+        parentId: 1,
+        rendererId: 7,
+        childIds: [3],
+      },
+      {
+        nodeId: 3,
+        displayName: 'Button',
+        elementType: 'host',
+        parentId: 2,
+        childIds: [],
+      },
+    ],
+  });
+
+  return { store, sent };
+};
+
+describe('React tree store getComponent', () => {
+  it('returns a node summary with inspected props, state, and hooks', async () => {
+    const { store, sent } = createStoreWithComponent();
+
+    const resultPromise = store.getComponent(DEVICE_ID, { id: 2 });
+    await waitFor(() => sent.length > 0);
+
+    expect(sent.at(-1)).toEqual({
+      event: 'inspectElement',
+      payload: {
+        forceFullData: true,
+        id: 2,
+        path: null,
+        rendererID: 7,
+        requestID: 1,
+      },
+    });
+
+    await store.ingestReactDevToolsMessage(DEVICE_ID, {
+      event: 'inspectedElement',
+      payload: {
+        id: 2,
+        type: 'full-data',
+        value: {
+          props: { title: 'Hello' },
+          state: { count: 1 },
+          hooks: [{ name: 'State', value: 'ready' }],
+        },
+      },
+    });
+
+    await expect(resultPromise).resolves.toMatchObject({
+      node: {
+        nodeId: 2,
+        displayName: 'App',
+        elementType: 'function',
+        childIds: [3],
+        rendererId: 7,
+      },
+      props: { title: 'Hello' },
+      state: { count: 1 },
+      hooks: [{ name: 'State', value: 'ready' }],
+    });
+  });
+
+  it('returns only requested sections', async () => {
+    const { store, sent } = createStoreWithComponent();
+
+    const resultPromise = store.getComponent(DEVICE_ID, {
+      nodeId: 2,
+      include: ['props'],
+    });
+    await waitFor(() => sent.length > 0);
+    await store.ingestReactDevToolsMessage(DEVICE_ID, {
+      event: 'inspectedElement',
+      payload: {
+        id: 2,
+        type: 'full-data',
+        value: {
+          props: { title: 'Hello' },
+          state: { count: 1 },
+          hooks: [{ name: 'State', value: 'ready' }],
+        },
+      },
+    });
+
+    await expect(resultPromise).resolves.toEqual(
+      expect.not.objectContaining({
+        state: expect.anything(),
+        hooks: expect.anything(),
+      }),
+    );
+    await expect(resultPromise).resolves.toMatchObject({
+      props: { title: 'Hello' },
+    });
+  });
+
+  it('marks the response partial when requested sections are unavailable', async () => {
+    const { store, sent } = createStoreWithComponent();
+
+    const resultPromise = store.getComponent(DEVICE_ID, { id: 2 });
+    await waitFor(() => sent.length > 0);
+    await store.ingestReactDevToolsMessage(DEVICE_ID, {
+      event: 'inspectedElement',
+      payload: {
+        id: 2,
+        type: 'full-data',
+        value: {
+          props: { title: 'Hello' },
+        },
+      },
+    });
+
+    await expect(resultPromise).resolves.toMatchObject({
+      props: { title: 'Hello' },
+      partial: true,
+      unavailable: ['state', 'hooks'],
+    });
+  });
+
+  it('bounds serialized nested values', async () => {
+    const { store, sent } = createStoreWithComponent();
+
+    const resultPromise = store.getComponent(DEVICE_ID, {
+      id: 2,
+      include: ['props'],
+      valueDepth: 1,
+    });
+    await waitFor(() => sent.length > 0);
+    await store.ingestReactDevToolsMessage(DEVICE_ID, {
+      event: 'inspectedElement',
+      payload: {
+        id: 2,
+        type: 'full-data',
+        value: {
+          props: {
+            nested: {
+              value: 'hidden',
+            },
+            onPress: () => undefined,
+          },
+        },
+      },
+    });
+
+    await expect(resultPromise).resolves.toMatchObject({
+      props: {
+        nested: '[object]',
+        onPress: '[function]',
+      },
+    });
+  });
+
+  it('throws when React DevTools returns no inspected data', async () => {
+    const { store, sent } = createStoreWithComponent();
+
+    const resultPromise = store.getComponent(DEVICE_ID, { id: 2 });
+    await waitFor(() => sent.length > 0);
+    await store.ingestReactDevToolsMessage(DEVICE_ID, {
+      event: 'inspectedElement',
+      payload: {
+        id: 2,
+        type: 'not-found',
+      },
+    });
+
+    await expect(resultPromise).rejects.toThrow(
+      'No inspected snapshot available for node "2".',
+    );
+  });
+});
+

--- a/packages/middleware/src/agent/runtime/react/store.ts
+++ b/packages/middleware/src/agent/runtime/react/store.ts
@@ -1,7 +1,9 @@
 import { hashFilters } from '../pagination/cursor.js';
 import type {
+  ReactComponentSection,
   ReactDevToolsBridgeMessage,
   ReactGetChildrenResult,
+  ReactGetComponentResult,
   ReactGetInspectableResult,
   ReactGetRenderDataResult,
   ReactInspectedNodeRecord,
@@ -26,6 +28,8 @@ const DEFAULT_SEARCH_LIMIT = 20;
 const MAX_SEARCH_LIMIT = 100;
 const SEARCH_TOOL_NAME = 'searchNodes';
 const GET_CHILDREN_TOOL_NAME = 'getChildren';
+const DEFAULT_COMPONENT_VALUE_DEPTH = 4;
+const MAX_COMPONENT_VALUE_DEPTH = 8;
 const GET_PROPS_TOOL_NAME = 'getProps';
 const GET_STATE_TOOL_NAME = 'getState';
 const GET_HOOKS_TOOL_NAME = 'getHooks';
@@ -183,6 +187,48 @@ const normalizeRenderDataSort = (value: unknown): ReactRenderDataSort => {
   return 'duration-desc';
 };
 
+const normalizeComponentSections = (value: unknown): ReactComponentSection[] => {
+  const defaultSections: ReactComponentSection[] = ['props', 'state', 'hooks'];
+  if (value === undefined) {
+    return defaultSections;
+  }
+
+  if (!Array.isArray(value)) {
+    throw new Error('"include" must be an array of props, state, or hooks');
+  }
+
+  const sections: ReactComponentSection[] = [];
+  for (const entry of value) {
+    if (entry !== 'props' && entry !== 'state' && entry !== 'hooks') {
+      throw new Error('"include" must contain only props, state, or hooks');
+    }
+    if (!sections.includes(entry)) {
+      sections.push(entry);
+    }
+  }
+
+  if (sections.length === 0) {
+    throw new Error('"include" must contain at least one section');
+  }
+
+  return sections;
+};
+
+const normalizeComponentValueDepth = (value: unknown): number => {
+  if (value === undefined) {
+    return DEFAULT_COMPONENT_VALUE_DEPTH;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(
+      `"valueDepth" must be an integer between 0 and ${MAX_COMPONENT_VALUE_DEPTH}`,
+    );
+  }
+
+  return Math.min(parsed, MAX_COMPONENT_VALUE_DEPTH);
+};
+
 const delay = async (ms: number): Promise<void> => {
   await new Promise((resolve) => {
     setTimeout(resolve, ms);
@@ -206,6 +252,10 @@ const getNodeId = (value: unknown): number => {
   }
 
   return Number(value);
+};
+
+const getRequestedNodeId = (request: Record<string, unknown>): number => {
+  return getNodeId(request.id !== undefined ? request.id : request.nodeId);
 };
 
 const ensureNodeExists = (
@@ -1006,6 +1056,74 @@ export const createReactTreeStore = (options?: {
     };
   };
 
+  const getInspectedRecord = async (
+    state: DeviceReactTreeState,
+    nodeId: number,
+    sections: ReactComponentSection[],
+  ): Promise<ReactInspectedNodeRecord | null> => {
+    let inspected = state.inspectedById.get(nodeId);
+    const hasAllRequestedSections = sections.every((section) => {
+      return inspected?.[section] !== undefined;
+    });
+
+    if (!inspected || !hasAllRequestedSections) {
+      inspected = await requestInspectableSnapshot(state, nodeId)
+        || state.inspectedById.get(nodeId);
+    }
+
+    return inspected ?? null;
+  };
+
+  const getComponent = async (
+    deviceId: string,
+    rawRequest: unknown,
+  ): Promise<ReactGetComponentResult> => {
+    const request = getRecord(rawRequest) || {};
+    const state = getOrCreateState(deviceId);
+    const nodeId = getRequestedNodeId(request);
+    const node = ensureNodeExists(state, nodeId);
+    const sections = normalizeComponentSections(request.include);
+    const valueDepth = normalizeComponentValueDepth(request.valueDepth);
+    const inspected = await getInspectedRecord(state, nodeId, sections);
+
+    if (!inspected) {
+      throw new Error(
+        `No inspected snapshot available for node "${nodeId}". React DevTools did not return inspected data for this node.`,
+      );
+    }
+
+    const unavailable: ReactComponentSection[] = [];
+    const result: ReactGetComponentResult = {
+      node: {
+        ...ensureNodeSummary(node),
+        childIds: node.childIds.filter((childId) => state.nodesById.has(childId)),
+        ...(node.rendererId !== undefined ? { rendererId: node.rendererId } : {}),
+      },
+    };
+
+    for (const section of sections) {
+      const value = inspected[section];
+      if (value === undefined) {
+        unavailable.push(section);
+        continue;
+      }
+
+      result[section] = createSerializableSnapshot(value, valueDepth);
+    }
+
+    if (unavailable.length === sections.length) {
+      throw new Error(
+        `No requested component snapshot sections available for node "${nodeId}".`,
+      );
+    }
+    if (unavailable.length > 0) {
+      result.partial = true;
+      result.unavailable = unavailable;
+    }
+
+    return result;
+  };
+
   const requestInspectableSnapshot = async (
     state: DeviceReactTreeState,
     nodeId: number,
@@ -1324,6 +1442,7 @@ export const createReactTreeStore = (options?: {
     isProfilingStarted,
     stopProfiling,
     getRenderData,
+    getComponent,
     searchNodes,
     getNode,
     getChildren,

--- a/packages/middleware/src/agent/runtime/react/types.ts
+++ b/packages/middleware/src/agent/runtime/react/types.ts
@@ -56,6 +56,20 @@ export interface ReactGetChildrenResult {
   };
 }
 
+export type ReactComponentSection = 'props' | 'state' | 'hooks';
+
+export interface ReactGetComponentResult {
+  node: ReactNodeSummary & {
+    childIds: number[];
+    rendererId?: number;
+  };
+  props?: unknown;
+  state?: unknown;
+  hooks?: unknown;
+  partial?: boolean;
+  unavailable?: ReactComponentSection[];
+}
+
 export interface ReactInspectableEntry {
   name: string;
   value: unknown;


### PR DESCRIPTION
## What is this?

This PR adds a `getComponent` tool to the built-in React agent domain. The tool gives agents one call for a component summary plus inspected props, state, and hooks, instead of requiring separate calls for each section.

## How does it work?

The React tree store reuses the existing full inspection request path and returns the requested sections from the inspected snapshot. Callers can choose which sections to include and can bound nested serialization depth. The response includes node details, selected inspection data, and partial-result metadata when React DevTools does not provide every requested section.

## Why is this useful?

Agents can inspect a component faster and with less orchestration. The existing paginated props, state, and hooks tools remain available for larger data, while `getComponent` covers the common case where a compact component-level snapshot is enough to decide the next debugging step.