### PR TITLE
feat(network-activity-plugin): support Expo fetch interception

### DIFF
--- a/.changeset/expo-fetch-network-activity.md
+++ b/.changeset/expo-fetch-network-activity.md
@@ -1,0 +1,6 @@
+---
+'@rozenite/network-activity-plugin': minor
+---
+
+Show Expo SDK 54+ `expo/fetch` activity in Network Activity, including Expo's
+SDK 56+ default global fetch alias.

--- a/apps/playground/src/app/screens/NetworkTestScreen.tsx
+++ b/apps/playground/src/app/screens/NetworkTestScreen.tsx
@@ -25,6 +25,10 @@ import {
 import { RootStackParamList } from '../navigation/types';
 import { api, User, Post, Todo } from '../utils/network-activity/api';
 import {
+  expoFetchApi,
+  type ExpoFetchDemoResult,
+} from '../utils/network-activity/expo';
+import {
   nitroApi,
   type NitroDemoResult,
 } from '../utils/network-activity/nitro';
@@ -768,6 +772,107 @@ const NitroHTTPTestComponent: React.FC = () => {
           <View style={styles.nitroStatusRow}>
             <ActivityIndicator size="small" color="#ffffff" />
             <Text style={styles.nitroStatusText}>Running Nitro request...</Text>
+          </View>
+        )}
+
+        {error && <Text style={styles.errorText}>Error: {error}</Text>}
+
+        {result && (
+          <View style={styles.responseContainer}>
+            <Text style={styles.responseTitle}>{result.title}</Text>
+            <Text style={styles.cardMeta}>
+              Status: {result.status} {result.statusText}
+            </Text>
+            {result.extra ? (
+              <Text style={styles.nitroExtraText}>{result.extra}</Text>
+            ) : null}
+            <ScrollView style={styles.responseScrollView} nestedScrollEnabled>
+              <Text style={styles.responseText}>{result.body}</Text>
+            </ScrollView>
+          </View>
+        )}
+      </View>
+    </ScrollView>
+  );
+};
+
+const ExpoFetchHTTPTestComponent: React.FC = () => {
+  const [isRunning, setIsRunning] = React.useState(false);
+  const [result, setResult] = React.useState<ExpoFetchDemoResult | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const runExpoFetchAction = React.useCallback(
+    async (action: () => Promise<ExpoFetchDemoResult>) => {
+      setIsRunning(true);
+      setError(null);
+
+      try {
+        const nextResult = await action();
+        setResult(nextResult);
+      } catch (actionError) {
+        setResult(null);
+        setError(
+          actionError instanceof Error
+            ? actionError.message
+            : String(actionError),
+        );
+      } finally {
+        setIsRunning(false);
+      }
+    },
+    [],
+  );
+
+  return (
+    <ScrollView contentContainerStyle={styles.listContainer}>
+      <View style={styles.card}>
+        <Text style={styles.cardTitle}>Expo Fetch Test</Text>
+        <Text style={styles.cardBody}>
+          Runs requests through `expo/fetch`. Watch the Network Activity panel
+          for Expo source badges. Prefetch is not exposed by `expo/fetch`, so
+          this tab focuses on GET, POST, and abort handling.
+        </Text>
+
+        <View style={styles.nitroButtonGrid}>
+          <TouchableOpacity
+            style={[
+              styles.nitroButton,
+              isRunning && styles.refetchButtonDisabled,
+            ]}
+            disabled={isRunning}
+            onPress={() => runExpoFetchAction(expoFetchApi.getUsers)}
+          >
+            <Text style={styles.nitroButtonText}>Expo GET</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={[
+              styles.nitroButton,
+              isRunning && styles.refetchButtonDisabled,
+            ]}
+            disabled={isRunning}
+            onPress={() => runExpoFetchAction(expoFetchApi.createPost)}
+          >
+            <Text style={styles.nitroButtonText}>Expo POST</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={[
+              styles.nitroButton,
+              styles.nitroButtonDanger,
+              isRunning && styles.refetchButtonDisabled,
+            ]}
+            disabled={isRunning}
+            onPress={() => runExpoFetchAction(expoFetchApi.abortSlowRequest)}
+          >
+            <Text style={styles.nitroButtonText}>Abort</Text>
+          </TouchableOpacity>
+        </View>
+
+        {isRunning && (
+          <View style={styles.nitroStatusRow}>
+            <ActivityIndicator size="small" color="#ffffff" />
+            <Text style={styles.nitroStatusText}>Running Expo request...</Text>
           </View>
         )}
 
@@ -1775,6 +1880,7 @@ export const NetworkTestScreen: React.FC = () => {
   const [activeTest, setActiveTest] = React.useState<
     | 'http'
     | 'nitro'
+    | 'expo-fetch'
     | 'websocket'
     | 'nitro-websocket'
     | 'sse'
@@ -1828,8 +1934,8 @@ export const NetworkTestScreen: React.FC = () => {
     <View style={styles.header}>
       <Text style={styles.title}>Network Test</Text>
       <Text style={styles.subtitle}>
-        Testing built-in HTTP, Nitro HTTP, built-in WebSocket, Nitro WebSocket,
-        and SSE connections
+        Testing built-in HTTP, Expo Fetch, Nitro HTTP, built-in WebSocket,
+        Nitro WebSocket, and SSE connections
       </Text>
 
       <TouchableOpacity
@@ -1842,6 +1948,7 @@ export const NetworkTestScreen: React.FC = () => {
       <View style={styles.mainTabContainer}>
         {[
           { key: 'http', label: 'HTTP Test' },
+          { key: 'expo-fetch', label: 'Expo Fetch' },
           { key: 'nitro', label: 'Nitro HTTP' },
           { key: 'websocket', label: 'WebSocket Test' },
           { key: 'nitro-websocket', label: 'Nitro WS' },
@@ -1862,6 +1969,7 @@ export const NetworkTestScreen: React.FC = () => {
               setActiveTest(
                 tab.key as
                   | 'http'
+                  | 'expo-fetch'
                   | 'nitro'
                   | 'websocket'
                   | 'nitro-websocket'
@@ -1893,6 +2001,8 @@ export const NetworkTestScreen: React.FC = () => {
       {renderHeader()}
       {activeTest === 'http' ? (
         <HTTPTestComponent />
+      ) : activeTest === 'expo-fetch' ? (
+        <ExpoFetchHTTPTestComponent />
       ) : activeTest === 'nitro' ? (
         <NitroHTTPTestComponent />
       ) : activeTest === 'websocket' ? (

--- a/apps/playground/src/app/screens/NetworkTestScreen.tsx
+++ b/apps/playground/src/app/screens/NetworkTestScreen.tsx
@@ -829,8 +829,8 @@ const ExpoFetchHTTPTestComponent: React.FC = () => {
         <Text style={styles.cardTitle}>Expo Fetch Test</Text>
         <Text style={styles.cardBody}>
           Runs requests through `expo/fetch`. Watch the Network Activity panel
-          for Expo source badges. Prefetch is not exposed by `expo/fetch`, so
-          this tab focuses on GET, POST, and abort handling.
+          for Expo source badges. This small flow covers a JSON response and
+          cancellation without becoming an Expo fetch conformance suite.
         </Text>
 
         <View style={styles.nitroButtonGrid}>
@@ -843,17 +843,6 @@ const ExpoFetchHTTPTestComponent: React.FC = () => {
             onPress={() => runExpoFetchAction(expoFetchApi.getUsers)}
           >
             <Text style={styles.nitroButtonText}>Expo GET</Text>
-          </TouchableOpacity>
-
-          <TouchableOpacity
-            style={[
-              styles.nitroButton,
-              isRunning && styles.refetchButtonDisabled,
-            ]}
-            disabled={isRunning}
-            onPress={() => runExpoFetchAction(expoFetchApi.createPost)}
-          >
-            <Text style={styles.nitroButtonText}>Expo POST</Text>
           </TouchableOpacity>
 
           <TouchableOpacity
@@ -1934,8 +1923,8 @@ export const NetworkTestScreen: React.FC = () => {
     <View style={styles.header}>
       <Text style={styles.title}>Network Test</Text>
       <Text style={styles.subtitle}>
-        Testing built-in HTTP, Expo Fetch, Nitro HTTP, built-in WebSocket,
-        Nitro WebSocket, and SSE connections
+        Testing built-in HTTP, Expo Fetch, Nitro HTTP, built-in WebSocket, Nitro
+        WebSocket, and SSE connections
       </Text>
 
       <TouchableOpacity

--- a/apps/playground/src/app/utils/network-activity/expo.ts
+++ b/apps/playground/src/app/utils/network-activity/expo.ts
@@ -1,0 +1,107 @@
+import { fetch as expoFetch } from 'expo/fetch';
+import type { Post, User } from './api';
+
+export type ExpoFetchDemoResult = {
+  title: string;
+  status: number;
+  statusText: string;
+  body: string;
+  extra?: string;
+};
+
+const prettyPrint = (value: unknown) => JSON.stringify(value, null, 2);
+
+export const expoFetchApi = {
+  async getUsers(): Promise<ExpoFetchDemoResult> {
+    const response = await expoFetch(
+      'https://jsonplaceholder.typicode.com/users?_limit=3',
+      {
+        headers: {
+          'X-Rozenite-Test': 'expo-fetch-users',
+        },
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(`Expo fetch request failed with status ${response.status}`);
+    }
+
+    const users = (await response.json()) as User[];
+
+    return {
+      title: 'Expo GET users',
+      status: response.status,
+      statusText: response.statusText,
+      body: prettyPrint(users),
+      extra: `Fetched ${users.length} users via expo/fetch.`,
+    };
+  },
+
+  async createPost(): Promise<ExpoFetchDemoResult> {
+    const payload: Omit<Post, 'id'> = {
+      userId: 1,
+      title: 'Rozenite Expo fetch test post',
+      body: 'This request was created from the playground using expo/fetch.',
+    };
+
+    const response = await expoFetch(
+      'https://jsonplaceholder.typicode.com/posts?source=expo-fetch-playground',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Rozenite-Test': 'expo-fetch-create-post',
+        },
+        body: JSON.stringify(payload),
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(`Expo fetch request failed with status ${response.status}`);
+    }
+
+    const post = (await response.json()) as Post;
+
+    return {
+      title: 'Expo POST JSON',
+      status: response.status,
+      statusText: response.statusText,
+      body: prettyPrint(post),
+      extra: 'Creates a POST entry with an Expo source badge in Network Activity.',
+    };
+  },
+
+  async abortSlowRequest(): Promise<ExpoFetchDemoResult> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 250);
+
+    try {
+      await expoFetch('https://httpbin.org/delay/5', {
+        signal: controller.signal,
+        headers: {
+          'X-Rozenite-Test': 'expo-fetch-abort',
+        },
+      });
+
+      return {
+        title: 'Expo AbortController',
+        status: 200,
+        statusText: 'Unexpected success',
+        body: 'The delayed request completed before aborting.',
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+
+      return {
+        title: 'Expo AbortController',
+        status: 0,
+        statusText: 'Aborted',
+        body: message,
+        extra:
+          'Use this to verify failed Expo fetch requests show up in Network Activity.',
+      };
+    } finally {
+      clearTimeout(timeout);
+    }
+  },
+};

--- a/apps/playground/src/app/utils/network-activity/expo.ts
+++ b/apps/playground/src/app/utils/network-activity/expo.ts
@@ -1,5 +1,5 @@
 import { fetch as expoFetch } from 'expo/fetch';
-import type { Post, User } from './api';
+import type { User } from './api';
 
 export type ExpoFetchDemoResult = {
   title: string;
@@ -23,7 +23,9 @@ export const expoFetchApi = {
     );
 
     if (!response.ok) {
-      throw new Error(`Expo fetch request failed with status ${response.status}`);
+      throw new Error(
+        `Expo fetch request failed with status ${response.status}`,
+      );
     }
 
     const users = (await response.json()) as User[];
@@ -34,40 +36,6 @@ export const expoFetchApi = {
       statusText: response.statusText,
       body: prettyPrint(users),
       extra: `Fetched ${users.length} users via expo/fetch.`,
-    };
-  },
-
-  async createPost(): Promise<ExpoFetchDemoResult> {
-    const payload: Omit<Post, 'id'> = {
-      userId: 1,
-      title: 'Rozenite Expo fetch test post',
-      body: 'This request was created from the playground using expo/fetch.',
-    };
-
-    const response = await expoFetch(
-      'https://jsonplaceholder.typicode.com/posts?source=expo-fetch-playground',
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Rozenite-Test': 'expo-fetch-create-post',
-        },
-        body: JSON.stringify(payload),
-      },
-    );
-
-    if (!response.ok) {
-      throw new Error(`Expo fetch request failed with status ${response.status}`);
-    }
-
-    const post = (await response.json()) as Post;
-
-    return {
-      title: 'Expo POST JSON',
-      status: response.status,
-      statusText: response.statusText,
-      body: prettyPrint(post),
-      extra: 'Creates a POST entry with an Expo source badge in Network Activity.',
     };
   },
 

--- a/packages/network-activity-plugin/README.md
+++ b/packages/network-activity-plugin/README.md
@@ -20,6 +20,17 @@ The plugin now integrates with `react-native-nitro-fetch` when it is installed i
 - Response body lookup works for both built-in and nitro HTTP entries
 - HTTP response overrides remain built-in only and are disabled for nitro entries
 
+## Expo Fetch Support
+
+The plugin optionally observes `expo/fetch` on Expo SDK 54 and newer. Expo
+requests appear in the same panel with an `Expo` source badge, including when
+SDK 56+ installs Expo fetch as the default global `fetch` implementation.
+
+On SDK 54–55, response bodies can only be captured after the application
+consumes them with the usual body helpers (such as `text()` or `json()`).
+Unconsumed and directly streamed bodies remain unavailable; the request itself
+is still recorded normally. Expo response overrides are not supported.
+
 ## Features
 
 - **Real-time Network Monitoring**: Track all HTTP/HTTPS requests in real-time

--- a/packages/network-activity-plugin/package.json
+++ b/packages/network-activity-plugin/package.json
@@ -65,10 +65,14 @@
     "zustand": "^5.0.6"
   },
   "peerDependencies": {
+    "expo": "*",
     "react-native-nitro-fetch": "*",
     "react-native-sse": "*"
   },
   "peerDependenciesMeta": {
+    "expo": {
+      "optional": true
+    },
     "react-native-nitro-fetch": {
       "optional": true
     },

--- a/packages/network-activity-plugin/src/react-native/http/__tests__/fetch-interceptor.test.ts
+++ b/packages/network-activity-plugin/src/react-native/http/__tests__/fetch-interceptor.test.ts
@@ -1,9 +1,11 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-const originalFetch = globalThis.fetch;
+let captureResponseBodySpy: ReturnType<typeof vi.fn> | null = null;
 
-const loadFetchInterceptor = async () => {
+const loadFetchInterceptor = async (
+  expoFetchModule: { fetch: typeof fetch } | null = null,
+) => {
   vi.resetModules();
   vi.doMock('../http-utils', async (importOriginal) => {
     const actual = await importOriginal<typeof import('../http-utils')>();
@@ -13,6 +15,19 @@ const loadFetchInterceptor = async () => {
       getInitiatorFromStack: () => ({ type: 'other' }),
     };
   });
+  vi.doMock('../fetch-utils', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../fetch-utils')>();
+    captureResponseBodySpy = vi.fn(actual.captureFetchResponseBodyFromBytes);
+
+    return {
+      ...actual,
+      BINARY_CAPTURE_SIZE_CAP: 10,
+      captureFetchResponseBodyFromBytes: captureResponseBodySpy,
+    };
+  });
+  vi.doMock('../get-expo-fetch-module', () => ({
+    getExpoFetchModule: () => expoFetchModule,
+  }));
 
   return import('../fetch-interceptor');
 };
@@ -22,7 +37,10 @@ const createExpoResponse = (
   headers: Record<string, string>,
 ) => {
   const encodedChunks = bodyChunks.map((chunk) => new TextEncoder().encode(chunk));
-  const totalSize = encodedChunks.reduce((sum, chunk) => sum + chunk.byteLength, 0);
+  const totalSize = encodedChunks.reduce(
+    (sum, chunk) => sum + chunk.byteLength,
+    0,
+  );
 
   const createBody = () =>
     new ReadableStream<Uint8Array>({
@@ -50,22 +68,25 @@ const createExpoResponse = (
 };
 
 afterEach(() => {
-  globalThis.fetch = originalFetch;
   vi.restoreAllMocks();
   vi.unmock('../http-utils');
+  vi.unmock('../fetch-utils');
+  vi.unmock('../get-expo-fetch-module');
+  captureResponseBodySpy = null;
 });
 
 describe('FetchInterceptor', () => {
-  it('emits lifecycle events for Expo fetch responses and preserves the original response', async () => {
+  it('patches expo/fetch directly and preserves the original export', async () => {
     const fetchMock = vi.fn(async () =>
       createExpoResponse(['{"ok":', 'true}'], {
         'x-request-id': 'expo-1',
       }),
     );
-    globalThis.fetch = fetchMock as typeof fetch;
+    const expoFetchModule = { fetch: fetchMock as typeof fetch };
 
-    const { FetchInterceptor } = await loadFetchInterceptor();
+    const { FetchInterceptor } = await loadFetchInterceptor(expoFetchModule);
     const events: Array<{ type: string; event: unknown }> = [];
+    const originalModuleFetch = expoFetchModule.fetch;
 
     FetchInterceptor.setCallbacks({
       onRequestSent: (event) => events.push({ type: 'request-sent', event }),
@@ -86,7 +107,10 @@ describe('FetchInterceptor', () => {
 
     FetchInterceptor.enableInterception();
 
-    const response = await fetch('https://example.com/api', {
+    expect(FetchInterceptor.isInterceptorEnabled()).toBe(true);
+    expect(expoFetchModule.fetch).not.toBe(originalModuleFetch);
+
+    const response = await expoFetchModule.fetch('https://example.com/api', {
       method: 'post',
       headers: {
         'x-request-id': 'expo-1',
@@ -160,49 +184,27 @@ describe('FetchInterceptor', () => {
     });
 
     FetchInterceptor.disableInterception();
+
+    expect(FetchInterceptor.isInterceptorEnabled()).toBe(false);
+    expect(expoFetchModule.fetch).toBe(originalModuleFetch);
   });
 
-  it('does not emit fetch-owned events for non-streaming RN responses', async () => {
-    const fetchMock = vi.fn(async () =>
-      ({
-        url: 'https://example.com/api',
-        status: 200,
-        statusText: 'OK',
-        headers: new Headers(),
-        body: undefined,
-        clone: () => null,
-      }) as unknown as Response,
-    );
-    globalThis.fetch = fetchMock as typeof fetch;
+  it('does not start when expo/fetch is unavailable', async () => {
+    const { FetchInterceptor } = await loadFetchInterceptor(null);
 
-    const { FetchInterceptor } = await loadFetchInterceptor();
-    const onRequestSent = vi.fn();
-    const onResponseReceived = vi.fn();
-
-    FetchInterceptor.setCallbacks({
-      onRequestSent,
-      onResponseReceived,
-    });
     FetchInterceptor.enableInterception();
 
-    const response = await fetch('https://example.com/api');
-
-    expect(response).toBeDefined();
-    await new Promise((resolve) => setTimeout(resolve, 0));
-
-    expect(onRequestSent).not.toHaveBeenCalled();
-    expect(onResponseReceived).not.toHaveBeenCalled();
-    FetchInterceptor.disableInterception();
+    expect(FetchInterceptor.isInterceptorEnabled()).toBe(false);
   });
 
-  it('emits a canceled failure when the original fetch rejects with an AbortError', async () => {
+  it('emits a canceled failure when expo/fetch rejects with an AbortError', async () => {
     const abortError = new DOMException('Aborted', 'AbortError');
     const fetchMock = vi.fn(async () => {
       throw abortError;
     });
-    globalThis.fetch = fetchMock as typeof fetch;
+    const expoFetchModule = { fetch: fetchMock as typeof fetch };
 
-    const { FetchInterceptor } = await loadFetchInterceptor();
+    const { FetchInterceptor } = await loadFetchInterceptor(expoFetchModule);
     const onRequestFailed = vi.fn();
 
     FetchInterceptor.setCallbacks({
@@ -210,9 +212,9 @@ describe('FetchInterceptor', () => {
     });
     FetchInterceptor.enableInterception();
 
-    await expect(fetch('https://example.com/api')).rejects.toThrow(
-      'Aborted',
-    );
+    await expect(
+      expoFetchModule.fetch('https://example.com/api'),
+    ).rejects.toThrow('Aborted');
 
     expect(onRequestFailed).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -225,27 +227,92 @@ describe('FetchInterceptor', () => {
     FetchInterceptor.disableInterception();
   });
 
-  it('restores the original fetch implementation when disabled', async () => {
-    const fetchMock = vi.fn(async () =>
-      ({
-        url: 'https://example.com/api',
-        status: 204,
-        statusText: 'No Content',
-        headers: new Headers(),
-        body: undefined,
-        clone: () => null,
-      }) as unknown as Response,
-    );
-    globalThis.fetch = fetchMock as typeof fetch;
+  it('emits request metadata before a failed expo/fetch rejection', async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new Error('Network down');
+    });
+    const expoFetchModule = { fetch: fetchMock as typeof fetch };
 
-    const { FetchInterceptor } = await loadFetchInterceptor();
+    const { FetchInterceptor } = await loadFetchInterceptor(expoFetchModule);
+    const events: Array<{ type: string; event: unknown }> = [];
 
+    FetchInterceptor.setCallbacks({
+      onRequestSent: (event) => events.push({ type: 'request-sent', event }),
+      onRequestFailed: (event) =>
+        events.push({ type: 'request-failed', event }),
+    });
     FetchInterceptor.enableInterception();
-    expect(FetchInterceptor.isInterceptorEnabled()).toBe(true);
-    expect(globalThis.fetch).not.toBe(fetchMock);
+
+    await expect(
+      expoFetchModule.fetch('https://example.com/api'),
+    ).rejects.toThrow('Network down');
+
+    expect(events.map((entry) => entry.type)).toEqual([
+      'request-sent',
+      'request-failed',
+    ]);
+    expect(events[0]?.event).toMatchObject({
+      request: {
+        url: 'https://example.com/api',
+        method: 'GET',
+      },
+      type: 'Fetch',
+      source: 'expo',
+    });
+    expect(events[1]?.event).toMatchObject({
+      type: 'Fetch',
+      canceled: false,
+      source: 'expo',
+    });
 
     FetchInterceptor.disableInterception();
-    expect(FetchInterceptor.isInterceptorEnabled()).toBe(false);
-    expect(globalThis.fetch).toBe(fetchMock);
+  });
+
+  it('avoids buffering binary bodies past the capture cap', async () => {
+    const size = 11;
+    const fetchMock = vi.fn(async () => {
+      const bytes = new Uint8Array(size);
+      bytes.fill(7);
+
+      const createBody = () =>
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(bytes);
+            controller.close();
+          },
+        });
+
+      const createResponse = (): Response =>
+        ({
+          url: 'https://example.com/file',
+          status: 200,
+          statusText: 'OK',
+          headers: new Headers({
+            'content-type': 'application/octet-stream',
+            'content-length': String(size),
+          }),
+          body: createBody(),
+          clone: () => createResponse(),
+        }) as unknown as Response;
+
+      return createResponse();
+    });
+    const expoFetchModule = { fetch: fetchMock as typeof fetch };
+
+    const { FetchInterceptor } = await loadFetchInterceptor(expoFetchModule);
+    const sentEvents: Array<unknown> = [];
+
+    FetchInterceptor.setCallbacks({
+      onRequestSent: (event) => sentEvents.push(event),
+    });
+    FetchInterceptor.enableInterception();
+
+    await expoFetchModule.fetch('https://example.com/file');
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(sentEvents).toHaveLength(1);
+    expect(captureResponseBodySpy).not.toHaveBeenCalled();
+
+    FetchInterceptor.disableInterception();
   });
 });

--- a/packages/network-activity-plugin/src/react-native/http/__tests__/fetch-interceptor.test.ts
+++ b/packages/network-activity-plugin/src/react-native/http/__tests__/fetch-interceptor.test.ts
@@ -1,0 +1,251 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const originalFetch = globalThis.fetch;
+
+const loadFetchInterceptor = async () => {
+  vi.resetModules();
+  vi.doMock('../http-utils', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../http-utils')>();
+
+    return {
+      ...actual,
+      getInitiatorFromStack: () => ({ type: 'other' }),
+    };
+  });
+
+  return import('../fetch-interceptor');
+};
+
+const createExpoResponse = (
+  bodyChunks: string[],
+  headers: Record<string, string>,
+) => {
+  const encodedChunks = bodyChunks.map((chunk) => new TextEncoder().encode(chunk));
+  const totalSize = encodedChunks.reduce((sum, chunk) => sum + chunk.byteLength, 0);
+
+  const createBody = () =>
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        encodedChunks.forEach((chunk) => controller.enqueue(chunk));
+        controller.close();
+      },
+    });
+
+  const createResponse = (): Response =>
+    ({
+      url: 'https://example.com/api',
+      status: 200,
+      statusText: 'OK',
+      headers: new Headers({
+        'content-type': 'application/json',
+        'content-length': String(totalSize),
+        ...headers,
+      }),
+      body: createBody(),
+      clone: () => createResponse(),
+    }) as unknown as Response;
+
+  return createResponse();
+};
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+  vi.unmock('../http-utils');
+});
+
+describe('FetchInterceptor', () => {
+  it('emits lifecycle events for Expo fetch responses and preserves the original response', async () => {
+    const fetchMock = vi.fn(async () =>
+      createExpoResponse(['{"ok":', 'true}'], {
+        'x-request-id': 'expo-1',
+      }),
+    );
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const { FetchInterceptor } = await loadFetchInterceptor();
+    const events: Array<{ type: string; event: unknown }> = [];
+
+    FetchInterceptor.setCallbacks({
+      onRequestSent: (event) => events.push({ type: 'request-sent', event }),
+      onResponseReceived: (event) =>
+        events.push({ type: 'response-received', event }),
+      onRequestProgress: (event) =>
+        events.push({ type: 'request-progress', event }),
+      onRequestCompleted: (event) =>
+        events.push({ type: 'request-completed', event }),
+      onRequestFailed: (event) =>
+        events.push({ type: 'request-failed', event }),
+      onResponseBody: (requestId, body) =>
+        events.push({
+          type: 'response-body',
+          event: { requestId, body },
+        }),
+    });
+
+    FetchInterceptor.enableInterception();
+
+    const response = await fetch('https://example.com/api', {
+      method: 'post',
+      headers: {
+        'x-request-id': 'expo-1',
+      },
+      body: JSON.stringify({ ok: true }),
+    });
+
+    expect(response).toBeDefined();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const requestSent = events.find((entry) => entry.type === 'request-sent');
+    const responseReceived = events.find(
+      (entry) => entry.type === 'response-received',
+    );
+    const progressEvents = events.filter(
+      (entry) => entry.type === 'request-progress',
+    );
+    const completed = events.find(
+      (entry) => entry.type === 'request-completed',
+    );
+    const bodyEvent = events.find((entry) => entry.type === 'response-body');
+
+    expect(requestSent?.event).toMatchObject({
+      request: {
+        url: 'https://example.com/api',
+        method: 'POST',
+        headers: {
+          'x-request-id': 'expo-1',
+        },
+        postData: {
+          type: 'text',
+          value: '{"ok":true}',
+        },
+      },
+      type: 'Fetch',
+      source: 'expo',
+    });
+
+    expect(responseReceived?.event).toMatchObject({
+      type: 'Fetch',
+      source: 'expo',
+      response: {
+        url: 'https://example.com/api',
+        status: 200,
+        statusText: 'OK',
+        contentType: 'application/json',
+        size: 11,
+      },
+    });
+
+    expect(progressEvents.length).toBeGreaterThan(0);
+    expect(progressEvents.at(-1)?.event).toMatchObject({
+      loaded: 11,
+      total: 11,
+      lengthComputable: true,
+      source: 'expo',
+    });
+
+    expect(bodyEvent?.event).toEqual({
+      requestId: expect.any(String),
+      body: '{"ok":true}',
+    });
+
+    expect(completed?.event).toMatchObject({
+      duration: expect.any(Number),
+      size: 11,
+      ttfb: expect.any(Number),
+      source: 'expo',
+    });
+
+    FetchInterceptor.disableInterception();
+  });
+
+  it('does not emit fetch-owned events for non-streaming RN responses', async () => {
+    const fetchMock = vi.fn(async () =>
+      ({
+        url: 'https://example.com/api',
+        status: 200,
+        statusText: 'OK',
+        headers: new Headers(),
+        body: undefined,
+        clone: () => null,
+      }) as unknown as Response,
+    );
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const { FetchInterceptor } = await loadFetchInterceptor();
+    const onRequestSent = vi.fn();
+    const onResponseReceived = vi.fn();
+
+    FetchInterceptor.setCallbacks({
+      onRequestSent,
+      onResponseReceived,
+    });
+    FetchInterceptor.enableInterception();
+
+    const response = await fetch('https://example.com/api');
+
+    expect(response).toBeDefined();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(onRequestSent).not.toHaveBeenCalled();
+    expect(onResponseReceived).not.toHaveBeenCalled();
+    FetchInterceptor.disableInterception();
+  });
+
+  it('emits a canceled failure when the original fetch rejects with an AbortError', async () => {
+    const abortError = new DOMException('Aborted', 'AbortError');
+    const fetchMock = vi.fn(async () => {
+      throw abortError;
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const { FetchInterceptor } = await loadFetchInterceptor();
+    const onRequestFailed = vi.fn();
+
+    FetchInterceptor.setCallbacks({
+      onRequestFailed,
+    });
+    FetchInterceptor.enableInterception();
+
+    await expect(fetch('https://example.com/api')).rejects.toThrow(
+      'Aborted',
+    );
+
+    expect(onRequestFailed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'Fetch',
+        canceled: true,
+        source: 'expo',
+      }),
+    );
+
+    FetchInterceptor.disableInterception();
+  });
+
+  it('restores the original fetch implementation when disabled', async () => {
+    const fetchMock = vi.fn(async () =>
+      ({
+        url: 'https://example.com/api',
+        status: 204,
+        statusText: 'No Content',
+        headers: new Headers(),
+        body: undefined,
+        clone: () => null,
+      }) as unknown as Response,
+    );
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const { FetchInterceptor } = await loadFetchInterceptor();
+
+    FetchInterceptor.enableInterception();
+    expect(FetchInterceptor.isInterceptorEnabled()).toBe(true);
+    expect(globalThis.fetch).not.toBe(fetchMock);
+
+    FetchInterceptor.disableInterception();
+    expect(FetchInterceptor.isInterceptorEnabled()).toBe(false);
+    expect(globalThis.fetch).toBe(fetchMock);
+  });
+});

--- a/packages/network-activity-plugin/src/react-native/http/__tests__/fetch-interceptor.test.ts
+++ b/packages/network-activity-plugin/src/react-native/http/__tests__/fetch-interceptor.test.ts
@@ -36,7 +36,9 @@ const createExpoResponse = (
   bodyChunks: string[],
   headers: Record<string, string>,
 ) => {
-  const encodedChunks = bodyChunks.map((chunk) => new TextEncoder().encode(chunk));
+  const encodedChunks = bodyChunks.map((chunk) =>
+    new TextEncoder().encode(chunk),
+  );
   const totalSize = encodedChunks.reduce(
     (sum, chunk) => sum + chunk.byteLength,
     0,
@@ -76,13 +78,20 @@ afterEach(() => {
 });
 
 describe('FetchInterceptor', () => {
-  it('patches expo/fetch directly and preserves the original export', async () => {
+  it('patches the private export, its getter facade, and Expo global alias', async () => {
     const fetchMock = vi.fn(async () =>
       createExpoResponse(['{"ok":', 'true}'], {
         'x-request-id': 'expo-1',
       }),
     );
     const expoFetchModule = { fetch: fetchMock as typeof fetch };
+    const expoFetchFacade = {
+      get fetch() {
+        return expoFetchModule.fetch;
+      },
+    };
+    const originalGlobalFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock as typeof fetch;
 
     const { FetchInterceptor } = await loadFetchInterceptor(expoFetchModule);
     const events: Array<{ type: string; event: unknown }> = [];
@@ -108,9 +117,10 @@ describe('FetchInterceptor', () => {
     FetchInterceptor.enableInterception();
 
     expect(FetchInterceptor.isInterceptorEnabled()).toBe(true);
-    expect(expoFetchModule.fetch).not.toBe(originalModuleFetch);
+    expect(expoFetchFacade.fetch).not.toBe(originalModuleFetch);
+    expect(globalThis.fetch).toBe(expoFetchFacade.fetch);
 
-    const response = await expoFetchModule.fetch('https://example.com/api', {
+    const response = await expoFetchFacade.fetch('https://example.com/api', {
       method: 'post',
       headers: {
         'x-request-id': 'expo-1',
@@ -182,19 +192,278 @@ describe('FetchInterceptor', () => {
       ttfb: expect.any(Number),
       source: 'expo',
     });
+    expect(
+      events.filter(
+        (entry) =>
+          entry.type === 'request-completed' || entry.type === 'request-failed',
+      ),
+    ).toHaveLength(1);
 
     FetchInterceptor.disableInterception();
 
     expect(FetchInterceptor.isInterceptorEnabled()).toBe(false);
     expect(expoFetchModule.fetch).toBe(originalModuleFetch);
+    expect(globalThis.fetch).toBe(fetchMock);
+    globalThis.fetch = originalGlobalFetch;
   });
 
-  it('does not start when expo/fetch is unavailable', async () => {
-    const { FetchInterceptor } = await loadFetchInterceptor(null);
-
+  it('captures a consumed SDK 54–55 response without turning clone failure into a request failure', async () => {
+    const response = {
+      url: 'https://example.com/fallback',
+      status: 200,
+      statusText: 'OK',
+      headers: new Headers({ 'content-type': 'application/json' }),
+      clone: () => {
+        throw new Error('Response.clone is not supported');
+      },
+      text: vi.fn(async () => '{"ok":true}'),
+      json: function (this: { text: () => Promise<string> }) {
+        return this.text().then(JSON.parse);
+      },
+    } as unknown as Response;
+    const expoFetchModule = {
+      fetch: vi.fn(async () => response) as typeof fetch,
+    };
+    const { FetchInterceptor } = await loadFetchInterceptor(expoFetchModule);
+    const onResponseBody = vi.fn();
+    const onRequestCompleted = vi.fn();
+    const onRequestFailed = vi.fn();
+    const terminalEvents: string[] = [];
+    FetchInterceptor.setCallbacks({
+      onResponseBody,
+      onRequestCompleted: (event) => {
+        terminalEvents.push('request-completed');
+        onRequestCompleted(event);
+      },
+      onRequestFailed: (event) => {
+        terminalEvents.push('request-failed');
+        onRequestFailed(event);
+      },
+    });
     FetchInterceptor.enableInterception();
 
-    expect(FetchInterceptor.isInterceptorEnabled()).toBe(false);
+    const received = await expoFetchModule.fetch(
+      'https://example.com/fallback',
+    );
+    await expect(received.json()).resolves.toEqual({ ok: true });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(onRequestCompleted).toHaveBeenCalledTimes(1);
+    expect(onRequestFailed).not.toHaveBeenCalled();
+    expect(terminalEvents).toEqual(['request-completed']);
+    expect(onResponseBody).toHaveBeenCalledWith(
+      expect.any(String),
+      '{"ok":true}',
+    );
+    FetchInterceptor.disableInterception();
+  });
+
+  it('does not create a derived unhandled rejection when a consumed body rejects', async () => {
+    const error = new Error('Body read failed');
+    let rejectBody: (reason: unknown) => void = () => undefined;
+    const bodyPromise = new Promise<string>((_resolve, reject) => {
+      rejectBody = reject;
+    });
+    const response = {
+      url: 'https://example.com/fallback-error',
+      status: 200,
+      statusText: 'OK',
+      headers: new Headers({ 'content-type': 'text/plain' }),
+      clone: () => {
+        throw new Error('Response.clone is not supported');
+      },
+      text: vi.fn(() => bodyPromise),
+    } as unknown as Response;
+    const expoFetchModule = {
+      fetch: vi.fn(async () => response) as typeof fetch,
+    };
+    const { FetchInterceptor } = await loadFetchInterceptor(expoFetchModule);
+    FetchInterceptor.enableInterception();
+
+    const received = await expoFetchModule.fetch(response.url);
+    const returnedPromise = received.text();
+    expect(returnedPromise).toBe(bodyPromise);
+    rejectBody(error);
+    await expect(returnedPromise).rejects.toBe(error);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    FetchInterceptor.disableInterception();
+  });
+
+  it('uses one clone and reports captured bytes when Content-Length is unavailable', async () => {
+    const bytes = new TextEncoder().encode('{"ok":true}');
+    const clone = {
+      body: new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(bytes);
+          controller.close();
+        },
+      }),
+    } as Response;
+    const response = {
+      url: 'https://example.com/no-length',
+      status: 200,
+      statusText: 'OK',
+      headers: new Headers({ 'content-type': 'application/json' }),
+      clone: vi.fn(() => clone),
+    } as unknown as Response;
+    const expoFetchModule = {
+      fetch: vi.fn(async () => response) as typeof fetch,
+    };
+    const { FetchInterceptor } = await loadFetchInterceptor(expoFetchModule);
+    const events: string[] = [];
+    const onRequestCompleted = vi.fn((event) => {
+      events.push('request-completed');
+      return event;
+    });
+    FetchInterceptor.setCallbacks({
+      onRequestSent: () => events.push('request-sent'),
+      onResponseReceived: () => events.push('response-received'),
+      onResponseBody: () => events.push('response-body'),
+      onRequestCompleted,
+      onRequestFailed: () => events.push('request-failed'),
+    });
+    FetchInterceptor.enableInterception();
+
+    expect(await expoFetchModule.fetch(response.url)).toBe(response);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(response.clone).toHaveBeenCalledTimes(1);
+    expect(events).toEqual([
+      'request-sent',
+      'response-received',
+      'response-body',
+      'request-completed',
+    ]);
+    expect(onRequestCompleted).toHaveBeenCalledWith(
+      expect.objectContaining({ size: bytes.byteLength }),
+    );
+    FetchInterceptor.disableInterception();
+  });
+
+  it('completes successfully when response metadata throws', async () => {
+    const response = {
+      get headers() {
+        throw new Error('headers unavailable');
+      },
+    } as unknown as Response;
+    const expoFetchModule = {
+      fetch: vi.fn(async () => response) as typeof fetch,
+    };
+    const { FetchInterceptor } = await loadFetchInterceptor(expoFetchModule);
+    const onResponseBody = vi.fn();
+    const onRequestCompleted = vi.fn();
+    const onRequestFailed = vi.fn();
+    const terminalEvents: string[] = [];
+    FetchInterceptor.setCallbacks({
+      onResponseBody,
+      onRequestCompleted: (event) => {
+        terminalEvents.push('request-completed');
+        onRequestCompleted(event);
+      },
+      onRequestFailed: (event) => {
+        terminalEvents.push('request-failed');
+        onRequestFailed(event);
+      },
+    });
+    FetchInterceptor.enableInterception();
+
+    expect(await expoFetchModule.fetch('https://example.com/metadata')).toBe(
+      response,
+    );
+    expect(onResponseBody).toHaveBeenCalledWith(expect.any(String), null);
+    expect(onRequestCompleted).toHaveBeenCalledTimes(1);
+    expect(onRequestFailed).not.toHaveBeenCalled();
+    expect(terminalEvents).toEqual(['request-completed']);
+    FetchInterceptor.disableInterception();
+  });
+
+  it('leaves later wrappers intact and remains disabled without Expo', async () => {
+    const original = vi.fn();
+    const expoFetchModule = { fetch: original as typeof fetch };
+    const { FetchInterceptor } = await loadFetchInterceptor(expoFetchModule);
+    FetchInterceptor.enableInterception();
+    const rozeniteWrapper = expoFetchModule.fetch;
+    FetchInterceptor.enableInterception();
+    expect(expoFetchModule.fetch).toBe(rozeniteWrapper);
+
+    const laterWrapper = vi.fn();
+    expoFetchModule.fetch = laterWrapper as typeof fetch;
+    FetchInterceptor.disableInterception();
+    expect(expoFetchModule.fetch).toBe(laterWrapper);
+
+    const absent = await loadFetchInterceptor(null);
+    absent.FetchInterceptor.enableInterception();
+    expect(absent.FetchInterceptor.isInterceptorEnabled()).toBe(false);
+  });
+
+  it('restores a lazily materialized Expo global alias', async () => {
+    const originalGlobalDescriptor = Object.getOwnPropertyDescriptor(
+      globalThis,
+      'fetch',
+    );
+    const originalExpoFetch = vi.fn();
+    const expoFetchModule = { fetch: originalExpoFetch as typeof fetch };
+    Object.defineProperty(globalThis, 'fetch', {
+      configurable: true,
+      get: () => expoFetchModule.fetch,
+      set: (value) => {
+        Object.defineProperty(globalThis, 'fetch', {
+          configurable: true,
+          writable: true,
+          value,
+        });
+      },
+    });
+
+    try {
+      const { FetchInterceptor } = await loadFetchInterceptor(expoFetchModule);
+      FetchInterceptor.enableInterception();
+      expect(globalThis.fetch).toBe(expoFetchModule.fetch);
+
+      FetchInterceptor.disableInterception();
+      expect(globalThis.fetch).toBe(originalExpoFetch);
+    } finally {
+      if (originalGlobalDescriptor) {
+        Object.defineProperty(globalThis, 'fetch', originalGlobalDescriptor);
+      }
+    }
+  });
+
+  it('restores Expo fetch when its lazy global is installed after enable', async () => {
+    const originalGlobalDescriptor = Object.getOwnPropertyDescriptor(
+      globalThis,
+      'fetch',
+    );
+    const reactNativeFetch = vi.fn();
+    const originalExpoFetch = vi.fn();
+    const expoFetchModule = { fetch: originalExpoFetch as typeof fetch };
+    globalThis.fetch = reactNativeFetch as typeof fetch;
+
+    try {
+      const { FetchInterceptor } = await loadFetchInterceptor(expoFetchModule);
+      FetchInterceptor.enableInterception();
+      Object.defineProperty(globalThis, 'fetch', {
+        configurable: true,
+        get: () => expoFetchModule.fetch,
+        set: (value) => {
+          Object.defineProperty(globalThis, 'fetch', {
+            configurable: true,
+            writable: true,
+            value,
+          });
+        },
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(globalThis.fetch).toBe(expoFetchModule.fetch);
+      FetchInterceptor.disableInterception();
+      expect(globalThis.fetch).toBe(originalExpoFetch);
+    } finally {
+      if (originalGlobalDescriptor) {
+        Object.defineProperty(globalThis, 'fetch', originalGlobalDescriptor);
+      }
+    }
   });
 
   it('emits a canceled failure when expo/fetch rejects with an AbortError', async () => {
@@ -206,15 +475,24 @@ describe('FetchInterceptor', () => {
 
     const { FetchInterceptor } = await loadFetchInterceptor(expoFetchModule);
     const onRequestFailed = vi.fn();
+    const onRequestCompleted = vi.fn();
+    const terminalEvents: string[] = [];
 
     FetchInterceptor.setCallbacks({
-      onRequestFailed,
+      onRequestCompleted: (event) => {
+        terminalEvents.push('request-completed');
+        onRequestCompleted(event);
+      },
+      onRequestFailed: (event) => {
+        terminalEvents.push('request-failed');
+        onRequestFailed(event);
+      },
     });
     FetchInterceptor.enableInterception();
 
-    await expect(
-      expoFetchModule.fetch('https://example.com/api'),
-    ).rejects.toThrow('Aborted');
+    await expect(expoFetchModule.fetch('https://example.com/api')).rejects.toBe(
+      abortError,
+    );
 
     expect(onRequestFailed).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -223,6 +501,8 @@ describe('FetchInterceptor', () => {
         source: 'expo',
       }),
     );
+    expect(onRequestCompleted).not.toHaveBeenCalled();
+    expect(terminalEvents).toEqual(['request-failed']);
 
     FetchInterceptor.disableInterception();
   });
@@ -240,6 +520,8 @@ describe('FetchInterceptor', () => {
       onRequestSent: (event) => events.push({ type: 'request-sent', event }),
       onRequestFailed: (event) =>
         events.push({ type: 'request-failed', event }),
+      onRequestCompleted: (event) =>
+        events.push({ type: 'request-completed', event }),
     });
     FetchInterceptor.enableInterception();
 
@@ -264,54 +546,12 @@ describe('FetchInterceptor', () => {
       canceled: false,
       source: 'expo',
     });
-
-    FetchInterceptor.disableInterception();
-  });
-
-  it('avoids buffering binary bodies past the capture cap', async () => {
-    const size = 11;
-    const fetchMock = vi.fn(async () => {
-      const bytes = new Uint8Array(size);
-      bytes.fill(7);
-
-      const createBody = () =>
-        new ReadableStream<Uint8Array>({
-          start(controller) {
-            controller.enqueue(bytes);
-            controller.close();
-          },
-        });
-
-      const createResponse = (): Response =>
-        ({
-          url: 'https://example.com/file',
-          status: 200,
-          statusText: 'OK',
-          headers: new Headers({
-            'content-type': 'application/octet-stream',
-            'content-length': String(size),
-          }),
-          body: createBody(),
-          clone: () => createResponse(),
-        }) as unknown as Response;
-
-      return createResponse();
-    });
-    const expoFetchModule = { fetch: fetchMock as typeof fetch };
-
-    const { FetchInterceptor } = await loadFetchInterceptor(expoFetchModule);
-    const sentEvents: Array<unknown> = [];
-
-    FetchInterceptor.setCallbacks({
-      onRequestSent: (event) => sentEvents.push(event),
-    });
-    FetchInterceptor.enableInterception();
-
-    await expoFetchModule.fetch('https://example.com/file');
-    await new Promise((resolve) => setTimeout(resolve, 50));
-
-    expect(sentEvents).toHaveLength(1);
-    expect(captureResponseBodySpy).not.toHaveBeenCalled();
+    expect(
+      events.filter(
+        (entry) =>
+          entry.type === 'request-completed' || entry.type === 'request-failed',
+      ),
+    ).toHaveLength(1);
 
     FetchInterceptor.disableInterception();
   });

--- a/packages/network-activity-plugin/src/react-native/http/__tests__/fetch-utils.test.ts
+++ b/packages/network-activity-plugin/src/react-native/http/__tests__/fetch-utils.test.ts
@@ -70,7 +70,7 @@ describe('normalizeFetchRequest', () => {
     });
   });
 
-  it('normalizes Request input and merges override headers', () => {
+  it('normalizes Request input and replaces inherited headers with init headers', () => {
     const request = new Request('https://example.com/items', {
       method: 'put',
       headers: {
@@ -94,6 +94,29 @@ describe('normalizeFetchRequest', () => {
       },
       postData: undefined,
       signal: expect.any(AbortSignal),
+    });
+  });
+
+  it('normalizes Expo request-like inputs and gives init precedence', () => {
+    const requestLike = {
+      url: 'https://example.com/expo',
+      method: 'patch',
+      headers: { 'x-inherited': 'yes', 'x-replaced': 'old' },
+      body: 'inherited body',
+      signal: new AbortController().signal,
+    };
+
+    expect(
+      normalizeFetchRequest(requestLike, {
+        method: 'post',
+        headers: { 'x-replaced': 'new' },
+        body: 'init body',
+      }),
+    ).toMatchObject({
+      url: 'https://example.com/expo',
+      method: 'POST',
+      headers: { 'x-replaced': 'new' },
+      postData: { type: 'text', value: 'init body' },
     });
   });
 
@@ -121,10 +144,12 @@ describe('captureFetchResponseBodyFromBytes', () => {
       await captureFetchResponseBodyFromBytes(xml, 'application/xml'),
     ).toBe('<root />');
 
-    const svg = new TextEncoder().encode('<svg xmlns="http://www.w3.org/2000/svg" />');
-    expect(
-      await captureFetchResponseBodyFromBytes(svg, 'image/svg+xml'),
-    ).toBe('<svg xmlns="http://www.w3.org/2000/svg" />');
+    const svg = new TextEncoder().encode(
+      '<svg xmlns="http://www.w3.org/2000/svg" />',
+    );
+    expect(await captureFetchResponseBodyFromBytes(svg, 'image/svg+xml')).toBe(
+      '<svg xmlns="http://www.w3.org/2000/svg" />',
+    );
   });
 
   it('returns a binary union for non-text bytes under the cap', async () => {
@@ -137,7 +162,10 @@ describe('captureFetchResponseBodyFromBytes', () => {
   it('short-circuits binary capture above the cap', async () => {
     const bytes = new Uint8Array(BINARY_CAPTURE_SIZE_CAP + 1);
     expect(
-      await captureFetchResponseBodyFromBytes(bytes, 'application/octet-stream'),
+      await captureFetchResponseBodyFromBytes(
+        bytes,
+        'application/octet-stream',
+      ),
     ).toEqual({
       kind: 'binary-too-large',
       size: BINARY_CAPTURE_SIZE_CAP + 1,

--- a/packages/network-activity-plugin/src/react-native/http/__tests__/fetch-utils.test.ts
+++ b/packages/network-activity-plugin/src/react-native/http/__tests__/fetch-utils.test.ts
@@ -1,0 +1,178 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import {
+  BINARY_CAPTURE_SIZE_CAP,
+  captureFetchResponseBodyFromBytes,
+  createProgressThrottler,
+  getFetchContentLength,
+  getFetchContentType,
+  isExpoFetchResponse,
+  normalizeFetchRequest,
+  normalizeHeaders,
+} from '../fetch-utils';
+
+describe('normalizeHeaders', () => {
+  it('normalizes plain object headers', () => {
+    expect(
+      normalizeHeaders({
+        Accept: 'application/json',
+        'x-token': 'abc',
+      }),
+    ).toEqual({
+      Accept: 'application/json',
+      'x-token': 'abc',
+    });
+  });
+
+  it('normalizes array headers and preserves repeated values', () => {
+    expect(
+      normalizeHeaders([
+        ['set-cookie', 'a=1'],
+        ['set-cookie', 'b=2'],
+      ]),
+    ).toEqual({
+      'set-cookie': ['a=1', 'b=2'],
+    });
+  });
+
+  it('normalizes Headers instances', () => {
+    const headers = new Headers([
+      ['content-type', 'application/json'],
+      ['x-id', '123'],
+    ]);
+
+    expect(normalizeHeaders(headers)).toEqual({
+      'content-type': 'application/json',
+      'x-id': '123',
+    });
+  });
+});
+
+describe('normalizeFetchRequest', () => {
+  it('normalizes string input and request init options', () => {
+    const result = normalizeFetchRequest('https://example.com/api', {
+      method: 'post',
+      headers: {
+        Accept: 'application/json',
+      },
+      body: JSON.stringify({ ok: true }),
+    });
+
+    expect(result).toEqual({
+      url: 'https://example.com/api',
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+      },
+      postData: {
+        type: 'text',
+        value: '{"ok":true}',
+      },
+    });
+  });
+
+  it('normalizes Request input and merges override headers', () => {
+    const request = new Request('https://example.com/items', {
+      method: 'put',
+      headers: {
+        'x-original': 'one',
+      },
+    });
+
+    expect(
+      normalizeFetchRequest(request, {
+        headers: {
+          'x-original': 'two',
+          'x-extra': 'three',
+        },
+      }),
+    ).toMatchObject({
+      url: 'https://example.com/items',
+      method: 'PUT',
+      headers: {
+        'x-original': 'two',
+        'x-extra': 'three',
+      },
+      postData: undefined,
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it('serializes URLSearchParams request bodies as text', () => {
+    const result = normalizeFetchRequest('https://example.com/search', {
+      body: new URLSearchParams({ q: 'expo fetch' }),
+    });
+
+    expect(result.postData).toEqual({
+      type: 'text',
+      value: 'q=expo+fetch',
+    });
+  });
+});
+
+describe('captureFetchResponseBodyFromBytes', () => {
+  it('returns text for JSON, XML, and text content types', async () => {
+    const json = new TextEncoder().encode('{"ok":true}');
+    expect(
+      await captureFetchResponseBodyFromBytes(json, 'application/json'),
+    ).toBe('{"ok":true}');
+
+    const xml = new TextEncoder().encode('<root />');
+    expect(
+      await captureFetchResponseBodyFromBytes(xml, 'application/xml'),
+    ).toBe('<root />');
+
+    const svg = new TextEncoder().encode('<svg xmlns="http://www.w3.org/2000/svg" />');
+    expect(
+      await captureFetchResponseBodyFromBytes(svg, 'image/svg+xml'),
+    ).toBe('<svg xmlns="http://www.w3.org/2000/svg" />');
+  });
+
+  it('returns a binary union for non-text bytes under the cap', async () => {
+    const bytes = new Uint8Array([1, 2, 3]);
+    expect(
+      await captureFetchResponseBodyFromBytes(bytes, 'application/pdf'),
+    ).toEqual({ kind: 'binary', base64: 'AQID' });
+  });
+
+  it('short-circuits binary capture above the cap', async () => {
+    const bytes = new Uint8Array(BINARY_CAPTURE_SIZE_CAP + 1);
+    expect(
+      await captureFetchResponseBodyFromBytes(bytes, 'application/octet-stream'),
+    ).toEqual({
+      kind: 'binary-too-large',
+      size: BINARY_CAPTURE_SIZE_CAP + 1,
+    });
+  });
+});
+
+describe('progress throttling and response metadata helpers', () => {
+  it('throttles progress emissions and allows forced updates', () => {
+    const shouldEmit = createProgressThrottler(100);
+
+    expect(shouldEmit(1_000)).toBe(true);
+    expect(shouldEmit(1_050)).toBe(false);
+    expect(shouldEmit(1_100)).toBe(true);
+    expect(shouldEmit(1_120, true)).toBe(true);
+  });
+
+  it('detects Expo fetch responses from runtime capabilities', () => {
+    const response = {
+      clone: () => response,
+      body: undefined,
+    } as unknown as Response;
+    expect(isExpoFetchResponse(response)).toBe(false);
+  });
+
+  it('reads fetch response metadata from headers', () => {
+    const response = new Response('hello', {
+      headers: {
+        'content-type': 'application/json; charset=utf-8',
+        'content-length': '12',
+      },
+    });
+
+    expect(getFetchContentType(response)).toBe('application/json');
+    expect(getFetchContentLength(response)).toBe(12);
+  });
+});

--- a/packages/network-activity-plugin/src/react-native/http/__tests__/fetch-utils.test.ts
+++ b/packages/network-activity-plugin/src/react-native/http/__tests__/fetch-utils.test.ts
@@ -6,7 +6,6 @@ import {
   createProgressThrottler,
   getFetchContentLength,
   getFetchContentType,
-  isExpoFetchResponse,
   normalizeFetchRequest,
   normalizeHeaders,
 } from '../fetch-utils';
@@ -154,14 +153,6 @@ describe('progress throttling and response metadata helpers', () => {
     expect(shouldEmit(1_050)).toBe(false);
     expect(shouldEmit(1_100)).toBe(true);
     expect(shouldEmit(1_120, true)).toBe(true);
-  });
-
-  it('detects Expo fetch responses from runtime capabilities', () => {
-    const response = {
-      clone: () => response,
-      body: undefined,
-    } as unknown as Response;
-    expect(isExpoFetchResponse(response)).toBe(false);
   });
 
   it('reads fetch response metadata from headers', () => {

--- a/packages/network-activity-plugin/src/react-native/http/__tests__/network-requests-registry.test.ts
+++ b/packages/network-activity-plugin/src/react-native/http/__tests__/network-requests-registry.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { getNetworkRequestsRegistry } from '../network-requests-registry';
+
+describe('getNetworkRequestsRegistry', () => {
+  it('stores response bodies for fetch-owned requests without an XHR entry', () => {
+    const registry = getNetworkRequestsRegistry();
+
+    registry.setResponseBody('fetch-1', '{"ok":true}');
+
+    expect(registry.getEntry('fetch-1')).toBeNull();
+    expect(registry.getResponseBody('fetch-1')).toBe('{"ok":true}');
+  });
+
+  it('keeps the XHR request entry and response body side by side', () => {
+    const registry = getNetworkRequestsRegistry();
+    const xhr = {
+      responseType: '',
+    } as unknown as XMLHttpRequest;
+
+    registry.addEntry('xhr-1', xhr);
+    registry.setResponseBody('xhr-1', 'hello');
+
+    expect(registry.getEntry('xhr-1')).toBe(xhr);
+    expect(registry.getResponseBody('xhr-1')).toBe('hello');
+  });
+});

--- a/packages/network-activity-plugin/src/react-native/http/fetch-interceptor.ts
+++ b/packages/network-activity-plugin/src/react-native/http/fetch-interceptor.ts
@@ -1,0 +1,263 @@
+import type { HttpEventMap } from '../../shared/http-events';
+import { getInitiatorFromStack } from './http-utils';
+import {
+  captureFetchResponseBodyFromBytes,
+  createProgressThrottler,
+  getFetchContentLength,
+  getFetchContentType,
+  getFetchResponseHeaders,
+  isExpoFetchResponse,
+  normalizeFetchRequest,
+  isFetchAbortError,
+} from './fetch-utils';
+
+type FetchInterceptorCallbacks = {
+  onRequestSent?: (event: HttpEventMap['request-sent']) => void;
+  onResponseReceived?: (event: HttpEventMap['response-received']) => void;
+  onRequestCompleted?: (event: HttpEventMap['request-completed']) => void;
+  onRequestFailed?: (event: HttpEventMap['request-failed']) => void;
+  onRequestProgress?: (event: HttpEventMap['request-progress']) => void;
+  onResponseBody?: (
+    requestId: string,
+    body: HttpEventMap['response-body']['body'],
+  ) => void;
+};
+
+type FetchArgs = Parameters<typeof fetch>;
+
+const originalFetch = globalThis.fetch;
+
+let callbacks: FetchInterceptorCallbacks | null = null;
+let isInterceptorEnabled = false;
+
+const createRequestId = () =>
+  `req_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`;
+
+const concatChunks = (chunks: Uint8Array[], totalBytes: number) => {
+  const bytes = new Uint8Array(totalBytes);
+  let offset = 0;
+
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  return bytes;
+};
+
+const emitRequestFailed = (
+  requestId: string,
+  error: unknown,
+  canceled: boolean,
+) => {
+  callbacks?.onRequestFailed?.({
+    requestId,
+    timestamp: Date.now(),
+    type: 'Fetch',
+    error:
+      error instanceof Error && error.message
+        ? error.message
+        : typeof error === 'string'
+          ? error
+          : 'Failed',
+    canceled,
+    source: 'expo',
+  });
+};
+
+const captureExpoFetchResponse = async (
+  requestId: string,
+  sendTime: number,
+  response: Response,
+  request: ReturnType<typeof normalizeFetchRequest>,
+  initiator: ReturnType<typeof getInitiatorFromStack>,
+) => {
+  try {
+    const responseReceivedAt = Date.now();
+    const contentLength = getFetchContentLength(response);
+    const contentType = getFetchContentType(response);
+
+    callbacks?.onRequestSent?.({
+      requestId,
+      timestamp: sendTime,
+      request,
+      initiator,
+      type: 'Fetch',
+      source: 'expo',
+    });
+
+    callbacks?.onResponseReceived?.({
+      requestId,
+      timestamp: responseReceivedAt,
+      type: 'Fetch',
+      response: {
+        url: response.url,
+        status: response.status,
+        statusText: response.statusText,
+        headers: getFetchResponseHeaders(response),
+        contentType,
+        size: contentLength ?? null,
+        responseTime: responseReceivedAt,
+      },
+      source: 'expo',
+    });
+
+    const clone = response.clone();
+    const reader = clone.body?.getReader();
+    const progressThrottle = createProgressThrottler();
+    const chunks: Uint8Array[] = [];
+    let loaded = 0;
+
+    if (!reader) {
+      const body = await captureFetchResponseBodyFromBytes(
+        new Uint8Array(),
+        contentType,
+      );
+      callbacks?.onResponseBody?.(requestId, body);
+      callbacks?.onRequestCompleted?.({
+        requestId,
+        timestamp: Date.now(),
+        duration: Date.now() - sendTime,
+        size: 0,
+        ttfb: responseReceivedAt - sendTime,
+        source: 'expo',
+      });
+      return;
+    }
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+
+      if (!value) {
+        continue;
+      }
+
+      chunks.push(value);
+      loaded += value.byteLength;
+
+      const timestamp = Date.now();
+      if (progressThrottle(timestamp)) {
+        callbacks?.onRequestProgress?.({
+          requestId,
+          timestamp,
+          loaded,
+          total: contentLength ?? 0,
+          lengthComputable: contentLength !== undefined && contentLength > 0,
+          source: 'expo',
+        });
+      }
+    }
+
+    const timestamp = Date.now();
+    if (loaded > 0 || contentLength !== undefined) {
+      callbacks?.onRequestProgress?.({
+        requestId,
+        timestamp,
+        loaded,
+        total: contentLength ?? 0,
+        lengthComputable: contentLength !== undefined && contentLength > 0,
+        source: 'expo',
+      });
+    }
+
+    const bodyBytes = concatChunks(chunks, loaded);
+    const body = await captureFetchResponseBodyFromBytes(bodyBytes, contentType);
+    callbacks?.onResponseBody?.(requestId, body);
+    callbacks?.onRequestCompleted?.({
+      requestId,
+      timestamp: Date.now(),
+      duration: Date.now() - sendTime,
+      size: loaded,
+      ttfb: responseReceivedAt - sendTime,
+      source: 'expo',
+    });
+  } catch (error) {
+    const canceled =
+      isFetchAbortError(error) ||
+      ((error instanceof Error && error.name === 'AbortError') ?? false);
+    callbacks?.onResponseBody?.(requestId, null);
+    emitRequestFailed(requestId, error, canceled);
+  }
+};
+
+export const FetchInterceptor = {
+  setCallbacks(nextCallbacks: FetchInterceptorCallbacks | null) {
+    callbacks = nextCallbacks;
+  },
+
+  isInterceptorEnabled(): boolean {
+    return isInterceptorEnabled;
+  },
+
+  enableInterception() {
+    if (isInterceptorEnabled || !originalFetch) {
+      return;
+    }
+
+    globalThis.fetch = (async (...args: FetchArgs) => {
+      const sendTime = Date.now();
+      const requestId = createRequestId();
+      const normalizedRequest = normalizeFetchRequest(args[0], args[1] ?? {});
+      const initiator = getInitiatorFromStack();
+
+      try {
+        const response = await originalFetch.apply(globalThis, args);
+
+        if (!isExpoFetchResponse(response)) {
+          return response;
+        }
+
+        void captureExpoFetchResponse(
+          requestId,
+          sendTime,
+          response,
+          normalizedRequest,
+          initiator,
+        );
+
+        // The original response is returned to app code unchanged. The
+        // interceptor works off a clone so it can record the response body
+        // without consuming the app's copy.
+        return response;
+      } catch (error) {
+        const signal = normalizedRequest.signal;
+        const canceled =
+          isFetchAbortError(error) || signal?.aborted === true;
+
+        if (canceled) {
+          callbacks?.onRequestFailed?.({
+            requestId,
+            timestamp: Date.now(),
+            type: 'Fetch',
+            error:
+              error instanceof Error && error.message
+                ? error.message
+                : 'Aborted',
+            canceled: true,
+            source: 'expo',
+          });
+        }
+
+        throw error;
+      }
+    }) as typeof fetch;
+
+    isInterceptorEnabled = true;
+  },
+
+  disableInterception() {
+    if (!isInterceptorEnabled) {
+      return;
+    }
+
+    if (originalFetch) {
+      globalThis.fetch = originalFetch;
+    }
+
+    isInterceptorEnabled = false;
+    callbacks = null;
+  },
+};

--- a/packages/network-activity-plugin/src/react-native/http/fetch-interceptor.ts
+++ b/packages/network-activity-plugin/src/react-native/http/fetch-interceptor.ts
@@ -8,9 +8,10 @@ import {
   getFetchContentLength,
   getFetchContentType,
   getFetchResponseHeaders,
-  normalizeFetchRequest,
   isFetchAbortError,
+  normalizeFetchRequest,
 } from './fetch-utils';
+import { captureResponseBodyFromArrayBuffer } from './response-body-utils';
 import { isTextLikeContentType } from './response-body-utils';
 
 type FetchInterceptorCallbacks = {
@@ -26,15 +27,14 @@ type FetchInterceptorCallbacks = {
 };
 
 type FetchArgs = Parameters<typeof fetch>;
-
-type ExpoFetchModule = {
-  fetch: typeof globalThis.fetch;
-};
+type ExpoFetchModule = { fetch: typeof globalThis.fetch };
 
 let callbacks: FetchInterceptorCallbacks | null = null;
-let isInterceptorEnabled = false;
 let expoFetchModule: ExpoFetchModule | null = null;
 let originalExpoFetch: typeof globalThis.fetch | null = null;
+let wrapper: typeof globalThis.fetch | null = null;
+let originalGlobalFetch: typeof globalThis.fetch | null = null;
+let reconciliationTimer: ReturnType<typeof setTimeout> | null = null;
 
 const createRequestId = () =>
   `req_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`;
@@ -42,46 +42,181 @@ const createRequestId = () =>
 const concatChunks = (chunks: Uint8Array[], totalBytes: number) => {
   const bytes = new Uint8Array(totalBytes);
   let offset = 0;
-
   for (const chunk of chunks) {
     bytes.set(chunk, offset);
     offset += chunk.byteLength;
   }
-
   return bytes;
 };
 
-const emitRequestFailed = (
-  requestId: string,
-  error: unknown,
-  canceled: boolean,
-) => {
-  callbacks?.onRequestFailed?.({
-    requestId,
-    timestamp: Date.now(),
-    type: 'Fetch',
-    error:
-      error instanceof Error && error.message
-        ? error.message
-        : typeof error === 'string'
-          ? error
-          : 'Failed',
-    canceled,
-    source: 'expo',
-  });
+const emitFailed = (requestId: string, error: unknown, canceled: boolean) => {
+  try {
+    callbacks?.onRequestFailed?.({
+      requestId,
+      timestamp: Date.now(),
+      type: 'Fetch',
+      error:
+        error instanceof Error && error.message
+          ? error.message
+          : typeof error === 'string'
+            ? error
+            : 'Failed',
+      canceled,
+      source: 'expo',
+    });
+  } catch {
+    // Instrumentation must never affect application fetch behavior.
+  }
 };
 
-const captureExpoFetchResponse = async (
+const emitCompleted = (
+  requestId: string,
+  sendTime: number,
+  responseReceivedAt: number,
+  size: number | null,
+) => {
+  try {
+    callbacks?.onRequestCompleted?.({
+      requestId,
+      timestamp: Date.now(),
+      duration: Date.now() - sendTime,
+      size,
+      ttfb: responseReceivedAt - sendTime,
+      source: 'expo',
+    });
+  } catch {
+    // Instrumentation must never affect application fetch behavior.
+  }
+};
+
+const captureCloneBody = async (
+  requestId: string,
+  clone: Response,
+  contentType: string,
+  contentLength: number | undefined,
+) => {
+  const reader = clone.body?.getReader();
+  if (!reader) {
+    callbacks?.onResponseBody?.(
+      requestId,
+      await captureFetchResponseBodyFromBytes(new Uint8Array(), contentType),
+    );
+    return 0;
+  }
+
+  const throttle = createProgressThrottler();
+  const chunks: Uint8Array[] = [];
+  const textLike = isTextLikeContentType(contentType);
+  let captureBinary = !textLike;
+  let loaded = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+    loaded += value.byteLength;
+    if (textLike || captureBinary) chunks.push(value);
+    if (!textLike && captureBinary && loaded > BINARY_CAPTURE_SIZE_CAP) {
+      chunks.length = 0;
+      captureBinary = false;
+    }
+    if (throttle(Date.now())) {
+      callbacks?.onRequestProgress?.({
+        requestId,
+        timestamp: Date.now(),
+        loaded,
+        total: contentLength ?? 0,
+        lengthComputable: contentLength !== undefined && contentLength > 0,
+        source: 'expo',
+      });
+    }
+  }
+
+  if (loaded > 0 || contentLength !== undefined) {
+    callbacks?.onRequestProgress?.({
+      requestId,
+      timestamp: Date.now(),
+      loaded,
+      total: contentLength ?? 0,
+      lengthComputable: contentLength !== undefined && contentLength > 0,
+      source: 'expo',
+    });
+  }
+  callbacks?.onResponseBody?.(
+    requestId,
+    captureBinary || textLike
+      ? await captureFetchResponseBodyFromBytes(
+          concatChunks(chunks, loaded),
+          contentType,
+        )
+      : { kind: 'binary-too-large', size: loaded },
+  );
+  return loaded;
+};
+
+const decorateConsumedBody = (
+  requestId: string,
+  response: Response,
+  contentType: string,
+) => {
+  let captured = false;
+  const captureOnce = (
+    capture: () => Promise<HttpEventMap['response-body']['body']>,
+  ) => {
+    if (captured) return;
+    captured = true;
+    void capture()
+      .then((body) => callbacks?.onResponseBody?.(requestId, body))
+      .catch(() => undefined);
+  };
+
+  try {
+    const originalText = response.text;
+    if (typeof originalText === 'function') {
+      response.text = function () {
+        const result = originalText.call(this);
+        void result.then(
+          (value) => captureOnce(async () => value),
+          () => undefined,
+        );
+        return result;
+      };
+    }
+  } catch {
+    // Some Response implementations may not permit instance decoration.
+  }
+
+  try {
+    const originalArrayBuffer = response.arrayBuffer;
+    if (typeof originalArrayBuffer === 'function') {
+      response.arrayBuffer = function () {
+        const result = originalArrayBuffer.call(this);
+        void result.then(
+          (value) =>
+            captureOnce(() =>
+              captureResponseBodyFromArrayBuffer(value, contentType),
+            ),
+          () => undefined,
+        );
+        return result;
+      };
+    }
+  } catch {
+    // See text() above.
+  }
+};
+
+const observeResponse = (
   requestId: string,
   sendTime: number,
   response: Response,
 ) => {
+  const responseReceivedAt = Date.now();
+  let contentLength: number | undefined;
+  let contentType = '';
   try {
-    const responseReceivedAt = Date.now();
-    const contentLength = getFetchContentLength(response);
-    const contentType = getFetchContentType(response);
-    const isTextLikeResponse = isTextLikeContentType(contentType);
-
+    contentLength = getFetchContentLength(response);
+    contentType = getFetchContentType(response);
     callbacks?.onResponseReceived?.({
       requestId,
       timestamp: responseReceivedAt,
@@ -97,154 +232,105 @@ const captureExpoFetchResponse = async (
       },
       source: 'expo',
     });
+  } catch {
+    // A non-standard response can throw while exposing metadata. It is still a
+    // successful application fetch, so finish it without a failure event.
+    try {
+      callbacks?.onResponseBody?.(requestId, null);
+    } catch {
+      // Keep observation fail-open.
+    }
+    emitCompleted(requestId, sendTime, responseReceivedAt, null);
+    return;
+  }
 
+  try {
     const clone = response.clone();
-    const reader = clone.body?.getReader();
-    const progressThrottle = createProgressThrottler();
-    const chunks: Uint8Array[] = [];
-    let captureBinaryBody = !isTextLikeResponse;
-    let loaded = 0;
-
-    if (!reader) {
-      const body = await captureFetchResponseBodyFromBytes(
-        new Uint8Array(),
-        contentType,
-      );
-      callbacks?.onResponseBody?.(requestId, body);
-      callbacks?.onRequestCompleted?.({
-        requestId,
-        timestamp: Date.now(),
-        duration: Date.now() - sendTime,
-        size: 0,
-        ttfb: responseReceivedAt - sendTime,
-        source: 'expo',
-      });
-      return;
-    }
-
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) {
-        break;
-      }
-
-      if (!value) {
-        continue;
-      }
-
-      loaded += value.byteLength;
-
-      if (isTextLikeResponse || captureBinaryBody) {
-        chunks.push(value);
-      }
-
-      if (!isTextLikeResponse && captureBinaryBody) {
-        if (loaded > BINARY_CAPTURE_SIZE_CAP) {
-          chunks.length = 0;
-          captureBinaryBody = false;
-        }
-      }
-
-      const timestamp = Date.now();
-      if (progressThrottle(timestamp)) {
-        callbacks?.onRequestProgress?.({
+    void captureCloneBody(requestId, clone, contentType, contentLength).then(
+      (loaded) =>
+        emitCompleted(
           requestId,
-          timestamp,
-          loaded,
-          total: contentLength ?? 0,
-          lengthComputable: contentLength !== undefined && contentLength > 0,
-          source: 'expo',
-        });
-      }
-    }
-
-    const timestamp = Date.now();
-    if (loaded > 0 || contentLength !== undefined) {
-      callbacks?.onRequestProgress?.({
-        requestId,
-        timestamp,
-        loaded,
-        total: contentLength ?? 0,
-        lengthComputable: contentLength !== undefined && contentLength > 0,
-        source: 'expo',
-      });
-    }
-
-    const body: HttpEventMap['response-body']['body'] =
-      captureBinaryBody || isTextLikeResponse
-      ? await captureFetchResponseBodyFromBytes(
-          concatChunks(chunks, loaded),
-          contentType,
-        )
-      : { kind: 'binary-too-large', size: loaded };
-    callbacks?.onResponseBody?.(requestId, body);
-    callbacks?.onRequestCompleted?.({
+          sendTime,
+          responseReceivedAt,
+          contentLength ?? loaded,
+        ),
+      () => {
+        try {
+          callbacks?.onResponseBody?.(requestId, null);
+        } catch {
+          // Keep observation fail-open.
+        }
+        emitCompleted(
+          requestId,
+          sendTime,
+          responseReceivedAt,
+          contentLength ?? null,
+        );
+      },
+    );
+  } catch {
+    // SDK 54–55: complete the request now, and only observe a primitive body
+    // consumer if application code uses one later.
+    decorateConsumedBody(requestId, response, contentType);
+    emitCompleted(
       requestId,
-      timestamp: Date.now(),
-      duration: Date.now() - sendTime,
-      size: loaded,
-      ttfb: responseReceivedAt - sendTime,
-      source: 'expo',
-    });
-  } catch (error) {
-    const canceled =
-      isFetchAbortError(error) ||
-      ((error instanceof Error && error.name === 'AbortError') ?? false);
-    callbacks?.onResponseBody?.(requestId, null);
-    emitRequestFailed(requestId, error, canceled);
+      sendTime,
+      responseReceivedAt,
+      contentLength ?? null,
+    );
   }
 };
 
-const patchExpoFetch = (fetchFn: typeof globalThis.fetch) => {
-  if (!expoFetchModule) {
-    return false;
+const reconcileGlobalFetch = () => {
+  if (!originalExpoFetch || !wrapper) return;
+  if (globalThis.fetch === originalExpoFetch) {
+    originalGlobalFetch ??= originalExpoFetch;
+    globalThis.fetch = wrapper;
+  } else if (globalThis.fetch === wrapper) {
+    // Expo may install a lazy global getter only after the private export was
+    // patched. In that case it resolves directly to our wrapper, but the
+    // restoration target is still Expo's original private implementation.
+    originalGlobalFetch ??= originalExpoFetch;
   }
+};
 
-  if (isInterceptorEnabled) {
-    return true;
-  }
-
-  originalExpoFetch = fetchFn;
-  expoFetchModule.fetch = (async (...args: FetchArgs) => {
+const createWrapper = (fetchFn: typeof globalThis.fetch) =>
+  async function (this: unknown, ...args: FetchArgs) {
     const sendTime = Date.now();
     const requestId = createRequestId();
-    const normalizedRequest = normalizeFetchRequest(args[0], args[1] ?? {});
-    const initiator = getInitiatorFromStack();
-
-    callbacks?.onRequestSent?.({
-      requestId,
-      timestamp: sendTime,
-      request: normalizedRequest,
-      initiator,
-      type: 'Fetch',
-      source: 'expo',
-    });
+    let normalizedRequest: ReturnType<typeof normalizeFetchRequest> | null =
+      null;
+    try {
+      normalizedRequest = normalizeFetchRequest(args[0], args[1] ?? {});
+      callbacks?.onRequestSent?.({
+        requestId,
+        timestamp: sendTime,
+        request: normalizedRequest,
+        initiator: getInitiatorFromStack(),
+        type: 'Fetch',
+        source: 'expo',
+      });
+    } catch {
+      // Request normalization and event delivery are best-effort only.
+    }
 
     try {
-      const response = await fetchFn(...args);
-      void captureExpoFetchResponse(
-        requestId,
-        sendTime,
-        response,
-      );
-
-      // The original response is returned to app code unchanged. The
-      // interceptor works off a clone so it can record the response body
-      // without consuming the app's copy.
+      const response = await fetchFn.apply(this, args);
+      try {
+        observeResponse(requestId, sendTime, response);
+      } catch {
+        // Return the original response even if observation itself fails.
+      }
       return response;
     } catch (error) {
-      const signal = normalizedRequest.signal;
-      const canceled =
-        isFetchAbortError(error) || signal?.aborted === true;
-
-      emitRequestFailed(requestId, error, canceled);
+      emitFailed(
+        requestId,
+        error,
+        isFetchAbortError(error) || normalizedRequest?.signal?.aborted === true,
+      );
       throw error;
     }
-  }) as typeof globalThis.fetch;
-
-  isInterceptorEnabled = true;
-  return true;
-};
+  } as typeof globalThis.fetch;
 
 export const FetchInterceptor = {
   setCallbacks(nextCallbacks: FetchInterceptorCallbacks | null) {
@@ -252,34 +338,48 @@ export const FetchInterceptor = {
   },
 
   isInterceptorEnabled(): boolean {
-    return isInterceptorEnabled;
+    return wrapper !== null;
   },
 
   enableInterception() {
-    if (isInterceptorEnabled) {
-      return;
-    }
-
+    if (wrapper) return;
     expoFetchModule = getExpoFetchModule();
-    if (!expoFetchModule) {
-      return;
-    }
+    if (!expoFetchModule || typeof expoFetchModule.fetch !== 'function') return;
 
-    patchExpoFetch(expoFetchModule.fetch);
+    originalExpoFetch = expoFetchModule.fetch;
+    // Expo SDK 56 can install global fetch lazily. Read it before patching the
+    // private export so a getter that later resolves to our wrapper can still
+    // be restored to Expo's original implementation.
+    try {
+      if (globalThis.fetch === originalExpoFetch) {
+        originalGlobalFetch = originalExpoFetch;
+      }
+    } catch {
+      // A hostile global getter must not prevent Expo interception.
+    }
+    wrapper = createWrapper(originalExpoFetch);
+    expoFetchModule.fetch = wrapper;
+    reconcileGlobalFetch();
+    reconciliationTimer = setTimeout(() => {
+      reconciliationTimer = null;
+      reconcileGlobalFetch();
+    }, 0);
   },
 
   disableInterception() {
-    if (!isInterceptorEnabled) {
-      return;
-    }
-
-    if (expoFetchModule && originalExpoFetch) {
+    if (!wrapper) return;
+    if (reconciliationTimer) clearTimeout(reconciliationTimer);
+    reconciliationTimer = null;
+    if (expoFetchModule?.fetch === wrapper && originalExpoFetch) {
       expoFetchModule.fetch = originalExpoFetch;
     }
-
+    if (globalThis.fetch === wrapper && originalGlobalFetch) {
+      globalThis.fetch = originalGlobalFetch;
+    }
     expoFetchModule = null;
     originalExpoFetch = null;
-    isInterceptorEnabled = false;
+    originalGlobalFetch = null;
+    wrapper = null;
     callbacks = null;
   },
 };

--- a/packages/network-activity-plugin/src/react-native/http/fetch-interceptor.ts
+++ b/packages/network-activity-plugin/src/react-native/http/fetch-interceptor.ts
@@ -1,15 +1,17 @@
 import type { HttpEventMap } from '../../shared/http-events';
 import { getInitiatorFromStack } from './http-utils';
+import { getExpoFetchModule } from './get-expo-fetch-module';
 import {
+  BINARY_CAPTURE_SIZE_CAP,
   captureFetchResponseBodyFromBytes,
   createProgressThrottler,
   getFetchContentLength,
   getFetchContentType,
   getFetchResponseHeaders,
-  isExpoFetchResponse,
   normalizeFetchRequest,
   isFetchAbortError,
 } from './fetch-utils';
+import { isTextLikeContentType } from './response-body-utils';
 
 type FetchInterceptorCallbacks = {
   onRequestSent?: (event: HttpEventMap['request-sent']) => void;
@@ -25,10 +27,14 @@ type FetchInterceptorCallbacks = {
 
 type FetchArgs = Parameters<typeof fetch>;
 
-const originalFetch = globalThis.fetch;
+type ExpoFetchModule = {
+  fetch: typeof globalThis.fetch;
+};
 
 let callbacks: FetchInterceptorCallbacks | null = null;
 let isInterceptorEnabled = false;
+let expoFetchModule: ExpoFetchModule | null = null;
+let originalExpoFetch: typeof globalThis.fetch | null = null;
 
 const createRequestId = () =>
   `req_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`;
@@ -69,22 +75,12 @@ const captureExpoFetchResponse = async (
   requestId: string,
   sendTime: number,
   response: Response,
-  request: ReturnType<typeof normalizeFetchRequest>,
-  initiator: ReturnType<typeof getInitiatorFromStack>,
 ) => {
   try {
     const responseReceivedAt = Date.now();
     const contentLength = getFetchContentLength(response);
     const contentType = getFetchContentType(response);
-
-    callbacks?.onRequestSent?.({
-      requestId,
-      timestamp: sendTime,
-      request,
-      initiator,
-      type: 'Fetch',
-      source: 'expo',
-    });
+    const isTextLikeResponse = isTextLikeContentType(contentType);
 
     callbacks?.onResponseReceived?.({
       requestId,
@@ -106,6 +102,7 @@ const captureExpoFetchResponse = async (
     const reader = clone.body?.getReader();
     const progressThrottle = createProgressThrottler();
     const chunks: Uint8Array[] = [];
+    let captureBinaryBody = !isTextLikeResponse;
     let loaded = 0;
 
     if (!reader) {
@@ -135,8 +132,18 @@ const captureExpoFetchResponse = async (
         continue;
       }
 
-      chunks.push(value);
       loaded += value.byteLength;
+
+      if (isTextLikeResponse || captureBinaryBody) {
+        chunks.push(value);
+      }
+
+      if (!isTextLikeResponse && captureBinaryBody) {
+        if (loaded > BINARY_CAPTURE_SIZE_CAP) {
+          chunks.length = 0;
+          captureBinaryBody = false;
+        }
+      }
 
       const timestamp = Date.now();
       if (progressThrottle(timestamp)) {
@@ -163,8 +170,13 @@ const captureExpoFetchResponse = async (
       });
     }
 
-    const bodyBytes = concatChunks(chunks, loaded);
-    const body = await captureFetchResponseBodyFromBytes(bodyBytes, contentType);
+    const body: HttpEventMap['response-body']['body'] =
+      captureBinaryBody || isTextLikeResponse
+      ? await captureFetchResponseBodyFromBytes(
+          concatChunks(chunks, loaded),
+          contentType,
+        )
+      : { kind: 'binary-too-large', size: loaded };
     callbacks?.onResponseBody?.(requestId, body);
     callbacks?.onRequestCompleted?.({
       requestId,
@@ -183,6 +195,57 @@ const captureExpoFetchResponse = async (
   }
 };
 
+const patchExpoFetch = (fetchFn: typeof globalThis.fetch) => {
+  if (!expoFetchModule) {
+    return false;
+  }
+
+  if (isInterceptorEnabled) {
+    return true;
+  }
+
+  originalExpoFetch = fetchFn;
+  expoFetchModule.fetch = (async (...args: FetchArgs) => {
+    const sendTime = Date.now();
+    const requestId = createRequestId();
+    const normalizedRequest = normalizeFetchRequest(args[0], args[1] ?? {});
+    const initiator = getInitiatorFromStack();
+
+    callbacks?.onRequestSent?.({
+      requestId,
+      timestamp: sendTime,
+      request: normalizedRequest,
+      initiator,
+      type: 'Fetch',
+      source: 'expo',
+    });
+
+    try {
+      const response = await fetchFn(...args);
+      void captureExpoFetchResponse(
+        requestId,
+        sendTime,
+        response,
+      );
+
+      // The original response is returned to app code unchanged. The
+      // interceptor works off a clone so it can record the response body
+      // without consuming the app's copy.
+      return response;
+    } catch (error) {
+      const signal = normalizedRequest.signal;
+      const canceled =
+        isFetchAbortError(error) || signal?.aborted === true;
+
+      emitRequestFailed(requestId, error, canceled);
+      throw error;
+    }
+  }) as typeof globalThis.fetch;
+
+  isInterceptorEnabled = true;
+  return true;
+};
+
 export const FetchInterceptor = {
   setCallbacks(nextCallbacks: FetchInterceptorCallbacks | null) {
     callbacks = nextCallbacks;
@@ -193,59 +256,16 @@ export const FetchInterceptor = {
   },
 
   enableInterception() {
-    if (isInterceptorEnabled || !originalFetch) {
+    if (isInterceptorEnabled) {
       return;
     }
 
-    globalThis.fetch = (async (...args: FetchArgs) => {
-      const sendTime = Date.now();
-      const requestId = createRequestId();
-      const normalizedRequest = normalizeFetchRequest(args[0], args[1] ?? {});
-      const initiator = getInitiatorFromStack();
+    expoFetchModule = getExpoFetchModule();
+    if (!expoFetchModule) {
+      return;
+    }
 
-      try {
-        const response = await originalFetch.apply(globalThis, args);
-
-        if (!isExpoFetchResponse(response)) {
-          return response;
-        }
-
-        void captureExpoFetchResponse(
-          requestId,
-          sendTime,
-          response,
-          normalizedRequest,
-          initiator,
-        );
-
-        // The original response is returned to app code unchanged. The
-        // interceptor works off a clone so it can record the response body
-        // without consuming the app's copy.
-        return response;
-      } catch (error) {
-        const signal = normalizedRequest.signal;
-        const canceled =
-          isFetchAbortError(error) || signal?.aborted === true;
-
-        if (canceled) {
-          callbacks?.onRequestFailed?.({
-            requestId,
-            timestamp: Date.now(),
-            type: 'Fetch',
-            error:
-              error instanceof Error && error.message
-                ? error.message
-                : 'Aborted',
-            canceled: true,
-            source: 'expo',
-          });
-        }
-
-        throw error;
-      }
-    }) as typeof fetch;
-
-    isInterceptorEnabled = true;
+    patchExpoFetch(expoFetchModule.fetch);
   },
 
   disableInterception() {
@@ -253,10 +273,12 @@ export const FetchInterceptor = {
       return;
     }
 
-    if (originalFetch) {
-      globalThis.fetch = originalFetch;
+    if (expoFetchModule && originalExpoFetch) {
+      expoFetchModule.fetch = originalExpoFetch;
     }
 
+    expoFetchModule = null;
+    originalExpoFetch = null;
     isInterceptorEnabled = false;
     callbacks = null;
   },

--- a/packages/network-activity-plugin/src/react-native/http/fetch-utils.ts
+++ b/packages/network-activity-plugin/src/react-native/http/fetch-utils.ts
@@ -1,0 +1,170 @@
+import type {
+  HttpHeaders,
+  HttpMethod,
+  RequestPostData,
+  ResponseBody,
+} from '../../shared/client';
+import { getRequestBody } from './http-utils';
+import { captureResponseBodyFromBytes } from './response-body-utils';
+import { getContentTypeMime } from '../../utils/getContentTypeMimeType';
+export { BINARY_CAPTURE_SIZE_CAP } from './response-body-utils';
+
+export type FetchInput = RequestInfo | URL;
+
+export type NormalizedFetchRequest = {
+  url: string;
+  method: HttpMethod;
+  headers: HttpHeaders;
+  postData: RequestPostData;
+  signal?: AbortSignal;
+};
+
+export const normalizeHeaders = (headers?: HeadersInit): HttpHeaders => {
+  const normalized: HttpHeaders = {};
+
+  if (!headers) {
+    return normalized;
+  }
+
+  const assign = (key: string, value: string) => {
+    const existing = normalized[key];
+
+    if (existing === undefined) {
+      normalized[key] = value;
+      return;
+    }
+
+    normalized[key] = Array.isArray(existing)
+      ? [...existing, value]
+      : [existing, value];
+  };
+
+  if (headers instanceof Headers) {
+    headers.forEach((value, key) => {
+      assign(key, value);
+    });
+    return normalized;
+  }
+
+  if (Array.isArray(headers)) {
+    headers.forEach(([key, value]) => {
+      assign(key, value);
+    });
+    return normalized;
+  }
+
+  Object.entries(headers).forEach(([key, value]) => {
+    if (Array.isArray(value)) {
+      value.forEach((item) => assign(key, item));
+      return;
+    }
+
+    assign(key, value);
+  });
+
+  return normalized;
+};
+
+const normalizeFetchBody = (body?: BodyInit | null): RequestPostData => {
+  if (typeof ReadableStream !== 'undefined' && body instanceof ReadableStream) {
+    return undefined;
+  }
+
+  if (body instanceof URLSearchParams) {
+    return getRequestBody(body.toString());
+  }
+
+  return getRequestBody(body as RequestPostData);
+};
+
+export const normalizeFetchRequest = (
+  input: FetchInput,
+  init: RequestInit = {},
+): NormalizedFetchRequest => {
+  const request = input instanceof Request ? input : null;
+  const headers = {
+    ...normalizeHeaders(request?.headers),
+    ...normalizeHeaders(init.headers),
+  };
+
+  return {
+    url: request?.url ?? input.toString(),
+    method: (init.method ?? request?.method ?? 'GET').toUpperCase() as HttpMethod,
+    headers,
+    postData: normalizeFetchBody(init.body),
+    signal: init.signal ?? request?.signal,
+  };
+};
+
+export const isExpoFetchResponse = (response: Response): boolean => {
+  const body = response.body;
+
+  return (
+    typeof response.clone === 'function' &&
+    body != null &&
+    typeof body.getReader === 'function' &&
+    typeof body.tee === 'function'
+  );
+};
+
+export const getFetchResponseHeaders = (response: Response): HttpHeaders => {
+  return normalizeHeaders(response.headers);
+};
+
+export const getFetchContentType = (response: Response): string => {
+  const contentType = response.headers.get('content-type');
+  return contentType
+    ? getContentTypeMime({ 'content-type': contentType }) ?? ''
+    : '';
+};
+
+export const getFetchContentLength = (
+  response: Response,
+): number | undefined => {
+  const contentLength = response.headers.get('content-length');
+
+  if (!contentLength) {
+    return undefined;
+  }
+
+  const parsed = Number.parseInt(contentLength, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+};
+
+export const createProgressThrottler = (minIntervalMs = 100) => {
+  let lastEmittedAt = 0;
+
+  return (timestamp: number, force = false) => {
+    if (
+      force ||
+      lastEmittedAt === 0 ||
+      timestamp - lastEmittedAt >= minIntervalMs
+    ) {
+      lastEmittedAt = timestamp;
+      return true;
+    }
+
+    return false;
+  };
+};
+
+export const captureFetchResponseBodyFromBytes = async (
+  bytes: Uint8Array,
+  contentType: string,
+): Promise<ResponseBody> => {
+  return captureResponseBodyFromBytes(bytes, contentType);
+};
+
+export const isFetchAbortError = (error: unknown): boolean => {
+  if (typeof error !== 'object' || error === null) {
+    return false;
+  }
+
+  const { name, message } = error as { name?: string; message?: string };
+
+  return (
+    name === 'AbortError' ||
+    name === 'TimeoutError' ||
+    message?.toLowerCase().includes('aborted') === true
+  );
+};

--- a/packages/network-activity-plugin/src/react-native/http/fetch-utils.ts
+++ b/packages/network-activity-plugin/src/react-native/http/fetch-utils.ts
@@ -96,17 +96,6 @@ export const normalizeFetchRequest = (
   };
 };
 
-export const isExpoFetchResponse = (response: Response): boolean => {
-  const body = response.body;
-
-  return (
-    typeof response.clone === 'function' &&
-    body != null &&
-    typeof body.getReader === 'function' &&
-    typeof body.tee === 'function'
-  );
-};
-
 export const getFetchResponseHeaders = (response: Response): HttpHeaders => {
   return normalizeHeaders(response.headers);
 };

--- a/packages/network-activity-plugin/src/react-native/http/fetch-utils.ts
+++ b/packages/network-activity-plugin/src/react-native/http/fetch-utils.ts
@@ -9,7 +9,15 @@ import { captureResponseBodyFromBytes } from './response-body-utils';
 import { getContentTypeMime } from '../../utils/getContentTypeMimeType';
 export { BINARY_CAPTURE_SIZE_CAP } from './response-body-utils';
 
-export type FetchInput = RequestInfo | URL;
+export type FetchInput = RequestInfo | URL | FetchRequestLike;
+
+export type FetchRequestLike = {
+  url?: string;
+  method?: string;
+  headers?: HeadersInit;
+  body?: BodyInit | null;
+  signal?: AbortSignal | null;
+};
 
 export type NormalizedFetchRequest = {
   url: string;
@@ -39,7 +47,7 @@ export const normalizeHeaders = (headers?: HeadersInit): HttpHeaders => {
       : [existing, value];
   };
 
-  if (headers instanceof Headers) {
+  if (typeof Headers !== 'undefined' && headers instanceof Headers) {
     headers.forEach((value, key) => {
       assign(key, value);
     });
@@ -81,18 +89,29 @@ export const normalizeFetchRequest = (
   input: FetchInput,
   init: RequestInit = {},
 ): NormalizedFetchRequest => {
-  const request = input instanceof Request ? input : null;
-  const headers = {
-    ...normalizeHeaders(request?.headers),
-    ...normalizeHeaders(init.headers),
-  };
+  const request =
+    typeof Request !== 'undefined' && input instanceof Request ? input : null;
+  const requestLike =
+    !request && typeof input === 'object' && input !== null
+      ? (input as FetchRequestLike)
+      : null;
+  // Expo follows fetch's `init.headers ?? input.headers` semantics: supplying
+  // init headers replaces inherited headers instead of merging them.
+  const headers = normalizeHeaders(
+    init.headers ?? request?.headers ?? requestLike?.headers,
+  );
 
   return {
-    url: request?.url ?? input.toString(),
-    method: (init.method ?? request?.method ?? 'GET').toUpperCase() as HttpMethod,
+    url: request?.url ?? requestLike?.url ?? input.toString(),
+    method: (
+      init.method ??
+      request?.method ??
+      requestLike?.method ??
+      'GET'
+    ).toUpperCase() as HttpMethod,
     headers,
-    postData: normalizeFetchBody(init.body),
-    signal: init.signal ?? request?.signal,
+    postData: normalizeFetchBody(init.body ?? requestLike?.body),
+    signal: init.signal ?? request?.signal ?? requestLike?.signal ?? undefined,
   };
 };
 
@@ -103,7 +122,7 @@ export const getFetchResponseHeaders = (response: Response): HttpHeaders => {
 export const getFetchContentType = (response: Response): string => {
   const contentType = response.headers.get('content-type');
   return contentType
-    ? getContentTypeMime({ 'content-type': contentType }) ?? ''
+    ? (getContentTypeMime({ 'content-type': contentType }) ?? '')
     : '';
 };
 

--- a/packages/network-activity-plugin/src/react-native/http/get-expo-fetch-module.ts
+++ b/packages/network-activity-plugin/src/react-native/http/get-expo-fetch-module.ts
@@ -4,7 +4,10 @@ type ExpoFetchModule = {
 
 const expoFetchModule = (() => {
   try {
-    return require('expo/fetch') as ExpoFetchModule;
+    // `expo/fetch` is a getter-only public facade. Patching the writable
+    // implementation export keeps normal ESM imports live without trying to
+    // assign through that facade.
+    return require('expo/src/winter/fetch/fetch') as ExpoFetchModule;
   } catch {
     return null;
   }

--- a/packages/network-activity-plugin/src/react-native/http/get-expo-fetch-module.ts
+++ b/packages/network-activity-plugin/src/react-native/http/get-expo-fetch-module.ts
@@ -1,0 +1,15 @@
+type ExpoFetchModule = {
+  fetch: typeof globalThis.fetch;
+};
+
+const expoFetchModule = (() => {
+  try {
+    return require('expo/fetch') as ExpoFetchModule;
+  } catch {
+    return null;
+  }
+})();
+
+export const getExpoFetchModule = (): ExpoFetchModule | null => {
+  return expoFetchModule;
+};

--- a/packages/network-activity-plugin/src/react-native/http/http-inspector.ts
+++ b/packages/network-activity-plugin/src/react-native/http/http-inspector.ts
@@ -52,121 +52,113 @@ export const getHTTPInspector = (): HTTPInspector => {
 
   return {
     enable: () => {
-      if (
-        XHRInterceptor.isInterceptorEnabled() &&
-        FetchInterceptor.isInterceptorEnabled()
-      ) {
-        return;
-      }
+      if (!XHRInterceptor.isInterceptorEnabled()) {
+        XHRInterceptor.setSendCallback((data, request) => {
+          const initiator = getInitiatorFromStack();
+          const sendTime = Date.now();
+          const requestId = `req_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`;
 
-      XHRInterceptor.disableInterception();
-      FetchInterceptor.disableInterception();
+          request._rozeniteRequestId = requestId;
+          networkRequestsRegistry.addEntry(requestId, request);
 
-      XHRInterceptor.setSendCallback((data, request) => {
-        const initiator = getInitiatorFromStack();
-        const sendTime = Date.now();
-        const requestId = `req_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`;
+          let ttfb = 0;
 
-        request._rozeniteRequestId = requestId;
-        networkRequestsRegistry.addEntry(requestId, request);
-
-        let ttfb = 0;
-
-        eventEmitter.emit('request-sent', {
-          requestId: requestId,
-          timestamp: sendTime,
-          request: {
-            url: request._url as string,
-            method: request._method as HttpMethod,
-            headers: request._headers,
-            postData: getRequestBody(data),
-          },
-          type: 'XHR',
-          initiator,
-          source: 'builtin',
-        });
-
-        request.addEventListener('readystatechange', () => {
-          if (request.readyState === READY_STATE_HEADERS_RECEIVED) {
-            ttfb = Date.now() - sendTime;
-          }
-        });
-
-        request.addEventListener('progress', (event) => {
-          eventEmitter.emit('request-progress', {
+          eventEmitter.emit('request-sent', {
             requestId: requestId,
-            timestamp: Date.now(),
-            loaded: event.loaded,
-            total: event.total,
-            lengthComputable: event.lengthComputable,
-            source: 'builtin',
-          });
-        });
-
-        request.addEventListener('load', () => {
-          eventEmitter.emit('response-received', {
-            requestId: requestId,
-            timestamp: Date.now(),
-            type: 'XHR',
-            response: {
+            timestamp: sendTime,
+            request: {
               url: request._url as string,
-              status: request.status,
-              statusText: request.statusText,
-              headers: applyReactNativeResponseHeadersLogic(
-                request.responseHeaders || {},
-              ),
-              contentType: getContentType(request),
-              size: getResponseSize(request),
-              responseTime: Date.now(),
+              method: request._method as HttpMethod,
+              headers: request._headers,
+              postData: getRequestBody(data),
             },
-            source: 'builtin',
-          });
-        });
-
-        request.addEventListener('loadend', () => {
-          eventEmitter.emit('request-completed', {
-            requestId: requestId,
-            timestamp: Date.now(),
-            duration: Date.now() - sendTime,
-            size: getResponseSize(request),
-            ttfb,
-            source: 'builtin',
-          });
-        });
-
-        request.addEventListener('error', () => {
-          eventEmitter.emit('request-failed', {
-            requestId: requestId,
-            timestamp: Date.now(),
             type: 'XHR',
-            error: 'Failed',
-            canceled: false,
+            initiator,
             source: 'builtin',
           });
-        });
 
-        request.addEventListener('abort', () => {
-          eventEmitter.emit('request-failed', {
-            requestId: requestId,
-            timestamp: Date.now(),
-            type: 'XHR',
-            error: 'Aborted',
-            canceled: true,
-            source: 'builtin',
+          request.addEventListener('readystatechange', () => {
+            if (request.readyState === READY_STATE_HEADERS_RECEIVED) {
+              ttfb = Date.now() - sendTime;
+            }
           });
-        });
 
-        request.addEventListener('timeout', () => {
-          eventEmitter.emit('request-failed', {
-            requestId: requestId,
-            timestamp: Date.now(),
-            type: 'XHR',
-            error: 'Timeout',
-            canceled: false,
-            source: 'builtin',
+          request.addEventListener('progress', (event) => {
+            eventEmitter.emit('request-progress', {
+              requestId: requestId,
+              timestamp: Date.now(),
+              loaded: event.loaded,
+              total: event.total,
+              lengthComputable: event.lengthComputable,
+              source: 'builtin',
+            });
+          });
+
+          request.addEventListener('load', () => {
+            eventEmitter.emit('response-received', {
+              requestId: requestId,
+              timestamp: Date.now(),
+              type: 'XHR',
+              response: {
+                url: request._url as string,
+                status: request.status,
+                statusText: request.statusText,
+                headers: applyReactNativeResponseHeadersLogic(
+                  request.responseHeaders || {},
+                ),
+                contentType: getContentType(request),
+                size: getResponseSize(request),
+                responseTime: Date.now(),
+              },
+              source: 'builtin',
+            });
+          });
+
+          request.addEventListener('loadend', () => {
+            eventEmitter.emit('request-completed', {
+              requestId: requestId,
+              timestamp: Date.now(),
+              duration: Date.now() - sendTime,
+              size: getResponseSize(request),
+              ttfb,
+              source: 'builtin',
+            });
+          });
+
+          request.addEventListener('error', () => {
+            eventEmitter.emit('request-failed', {
+              requestId: requestId,
+              timestamp: Date.now(),
+              type: 'XHR',
+              error: 'Failed',
+              canceled: false,
+              source: 'builtin',
+            });
+          });
+
+          request.addEventListener('abort', () => {
+            eventEmitter.emit('request-failed', {
+              requestId: requestId,
+              timestamp: Date.now(),
+              type: 'XHR',
+              error: 'Aborted',
+              canceled: true,
+              source: 'builtin',
+            });
+          });
+
+          request.addEventListener('timeout', () => {
+            eventEmitter.emit('request-failed', {
+              requestId: requestId,
+              timestamp: Date.now(),
+              type: 'XHR',
+              error: 'Timeout',
+              canceled: false,
+              source: 'builtin',
+            });
           });
         });
-      });
+      }
 
       FetchInterceptor.setCallbacks({
         onRequestSent: (event) => {
@@ -189,8 +181,12 @@ export const getHTTPInspector = (): HTTPInspector => {
         },
       });
 
-      XHRInterceptor.enableInterception();
-      FetchInterceptor.enableInterception();
+      if (!XHRInterceptor.isInterceptorEnabled()) {
+        XHRInterceptor.enableInterception();
+      }
+      if (!FetchInterceptor.isInterceptorEnabled()) {
+        FetchInterceptor.enableInterception();
+      }
     },
 
     disable: () => {

--- a/packages/network-activity-plugin/src/react-native/http/http-inspector.ts
+++ b/packages/network-activity-plugin/src/react-native/http/http-inspector.ts
@@ -1,6 +1,7 @@
 import { createNanoEvents } from 'nanoevents';
 import { getNetworkRequestsRegistry } from './network-requests-registry';
 import { XHRInterceptor } from './xhr-interceptor';
+import { FetchInterceptor } from './fetch-interceptor';
 import {
   getRequestBody,
   getResponseSize,
@@ -51,9 +52,15 @@ export const getHTTPInspector = (): HTTPInspector => {
 
   return {
     enable: () => {
-      if (XHRInterceptor.isInterceptorEnabled()) return;
+      if (
+        XHRInterceptor.isInterceptorEnabled() &&
+        FetchInterceptor.isInterceptorEnabled()
+      ) {
+        return;
+      }
 
       XHRInterceptor.disableInterception();
+      FetchInterceptor.disableInterception();
 
       XHRInterceptor.setSendCallback((data, request) => {
         const initiator = getInitiatorFromStack();
@@ -161,19 +168,46 @@ export const getHTTPInspector = (): HTTPInspector => {
         });
       });
 
+      FetchInterceptor.setCallbacks({
+        onRequestSent: (event) => {
+          eventEmitter.emit('request-sent', event);
+        },
+        onResponseReceived: (event) => {
+          eventEmitter.emit('response-received', event);
+        },
+        onRequestCompleted: (event) => {
+          eventEmitter.emit('request-completed', event);
+        },
+        onRequestFailed: (event) => {
+          eventEmitter.emit('request-failed', event);
+        },
+        onRequestProgress: (event) => {
+          eventEmitter.emit('request-progress', event);
+        },
+        onResponseBody: (requestId, body) => {
+          networkRequestsRegistry.setResponseBody(requestId, body);
+        },
+      });
+
       XHRInterceptor.enableInterception();
+      FetchInterceptor.enableInterception();
     },
 
     disable: () => {
       XHRInterceptor.disableInterception();
+      FetchInterceptor.disableInterception();
     },
 
     isEnabled: () => {
-      return XHRInterceptor.isInterceptorEnabled();
+      return (
+        XHRInterceptor.isInterceptorEnabled() ||
+        FetchInterceptor.isInterceptorEnabled()
+      );
     },
 
     dispose: () => {
       XHRInterceptor.disableInterception();
+      FetchInterceptor.disableInterception();
       networkRequestsRegistry.clear();
     },
 

--- a/packages/network-activity-plugin/src/react-native/http/http-utils.ts
+++ b/packages/network-activity-plugin/src/react-native/http/http-utils.ts
@@ -11,19 +11,22 @@ import type {
 import { safeStringify } from '../../utils/safeStringify';
 import { getStringSizeInBytes } from '../../utils/getStringSizeInBytes';
 import {
-  isJsonContentType,
-  isXmlContentType,
-} from '../../utils/getContentTypeMimeType';
-import {
   isBlob,
   isArrayBuffer,
   isFormData,
   isNullOrUndefined,
 } from '../../utils/typeChecks';
 import { getContentType } from '../utils';
+import { isJsonContentType } from '../../utils/getContentTypeMimeType';
 import { getBlobName } from '../utils/getBlobName';
 import { getFormDataEntries } from '../utils/getFormDataEntries';
 import type { OverridesRegistry } from './overrides-registry';
+import {
+  captureResponseBodyFromArrayBuffer,
+  captureResponseBodyFromBlob,
+} from './response-body-utils';
+
+export { BINARY_CAPTURE_SIZE_CAP } from './response-body-utils';
 
 /**
  * Utility functions for tracking HTTP requests
@@ -120,45 +123,6 @@ export const getResponseSize = (request: XMLHttpRequest): number | null => {
   }
 };
 
-// Cap on binary capture. Above this, we ship a 'binary-too-large' variant
-// with just the size — no bytes cross the bridge. 5MB comfortably covers
-// debug-relevant images while keeping the bridge from choking on outliers.
-export const BINARY_CAPTURE_SIZE_CAP = 5 * 1024 * 1024;
-
-const readBlobAsText = (blob: Blob): Promise<string> =>
-  new Promise((resolve) => {
-    const reader = new FileReader();
-    reader.onload = () => resolve(reader.result as string);
-    reader.readAsText(blob);
-  });
-
-const readBlobAsBase64 = (blob: Blob): Promise<string> =>
-  new Promise((resolve) => {
-    const reader = new FileReader();
-    reader.onload = () => {
-      // FileReader.readAsDataURL returns "data:<mime>;base64,<payload>".
-      // We only want the base64 payload.
-      const dataUrl = reader.result as string;
-      resolve(dataUrl.substring(dataUrl.indexOf(',') + 1));
-    };
-    reader.readAsDataURL(blob);
-  });
-
-// String.fromCharCode.apply(null, hugeArray) blows up around 64K elements
-// in some engines; chunk through 32K windows so we work uniformly across
-// large arraybuffer responses.
-const ARRAY_BUFFER_BASE64_CHUNK = 0x8000;
-
-const arrayBufferToBase64 = (buffer: ArrayBuffer): string => {
-  const bytes = new Uint8Array(buffer);
-  let binary = '';
-  for (let i = 0; i < bytes.length; i += ARRAY_BUFFER_BASE64_CHUNK) {
-    const chunk = bytes.subarray(i, i + ARRAY_BUFFER_BASE64_CHUNK);
-    binary += String.fromCharCode.apply(null, chunk as unknown as number[]);
-  }
-  return btoa(binary);
-};
-
 export const getResponseBody = async (
   request: XMLHttpRequest,
 ): Promise<ResponseBody> => {
@@ -171,38 +135,11 @@ export const getResponseBody = async (
 
   if (responseType === 'blob') {
     const contentType = request.getResponseHeader('Content-Type') || '';
-
-    // Text-shaped content stays on the text path so the panel can
-    // show source in the Raw view without base64 round-tripping. XML
-    // composite types (application/xml, atom+xml, soap+xml, ...) and
-    // image/svg+xml are all covered by isXmlContentType per RFC 7303.
-    if (
-      contentType.startsWith('text/') ||
-      isJsonContentType(contentType) ||
-      isXmlContentType(contentType)
-    ) {
-      return readBlobAsText(request.response);
-    }
-
-    // Everything else is binary — image/*, application/pdf, audio/*,
-    // video/*, font/*, application/octet-stream, anything novel a
-    // server might serve.
-    const blob = request.response as Blob;
-    if (blob.size > BINARY_CAPTURE_SIZE_CAP) {
-      return { kind: 'binary-too-large', size: blob.size };
-    }
-    return { kind: 'binary', base64: await readBlobAsBase64(blob) };
+    return captureResponseBodyFromBlob(request.response as Blob, contentType);
   }
 
   if (responseType === 'arraybuffer') {
-    const buffer = request.response as ArrayBuffer | null;
-    if (!buffer || buffer.byteLength === 0) {
-      return null;
-    }
-    if (buffer.byteLength > BINARY_CAPTURE_SIZE_CAP) {
-      return { kind: 'binary-too-large', size: buffer.byteLength };
-    }
-    return { kind: 'binary', base64: arrayBufferToBase64(buffer) };
+    return captureResponseBodyFromArrayBuffer(request.response as ArrayBuffer | null);
   }
 
   if (responseType === 'json') {

--- a/packages/network-activity-plugin/src/react-native/http/network-requests-registry.ts
+++ b/packages/network-activity-plugin/src/react-native/http/network-requests-registry.ts
@@ -1,12 +1,17 @@
+import type { ResponseBody } from '../../shared/client';
+
 type NetworkRegistryEntry = {
   id: string;
   sentAt: number;
-  request: XMLHttpRequest;
+  request?: XMLHttpRequest;
+  responseBody?: ResponseBody;
 };
 
 export type NetworkRequestRegistry = {
   addEntry: (id: string, request: XMLHttpRequest) => void;
   getEntry: (id: string) => XMLHttpRequest | null;
+  setResponseBody: (id: string, body: ResponseBody) => void;
+  getResponseBody: (id: string) => ResponseBody | undefined;
   clear: () => void;
 };
 
@@ -29,15 +34,34 @@ export const getNetworkRequestsRegistry = (): NetworkRequestRegistry => {
 
   const addEntry = (id: string, request: XMLHttpRequest): void => {
     trimRegistry();
+    const existing = registry.get(id);
+
     registry.set(id, {
       id,
       request,
-      sentAt: Date.now(),
+      responseBody: existing?.responseBody,
+      sentAt: existing?.sentAt ?? Date.now(),
     });
   };
 
   const getEntry = (id: string): XMLHttpRequest | null => {
     return registry.get(id)?.request ?? null;
+  };
+
+  const setResponseBody = (id: string, body: ResponseBody): void => {
+    trimRegistry();
+    const existing = registry.get(id);
+
+    registry.set(id, {
+      id,
+      request: existing?.request,
+      responseBody: body,
+      sentAt: existing?.sentAt ?? Date.now(),
+    });
+  };
+
+  const getResponseBody = (id: string): ResponseBody | undefined => {
+    return registry.get(id)?.responseBody;
   };
 
   const clear = () => {
@@ -47,6 +71,8 @@ export const getNetworkRequestsRegistry = (): NetworkRequestRegistry => {
   return {
     addEntry,
     getEntry,
+    setResponseBody,
+    getResponseBody,
     clear,
   };
 };

--- a/packages/network-activity-plugin/src/react-native/http/response-body-utils.ts
+++ b/packages/network-activity-plugin/src/react-native/http/response-body-utils.ts
@@ -22,7 +22,7 @@ export const bytesToBase64 = (bytes: Uint8Array): string => {
   return btoa(binary);
 };
 
-const isTextLikeContentType = (contentType?: string | null) => {
+export const isTextLikeContentType = (contentType?: string | null) => {
   if (!contentType) {
     return false;
   }

--- a/packages/network-activity-plugin/src/react-native/http/response-body-utils.ts
+++ b/packages/network-activity-plugin/src/react-native/http/response-body-utils.ts
@@ -1,0 +1,88 @@
+import type { ResponseBody } from '../../shared/client';
+import {
+  isJsonContentType,
+  isXmlContentType,
+} from '../../utils/getContentTypeMimeType';
+
+// Cap on binary capture. Above this, we ship a `binary-too-large` variant
+// with just the size — no bytes cross the bridge. 5MB comfortably covers
+// debug-relevant images while keeping the bridge from choking on outliers.
+export const BINARY_CAPTURE_SIZE_CAP = 5 * 1024 * 1024;
+
+const ARRAY_BUFFER_BASE64_CHUNK = 0x8000;
+
+export const bytesToBase64 = (bytes: Uint8Array): string => {
+  let binary = '';
+
+  for (let i = 0; i < bytes.length; i += ARRAY_BUFFER_BASE64_CHUNK) {
+    const chunk = bytes.subarray(i, i + ARRAY_BUFFER_BASE64_CHUNK);
+    binary += String.fromCharCode.apply(null, chunk as unknown as number[]);
+  }
+
+  return btoa(binary);
+};
+
+const isTextLikeContentType = (contentType?: string | null) => {
+  if (!contentType) {
+    return false;
+  }
+
+  return (
+    contentType.startsWith('text/') ||
+    isJsonContentType(contentType) ||
+    isXmlContentType(contentType)
+  );
+};
+
+export const captureResponseBodyFromBytes = (
+  bytes: Uint8Array,
+  contentType?: string | null,
+): ResponseBody => {
+  if (isTextLikeContentType(contentType)) {
+    return new TextDecoder().decode(bytes);
+  }
+
+  if (bytes.byteLength > BINARY_CAPTURE_SIZE_CAP) {
+    return { kind: 'binary-too-large', size: bytes.byteLength };
+  }
+
+  return { kind: 'binary', base64: bytesToBase64(bytes) };
+};
+
+export const captureResponseBodyFromArrayBuffer = async (
+  buffer: ArrayBuffer | null,
+  contentType?: string | null,
+): Promise<ResponseBody> => {
+  if (!buffer || buffer.byteLength === 0) {
+    return null;
+  }
+
+  if (buffer.byteLength > BINARY_CAPTURE_SIZE_CAP) {
+    return { kind: 'binary-too-large', size: buffer.byteLength };
+  }
+
+  return captureResponseBodyFromBytes(new Uint8Array(buffer), contentType);
+};
+
+const readBlobAsArrayBuffer = (blob: Blob): Promise<ArrayBuffer> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as ArrayBuffer);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsArrayBuffer(blob);
+  });
+
+export const captureResponseBodyFromBlob = async (
+  blob: Blob,
+  contentType?: string | null,
+): Promise<ResponseBody> => {
+  if (blob.size > BINARY_CAPTURE_SIZE_CAP) {
+    return { kind: 'binary-too-large', size: blob.size };
+  }
+
+  const buffer =
+    typeof blob.arrayBuffer === 'function'
+      ? await blob.arrayBuffer()
+      : await readBlobAsArrayBuffer(blob);
+  return captureResponseBodyFromBytes(new Uint8Array(buffer), contentType);
+};

--- a/packages/network-activity-plugin/src/react-native/network-inspector.ts
+++ b/packages/network-activity-plugin/src/react-native/network-inspector.ts
@@ -98,6 +98,12 @@ const createNetworkInspectorInstance = (): NetworkInspector => {
         return getHTTPResponseBody(request);
       }
 
+      const capturedResponseBody =
+        http.getNetworkRequestsRegistry().getResponseBody(requestId);
+      if (capturedResponseBody !== undefined) {
+        return capturedResponseBody;
+      }
+
       return nitro.getResponseBody(requestId);
     },
   };

--- a/packages/network-activity-plugin/src/shared/http-events.ts
+++ b/packages/network-activity-plugin/src/shared/http-events.ts
@@ -16,7 +16,7 @@ export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'HEAD';
 
 export type RequestId = string;
 export type Timestamp = number;
-export type NetworkEventSource = 'builtin' | 'nitro';
+export type NetworkEventSource = 'builtin' | 'nitro' | 'expo';
 
 export type XHRPostData =
   | string

--- a/packages/network-activity-plugin/src/ui/components/FilterBar.tsx
+++ b/packages/network-activity-plugin/src/ui/components/FilterBar.tsx
@@ -39,7 +39,7 @@ const HTTP_METHODS: HttpMethod[] = [
   'DELETE',
   'HEAD',
 ];
-const SOURCES: NetworkEventSource[] = ['builtin', 'nitro'];
+const SOURCES: NetworkEventSource[] = ['builtin', 'expo', 'nitro'];
 
 const getTypeLabel = (type: RequestTypeFilter) => {
   switch (type) {
@@ -56,6 +56,8 @@ const getSourceLabel = (source: NetworkEventSource) => {
   switch (source) {
     case 'builtin':
       return 'Built-in';
+    case 'expo':
+      return 'Expo';
     case 'nitro':
       return 'Nitro';
   }

--- a/packages/network-activity-plugin/src/ui/components/RequestList.tsx
+++ b/packages/network-activity-plugin/src/ui/components/RequestList.tsx
@@ -51,6 +51,10 @@ const getSourceLabel = (source?: NetworkEventSource) => {
     return 'Built-in';
   }
 
+  if (source === 'expo') {
+    return 'Expo';
+  }
+
   return null;
 };
 

--- a/packages/network-activity-plugin/src/ui/components/SidePanel.tsx
+++ b/packages/network-activity-plugin/src/ui/components/SidePanel.tsx
@@ -142,7 +142,8 @@ export const SidePanel = () => {
   }
 
   const override = legacyEntry !== null ? overrides.get(legacyEntry.url) : null;
-  const supportsOverrides = httpDetails?.source !== 'nitro';
+  const supportsOverrides =
+    httpDetails?.source !== 'nitro' && httpDetails?.source !== 'expo';
   const hasResponseOverride =
     !!(supportsOverrides && override && override.body);
 

--- a/packages/network-activity-plugin/src/ui/tabs/HeadersTab.tsx
+++ b/packages/network-activity-plugin/src/ui/tabs/HeadersTab.tsx
@@ -32,6 +32,8 @@ export const HeadersTab = ({ selectedRequest }: HeadersTabProps) => {
   const sourceLabel =
     selectedRequest.source === 'nitro'
       ? 'Nitro'
+      : selectedRequest.source === 'expo'
+        ? 'Expo'
       : selectedRequest.source === 'builtin'
         ? 'Built-in'
         : null;

--- a/packages/network-activity-plugin/vite.config.ts
+++ b/packages/network-activity-plugin/vite.config.ts
@@ -35,6 +35,10 @@ export default defineConfig({
             return 'get-nitro-module';
           }
 
+          if (id.includes('get-expo-fetch-module.ts')) {
+            return 'get-expo-fetch-module';
+          }
+
           return undefined;
         },
       },


### PR DESCRIPTION
## Description

Add Expo SDK 54+ fetch traffic to Network Activity. Explicit `expo/fetch` calls are captured across the supported range, and Expo SDK 56's default global fetch alias is captured through the same interceptor. Expo requests include request and response metadata, available bodies, failures, cancellation state, and an Expo source label in the existing Network Activity UI.

## Related Issue

Closes #295.

## Context

The public `expo/fetch` entry exposes a getter-only re-export, so the interceptor resolves and patches Expo's writable private fetch implementation instead. The optional resolver is isolated in its own build chunk so React Native applications without Expo retain the existing XHR behavior.

SDK 56 responses use clone-based body capture. SDK 54–55 responses, where cloning is unsupported, capture common bodies when application code consumes `text()` or `arrayBuffer()`; unconsumed and directly streamed bodies remain unavailable. The wrapper preserves original response and rejection identity, restores private and global fetch aliases safely, and leaves XHR and Nitro interception independent.

## Testing

- `pnpm --filter @rozenite/network-activity-plugin test` — 197 tests passed
- `pnpm --filter @rozenite/network-activity-plugin typecheck`
- `pnpm --filter @rozenite/network-activity-plugin lint`
- `pnpm --filter @rozenite/network-activity-plugin build`
- `pnpm release:plan`
- `git diff --check`
- Inspected the build output: the private Expo require is isolated in `dist/react-native/chunks/get-expo-fetch-module.{js,cjs}`, and the main React Native entry contains no Expo import or require.
- Manual Expo SDK 54/56 device smoke tests and a bare React Native Metro smoke test remain to be performed.
