### PR TITLE
docs(plugin-directory): add @avasapp/rozenite-plugin-ably

### DIFF
--- a/plugin-directory.json
+++ b/plugin-directory.json
@@ -82,5 +82,9 @@
   {
     "npmUrl": "https://www.npmjs.com/package/rozenite-navigation-inspector",
     "githubUrl": "https://github.com/IronTony/rozenite-navigation-inspector"
+  },
+  {
+    "npmUrl": "https://www.npmjs.com/package/@avasapp/rozenite-plugin-ably",
+    "githubUrl": "https://github.com/avas-app/rozenite-plugin-ably"
   }
 ]


### PR DESCRIPTION
## Description

Adds a community Rozenite plugin to the plugin directory:

- **[@avasapp/rozenite-plugin-ably](https://www.npmjs.com/package/@avasapp/rozenite-plugin-ably)** — an [Ably](https://ably.com) Realtime inspector: attached channels with their subscriber counts and error reasons, a filterable event stream, and a payload viewer that parses Ably's JSON-string payloads into a searchable tree.

The Network Activity panel already shows websocket frames; this answers the Ably-shaped questions instead — which channels are attached right now, which ones silently went `suspended`, which feature subscribed to a given channel, and what was actually inside a message.

Appended to `plugin-directory.json` with the standard `npmUrl` + `githubUrl` fields. The package is published on npm and the repository is public.

## Related Issue

N/A — follows the documented "open a pull request to contribute your plugin" flow for the plugin directory, as in #291.

## Context

Docs-only. One entry appended to `plugin-directory.json`; no packages, workflows, or website code touched, so no version plan is required.

Implementation notes that may be of interest, since they lean on Rozenite internals:

- The plugin instruments any `Ably.Realtime` client structurally, so it has **no `ably` dependency** and works against whatever ably-js version the host app has.
- It never wraps the app's own message listeners — content is observed through a separate passive subscription, so a bug in the plugin cannot stop the app receiving a message — and the passive subscription is installed lazily, only once the app has itself subscribed, so it never causes an attach the app did not ask for.
- Optional protocol-frame capture uses `client.setLog({ level: 4 })`, which is present at runtime but absent from ably-js's public typings, so it is feature-detected and off by default.

## Testing

- `@avasapp/rozenite-plugin-ably@0.1.0` installs from npm and is discovered by Rozenite 1.13 (`[Rozenite] Loaded 1 plugin(s)`).
- Verified end-to-end on an iOS 26.5 simulator via a bundled example app that drives a fake Ably client through the real hook and bridge, and separately in a production React Native monorepo across three apps.
- Both URLs in the new entry resolve, and `plugin-directory.json` still parses (22 entries).