### PR TITLE
fix(agent): auto-heal sessions after app relaunch

### DIFF
--- a/.changeset/agent-session-auto-heal.md
+++ b/.changeset/agent-session-auto-heal.md
@@ -1,0 +1,6 @@
+---
+'@rozenite/middleware': patch
+'rozenite': patch
+---
+
+Agent sessions now automatically recover after an app relaunch while keeping their session ID and restoring tools. If a relaunch interrupts profiling or recording, Rozenite reports the lost data instead of returning a misleading empty result.

--- a/packages/agent-shared/src/index.ts
+++ b/packages/agent-shared/src/index.ts
@@ -118,6 +118,12 @@ export const defineAgentToolDescriptors = <
 
 export type AgentSessionStatus = 'connecting' | 'connected' | 'stopped';
 
+export type AgentSessionHealingOutcome = {
+  outcome: 'recovered' | 'failed' | 'blocked';
+  message: string;
+  at: number;
+};
+
 export type MetroTarget = {
   id: string;
   name: string;
@@ -148,6 +154,7 @@ export type AgentSessionInfo = {
   lastActivityAt: number;
   connectedAt?: number;
   lastError?: string;
+  healing?: AgentSessionHealingOutcome;
   toolCount: number;
 };
 

--- a/packages/middleware/src/__tests__/agent-session-manager.test.ts
+++ b/packages/middleware/src/__tests__/agent-session-manager.test.ts
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => {
   const getInfo = vi.fn();
   const getTools = vi.fn();
   const callTool = vi.fn();
+  const isReusable = vi.fn(() => true);
   const createAgentSession = vi.fn(() => ({
     id: 'device-1',
     start,
@@ -26,6 +27,7 @@ const mocks = vi.hoisted(() => {
     getInfo,
     getTools,
     callTool,
+    isReusable,
   }));
 
   return {
@@ -36,6 +38,7 @@ const mocks = vi.hoisted(() => {
     getInfo,
     getTools,
     callTool,
+    isReusable,
     createAgentSession,
   };
 });
@@ -54,6 +57,7 @@ describe('agent session manager', () => {
     vi.clearAllMocks();
     mocks.start.mockReset();
     mocks.start.mockResolvedValue(undefined);
+    mocks.isReusable.mockReturnValue(true);
   });
 
   const target = {
@@ -123,6 +127,36 @@ describe('agent session manager', () => {
 
     expect(mocks.createAgentSession).toHaveBeenCalledTimes(1);
     expect(mocks.start).toHaveBeenCalledTimes(1);
+  });
+
+  it('recreates a stale session whose Metro page changed', async () => {
+    mocks.resolveMetroTarget.mockResolvedValue(target);
+    mocks.getInfo.mockReturnValue({ id: 'device-1', deviceName: 'Phone' });
+    mocks.isReusable.mockReturnValue(false);
+    const manager = createAgentSessionManager({ projectRoot: '/app' });
+
+    await manager.createSession({ deviceId: 'device-1' });
+    await manager.createSession({ deviceId: 'device-1' });
+
+    expect(mocks.stop).toHaveBeenCalledTimes(1);
+    expect(mocks.createAgentSession).toHaveBeenCalledTimes(2);
+  });
+
+  it('creates a new session when Metro assigns a relaunched app a new device id', async () => {
+    const replacementTarget = { ...target, id: 'device-2', pageId: 'page-2' };
+    mocks.resolveMetroTarget
+      .mockResolvedValueOnce(target)
+      .mockResolvedValueOnce(replacementTarget);
+    mocks.getInfo.mockReturnValue({ id: 'device-1', deviceName: 'Phone' });
+    const manager = createAgentSessionManager({ projectRoot: '/app' });
+
+    await manager.createSession({ deviceId: 'device-1' });
+    await manager.createSession({ deviceId: 'device-2' });
+
+    expect(mocks.createAgentSession).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ target: replacementTarget }),
+    );
   });
 
   it('passes CLI and Metro versions into a new session', async () => {

--- a/packages/middleware/src/__tests__/agent-session.test.ts
+++ b/packages/middleware/src/__tests__/agent-session.test.ts
@@ -290,6 +290,11 @@ const startSession = async (
   const started = createStartedSession(overrides);
   started.socket.open();
   await vi.advanceTimersByTimeAsync(500);
+  await emitRozeniteBindingPayload(started.socket, {
+    pluginId: '@rozenite/test-plugin',
+    type: 'register-tool',
+    payload: {},
+  });
   await vi.advanceTimersByTimeAsync(50);
   await flushMicrotasks();
   await started.startPromise;
@@ -385,10 +390,15 @@ describe('agent session', () => {
     await flushMicrotasks();
     expect(onResolved).not.toHaveBeenCalled();
 
-    await vi.advanceTimersByTimeAsync(1);
+    await vi.advanceTimersByTimeAsync(50);
     await flushMicrotasks();
     expect(onResolved).not.toHaveBeenCalled();
 
+    await emitRozeniteBindingPayload(socket, {
+      pluginId: '@rozenite/test-plugin',
+      type: 'register-tool',
+      payload: {},
+    });
     await vi.advanceTimersByTimeAsync(50);
     await flushMicrotasks();
     await startPromise;
@@ -399,7 +409,7 @@ describe('agent session', () => {
   it('resolves start after bootstrap and plugin readiness settles', async () => {
     const { startPromise, socket } = createStartedSession();
     const onResolved = vi.fn();
-    startPromise.then(onResolved);
+    startPromise.then(onResolved, () => undefined);
 
     socket.open();
     await vi.advanceTimersByTimeAsync(500);
@@ -411,7 +421,12 @@ describe('agent session', () => {
     await flushMicrotasks();
     expect(onResolved).not.toHaveBeenCalled();
 
-    await vi.advanceTimersByTimeAsync(1);
+    await emitRozeniteBindingPayload(socket, {
+      pluginId: '@rozenite/test-plugin',
+      type: 'register-tool',
+      payload: {},
+    });
+    await vi.advanceTimersByTimeAsync(50);
     await flushMicrotasks();
 
     expect(onResolved).toHaveBeenCalledTimes(1);
@@ -428,7 +443,7 @@ describe('agent session', () => {
   it('extends plugin readiness wait when activity arrives', async () => {
     const { startPromise, socket } = createStartedSession();
     const onResolved = vi.fn();
-    startPromise.then(onResolved);
+    startPromise.then(onResolved, () => undefined);
 
     socket.open();
     await vi.advanceTimersByTimeAsync(500);
@@ -438,7 +453,7 @@ describe('agent session', () => {
 
     await emitRozeniteBindingPayload(socket, {
       pluginId: '@rozenite/storage-plugin',
-      type: 'plugin-mounted',
+      type: 'register-tool',
       payload: {
         pluginId: '@rozenite/storage-plugin',
       },
@@ -455,10 +470,11 @@ describe('agent session', () => {
     await expect(startPromise).resolves.toBeUndefined();
   });
 
-  it('resolves start after the bounded plugin readiness timeout', async () => {
+  it('fails start when plugin readiness never arrives', async () => {
     const { startPromise, socket } = createStartedSession();
+    void startPromise.catch(() => undefined);
     const onResolved = vi.fn();
-    startPromise.then(onResolved);
+    startPromise.then(onResolved, () => undefined);
 
     socket.open();
     await vi.advanceTimersByTimeAsync(500);
@@ -479,7 +495,9 @@ describe('agent session', () => {
 
     await vi.advanceTimersByTimeAsync(5);
     await flushMicrotasks();
-    await expect(startPromise).resolves.toBeUndefined();
+    await expect(startPromise).rejects.toThrow(
+      'Plugin tools did not re-register',
+    );
   });
 
   it('emits agent-session-ready after rozenite domain initialization', async () => {
@@ -546,7 +564,13 @@ describe('agent session', () => {
 
     const replacementSocket = mocks.wsInstances[1];
     replacementSocket.open();
-    await vi.advanceTimersByTimeAsync(550);
+    await vi.advanceTimersByTimeAsync(500);
+    await emitRozeniteBindingPayload(replacementSocket, {
+      pluginId: '@rozenite/test-plugin',
+      type: 'register-tool',
+      payload: {},
+    });
+    await vi.advanceTimersByTimeAsync(50);
     await flushMicrotasks();
 
     expect(session.getInfo()).toMatchObject({
@@ -557,6 +581,28 @@ describe('agent session', () => {
     });
     expect(mocks.handler.disconnectDevice).toHaveBeenCalledWith('device-1');
     expect(mocks.handler.connectDevice).toHaveBeenCalledTimes(2);
+  });
+
+  it('heals PAGE_NOT_FOUND before the initial socket opens', async () => {
+    const replacementTarget = createTarget({ pageId: 'page-2' });
+    const { startPromise, socket } = createStartedSession({
+      resolveTarget: vi.fn().mockResolvedValue(replacementTarget),
+    });
+    void startPromise.catch(() => undefined);
+
+    socket.emit('close', 1000, Buffer.from('[PAGE_NOT_FOUND]'));
+    await flushMicrotasks();
+    const replacementSocket = mocks.wsInstances[1];
+    replacementSocket.open();
+    await vi.advanceTimersByTimeAsync(500);
+    await emitRozeniteBindingPayload(replacementSocket, {
+      pluginId: '@rozenite/test-plugin',
+      type: 'register-tool',
+      payload: {},
+    });
+    await vi.advanceTimersByTimeAsync(50);
+
+    await expect(startPromise).resolves.toBeUndefined();
   });
 
   it('does not reconnect when React Native DevTools takes the connection', async () => {
@@ -578,8 +624,29 @@ describe('agent session', () => {
     });
   });
 
+  it('cancels recovery when the session is stopped', async () => {
+    let resolveTarget: ((target: MetroTarget) => void) | undefined;
+    const targetPromise = new Promise<MetroTarget>((resolve) => {
+      resolveTarget = resolve;
+    });
+    const { session, socket } = await startSession({
+      resolveTarget: vi.fn().mockReturnValue(targetPromise),
+    });
+
+    socket.emit('close', 1000, Buffer.from('[CONNECTION_LOST]'));
+    await flushMicrotasks();
+    await session.stop();
+    resolveTarget?.(createTarget({ pageId: 'page-2' }));
+    await flushMicrotasks();
+
+    expect(session.getInfo().status).toBe('stopped');
+    expect(mocks.wsInstances).toHaveLength(1);
+  });
+
   it('surfaces profiling state lost during a healed relaunch', async () => {
-    const resolveTarget = vi.fn().mockResolvedValue(createTarget({ pageId: 'page-2' }));
+    const resolveTarget = vi
+      .fn()
+      .mockResolvedValue(createTarget({ pageId: 'page-2' }));
     const { session, socket } = await startSession({ resolveTarget });
     await session.callTool('startProfiling', {});
 
@@ -587,7 +654,13 @@ describe('agent session', () => {
     await flushMicrotasks();
     const replacementSocket = mocks.wsInstances[1];
     replacementSocket.open();
-    await vi.advanceTimersByTimeAsync(550);
+    await vi.advanceTimersByTimeAsync(500);
+    await emitRozeniteBindingPayload(replacementSocket, {
+      pluginId: '@rozenite/test-plugin',
+      type: 'register-tool',
+      payload: {},
+    });
+    await vi.advanceTimersByTimeAsync(50);
     await flushMicrotasks();
 
     await expect(session.callTool('stopProfiling', {})).rejects.toThrow(

--- a/packages/middleware/src/__tests__/agent-session.test.ts
+++ b/packages/middleware/src/__tests__/agent-session.test.ts
@@ -390,16 +390,7 @@ describe('agent session', () => {
     await flushMicrotasks();
     expect(onResolved).not.toHaveBeenCalled();
 
-    await vi.advanceTimersByTimeAsync(50);
-    await flushMicrotasks();
-    expect(onResolved).not.toHaveBeenCalled();
-
-    await emitRozeniteBindingPayload(socket, {
-      pluginId: '@rozenite/test-plugin',
-      type: 'register-tool',
-      payload: {},
-    });
-    await vi.advanceTimersByTimeAsync(50);
+    await vi.advanceTimersByTimeAsync(1);
     await flushMicrotasks();
     await startPromise;
 
@@ -415,18 +406,6 @@ describe('agent session', () => {
     await vi.advanceTimersByTimeAsync(500);
     await flushMicrotasks();
 
-    expect(onResolved).not.toHaveBeenCalled();
-
-    await vi.advanceTimersByTimeAsync(49);
-    await flushMicrotasks();
-    expect(onResolved).not.toHaveBeenCalled();
-
-    await emitRozeniteBindingPayload(socket, {
-      pluginId: '@rozenite/test-plugin',
-      type: 'register-tool',
-      payload: {},
-    });
-    await vi.advanceTimersByTimeAsync(50);
     await flushMicrotasks();
 
     expect(onResolved).toHaveBeenCalledTimes(1);
@@ -459,45 +438,20 @@ describe('agent session', () => {
       },
     });
 
-    expect(onResolved).not.toHaveBeenCalled();
-
-    await vi.advanceTimersByTimeAsync(49);
-    await flushMicrotasks();
-    expect(onResolved).not.toHaveBeenCalled();
-
-    await vi.advanceTimersByTimeAsync(1);
-    await flushMicrotasks();
     await expect(startPromise).resolves.toBeUndefined();
   });
 
-  it('fails start when plugin readiness never arrives', async () => {
+  it('starts built-in-only sessions without plugin registration', async () => {
     const { startPromise, socket } = createStartedSession();
-    void startPromise.catch(() => undefined);
     const onResolved = vi.fn();
-    startPromise.then(onResolved, () => undefined);
+    startPromise.then(onResolved);
 
     socket.open();
     await vi.advanceTimersByTimeAsync(500);
     await flushMicrotasks();
 
-    for (let elapsed = 0; elapsed < 245; elapsed += 49) {
-      await vi.advanceTimersByTimeAsync(49);
-      await flushMicrotasks();
-      await emitRozeniteBindingPayload(socket, {
-        pluginId: '@rozenite/storage-plugin',
-        type: 'plugin-mounted',
-        payload: {
-          pluginId: '@rozenite/storage-plugin',
-        },
-      });
-      expect(onResolved).not.toHaveBeenCalled();
-    }
-
-    await vi.advanceTimersByTimeAsync(5);
-    await flushMicrotasks();
-    await expect(startPromise).rejects.toThrow(
-      'Plugin tools did not re-register',
-    );
+    await expect(startPromise).resolves.toBeUndefined();
+    expect(onResolved).toHaveBeenCalledTimes(1);
   });
 
   it('emits agent-session-ready after rozenite domain initialization', async () => {

--- a/packages/middleware/src/__tests__/agent-session.test.ts
+++ b/packages/middleware/src/__tests__/agent-session.test.ts
@@ -25,6 +25,7 @@ const mocks = vi.hoisted(() => {
     handleDeviceMessage: vi.fn(),
     captureConsoleMessage: vi.fn(),
     getTools: vi.fn(() => []),
+    getRegisteredPluginTools: vi.fn(() => []),
     callTool: vi.fn(),
   };
   const services: MockService[] = Array.from({ length: 4 }, () => ({
@@ -188,6 +189,7 @@ const mocks = vi.hoisted(() => {
       handler.handleDeviceMessage.mockReset();
       handler.captureConsoleMessage.mockReset();
       handler.getTools.mockClear();
+      handler.getRegisteredPluginTools.mockClear();
       handler.callTool.mockReset();
       services.forEach((service) => {
         service.getTools.mockClear();

--- a/packages/middleware/src/__tests__/agent-session.test.ts
+++ b/packages/middleware/src/__tests__/agent-session.test.ts
@@ -263,6 +263,7 @@ const createStartedSession = (
     cliVersion: string;
     metroVersion: string;
     target: MetroTarget;
+    resolveTarget: (deviceId: string) => Promise<MetroTarget>;
   }>,
 ) => {
   const session = createAgentSession({
@@ -283,6 +284,7 @@ const startSession = async (
   overrides?: Partial<{
     cliVersion: string;
     metroVersion: string;
+    resolveTarget: (deviceId: string) => Promise<MetroTarget>;
   }>,
 ) => {
   const started = createStartedSession(overrides);
@@ -526,6 +528,71 @@ describe('agent session', () => {
     );
 
     expect(readyExpressions).toHaveLength(2);
+  });
+
+  it('heals a relaunched app with the same device id and a new page id', async () => {
+    const replacementTarget = createTarget({
+      pageId: 'page-2',
+      webSocketDebuggerUrl: 'ws://localhost:8081/debug?page=2',
+    });
+    const resolveTarget = vi.fn().mockResolvedValue(replacementTarget);
+    const { session, socket } = await startSession({ resolveTarget });
+
+    socket.emit('close', 1000, Buffer.from('[RECREATING_DEVICE]'));
+    await flushMicrotasks();
+
+    expect(session.getInfo()).toMatchObject({ status: 'connecting' });
+    expect(resolveTarget).toHaveBeenCalledWith('device-1');
+
+    const replacementSocket = mocks.wsInstances[1];
+    replacementSocket.open();
+    await vi.advanceTimersByTimeAsync(550);
+    await flushMicrotasks();
+
+    expect(session.getInfo()).toMatchObject({
+      id: 'device-1',
+      pageId: 'page-2',
+      status: 'connected',
+      healing: { outcome: 'recovered' },
+    });
+    expect(mocks.handler.disconnectDevice).toHaveBeenCalledWith('device-1');
+    expect(mocks.handler.connectDevice).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not reconnect when React Native DevTools takes the connection', async () => {
+    const resolveTarget = vi.fn();
+    const { session, socket } = await startSession({ resolveTarget });
+
+    socket.emit('close', 1000, Buffer.from('[NEW_DEBUGGER_OPENED]'));
+    await flushMicrotasks();
+
+    expect(resolveTarget).not.toHaveBeenCalled();
+    expect(mocks.wsInstances).toHaveLength(1);
+    expect(session.getInfo()).toMatchObject({
+      status: 'stopped',
+      healing: {
+        outcome: 'blocked',
+        message:
+          'React Native DevTools took the connection — close it and retry.',
+      },
+    });
+  });
+
+  it('surfaces profiling state lost during a healed relaunch', async () => {
+    const resolveTarget = vi.fn().mockResolvedValue(createTarget({ pageId: 'page-2' }));
+    const { session, socket } = await startSession({ resolveTarget });
+    await session.callTool('startProfiling', {});
+
+    socket.emit('close', 1000, Buffer.from('[CONNECTION_LOST]'));
+    await flushMicrotasks();
+    const replacementSocket = mocks.wsInstances[1];
+    replacementSocket.open();
+    await vi.advanceTimersByTimeAsync(550);
+    await flushMicrotasks();
+
+    await expect(session.callTool('stopProfiling', {})).rejects.toThrow(
+      'AGENT_SESSION_STATE_LOST: profiling data was lost',
+    );
   });
 
   it('logs when the agent session websocket connects', async () => {

--- a/packages/middleware/src/agent/runtime/handler.ts
+++ b/packages/middleware/src/agent/runtime/handler.ts
@@ -262,6 +262,10 @@ export const createAgentMessageHandler = () => {
     return [...registry.getAggregatedTools(), ...getConsoleTools()];
   };
 
+  const getRegisteredPluginTools = (deviceId: string): AgentTool[] => {
+    return registry.getToolsForDevice(deviceId);
+  };
+
   const getDevices = () => {
     return registry.getDevices();
   };
@@ -352,6 +356,7 @@ export const createAgentMessageHandler = () => {
     disconnectDevice,
     handleDeviceMessage,
     getTools,
+    getRegisteredPluginTools,
     getDevices,
     callTool,
     captureConsoleMessage: (deviceId: string, message: ConsoleMessageInput) => {

--- a/packages/middleware/src/agent/session-manager.ts
+++ b/packages/middleware/src/agent/session-manager.ts
@@ -89,7 +89,12 @@ export const createAgentSessionManager = (options: {
         resolveMetroTarget(currentHost, currentPort, deviceId),
       onTerminated: (sessionId) => {
         const current = sessions.get(sessionId);
-        if (current === session && session.getInfo().healing) {
+        if (
+          current === session &&
+          ['blocked', 'failed'].includes(
+            session.getInfo().healing?.outcome ?? '',
+          )
+        ) {
           // Keep terminal recovery information visible to `session show` and
           // `session list`; an explicit stop or a replacement target removes it.
           return;

--- a/packages/middleware/src/agent/session-manager.ts
+++ b/packages/middleware/src/agent/session-manager.ts
@@ -89,6 +89,11 @@ export const createAgentSessionManager = (options: {
         resolveMetroTarget(currentHost, currentPort, deviceId),
       onTerminated: (sessionId) => {
         const current = sessions.get(sessionId);
+        if (current === session && session.getInfo().healing) {
+          // Keep terminal recovery information visible to `session show` and
+          // `session list`; an explicit stop or a replacement target removes it.
+          return;
+        }
         if (current === session) {
           sessions.delete(sessionId);
         }

--- a/packages/middleware/src/agent/session-manager.ts
+++ b/packages/middleware/src/agent/session-manager.ts
@@ -65,10 +65,17 @@ export const createAgentSessionManager = (options: {
     );
     const existing = sessions.get(target.id);
     if (existing) {
-      return {
-        session: existing.getInfo(),
-        versionCheck,
-      };
+      if (existing.isReusable(target)) {
+        return {
+          session: existing.getInfo(),
+          versionCheck,
+        };
+      }
+
+      // A logical device id survives most reloads, while Metro gives the app a
+      // new page id. Never hand a caller a session pinned to that old page.
+      sessions.delete(target.id);
+      await existing.stop();
     }
 
     const session = createAgentSession({
@@ -78,6 +85,8 @@ export const createAgentSessionManager = (options: {
       target,
       cliVersion: request.cliVersion,
       metroVersion,
+      resolveTarget: (deviceId) =>
+        resolveMetroTarget(currentHost, currentPort, deviceId),
       onTerminated: (sessionId) => {
         const current = sessions.get(sessionId);
         if (current === session) {

--- a/packages/middleware/src/agent/session.ts
+++ b/packages/middleware/src/agent/session.ts
@@ -131,6 +131,7 @@ export const createAgentSession = (options: {
   let socketAttempt = 0;
   let activeSocketAttempt = 0;
   let expectedPluginToolNames = new Set<string>();
+  let pluginReadinessSatisfied = false;
   let healing: AgentSessionInfo['healing'];
   const activeAccumulatedDomains = new Map<string, string>();
   const lostAccumulatedDomains = new Map<string, string>();
@@ -242,7 +243,10 @@ export const createAgentSession = (options: {
     }
 
     pluginReadiness.quietTimer = setTimeout(() => {
-      resolveStartReadiness();
+      pluginReadinessSatisfied = true;
+      if (bootstrapped) {
+        resolveStartReadiness();
+      }
     }, PLUGIN_READINESS_QUIET_WINDOW_MS);
   };
 
@@ -252,8 +256,9 @@ export const createAgentSession = (options: {
     }
 
     clearPluginReadiness();
+    pluginReadinessSatisfied = false;
     if (expectedPluginToolNames.size === 0) {
-      resolveStartReadiness();
+      pluginReadinessSatisfied = true;
       return;
     }
     pluginReadiness = {
@@ -518,13 +523,17 @@ export const createAgentSession = (options: {
       await sendCommand('Runtime.evaluate', {
         expression: `void ${RUNTIME_GLOBAL}.initializeDomain("rozenite")`,
       });
-      bootstrapped = true;
       // Arm before notifying the plugin: registration may be synchronous.
       beginPluginReadinessWait();
       await sendAgentSessionReady();
       await sendCommand('Runtime.evaluate', {
         expression: `void ${RUNTIME_GLOBAL}.initializeDomain("react-devtools")`,
       });
+
+      bootstrapped = true;
+      if (pluginReadinessSatisfied) {
+        resolveStartReadiness();
+      }
 
       lastError = undefined;
       touch();
@@ -655,6 +664,9 @@ export const createAgentSession = (options: {
       new Error('CDP connection closed before bootstrap completed'),
     );
 
+    const previousPluginToolNames = new Set(
+      handler.getTools(options.target.id).map((tool) => tool.name),
+    );
     handler.disconnectDevice(options.target.id);
 
     for (const service of localServices) {
@@ -691,9 +703,7 @@ export const createAgentSession = (options: {
       (candidate) => reason.includes(candidate),
     );
     if (recoveryReason) {
-      expectedPluginToolNames = new Set(
-        handler.getTools(options.target.id).map((tool) => tool.name),
-      );
+      expectedPluginToolNames = previousPluginToolNames;
       rememberLostAccumulatedState();
       recoveryPromise ??= recover(recoveryReason, generation);
       return;

--- a/packages/middleware/src/agent/session.ts
+++ b/packages/middleware/src/agent/session.ts
@@ -127,6 +127,7 @@ export const createAgentSession = (options: {
   let startReadiness: StartReadiness | null = null;
   let pluginReadiness: PluginReadiness | null = null;
   let recoveryPromise: Promise<void> | null = null;
+  let connectionGeneration = 0;
   let healing: AgentSessionInfo['healing'];
   const activeAccumulatedDomains = new Map<string, string>();
   const lostAccumulatedDomains = new Map<string, string>();
@@ -218,6 +219,9 @@ export const createAgentSession = (options: {
   };
 
   const resolveStartReadiness = (): void => {
+    if (!stopped && bootstrapped) {
+      status = 'connected';
+    }
     startReadiness?.resolve();
   };
 
@@ -248,10 +252,13 @@ export const createAgentSession = (options: {
     pluginReadiness = {
       quietTimer: null,
       timeoutTimer: setTimeout(() => {
-        resolveStartReadiness();
+        rejectStartReadiness(
+          new Error(
+            'Plugin tools did not re-register after the agent session became ready',
+          ),
+        );
       }, PLUGIN_READINESS_MAX_WAIT_MS),
     };
-    schedulePluginReadinessQuietTimer();
   };
 
   const notePluginReadinessActivity = (): void => {
@@ -261,6 +268,9 @@ export const createAgentSession = (options: {
 
     schedulePluginReadinessQuietTimer();
   };
+
+  const isCurrentGeneration = (generation: number): boolean =>
+    !stopped && generation === connectionGeneration;
 
   const emitCDPEvent = (
     method: string,
@@ -518,15 +528,24 @@ export const createAgentSession = (options: {
     activeAccumulatedDomains.clear();
   };
 
-  const waitForRecoveryTarget = async (): Promise<MetroTarget> => {
+  const waitForRecoveryTarget = async (
+    generation: number,
+  ): Promise<MetroTarget> => {
     if (!options.resolveTarget) {
       throw new Error('This session cannot resolve a fresh Metro target');
     }
 
     let lastRecoveryError: unknown;
     for (let attempt = 1; attempt <= RECOVERY_MAX_ATTEMPTS; attempt += 1) {
+      if (!isCurrentGeneration(generation)) {
+        throw new Error('Agent session recovery was cancelled');
+      }
       try {
-        return await options.resolveTarget(options.target.id);
+        const resolvedTarget = await options.resolveTarget(options.target.id);
+        if (!isCurrentGeneration(generation)) {
+          throw new Error('Agent session recovery was cancelled');
+        }
+        return resolvedTarget;
       } catch (error) {
         lastRecoveryError = error;
         if (attempt < RECOVERY_MAX_ATTEMPTS) {
@@ -542,7 +561,7 @@ export const createAgentSession = (options: {
       : new Error('The app did not reconnect to Metro');
   };
 
-  const recover = async (reason: string): Promise<void> => {
+  const recover = async (reason: string, generation: number): Promise<void> => {
     status = 'connecting';
     try {
       // Metro can still be publishing the replacement page when it first
@@ -553,15 +572,21 @@ export const createAgentSession = (options: {
       let lastConnectError: unknown;
       for (let attempt = 1; attempt <= 2 && !connected; attempt += 1) {
         try {
-          target = await waitForRecoveryTarget();
+          target = await waitForRecoveryTarget(generation);
           const readinessPromise = createStartReadiness();
           void readinessPromise.catch(() => undefined);
-          await connect();
+          await connect(generation);
           await readinessPromise;
+          if (!isCurrentGeneration(generation)) {
+            throw new Error('Agent session recovery was cancelled');
+          }
           connected = true;
         } catch (error) {
           lastConnectError = error;
-          if (stopped || attempt === 2) {
+          if (!isCurrentGeneration(generation)) {
+            return;
+          }
+          if (attempt === 2) {
             throw error;
           }
           await new Promise<void>((resolve) => {
@@ -572,12 +597,21 @@ export const createAgentSession = (options: {
       if (!connected) {
         throw lastConnectError;
       }
+      if (!isCurrentGeneration(generation)) {
+        return;
+      }
       healing = {
         outcome: 'recovered',
-        message: `Reconnected after ${reason}. Accumulated state from the previous app instance was lost.`,
+        message:
+          lostAccumulatedDomains.size > 0
+            ? `Reconnected after ${reason}. Accumulated state was lost for: ${Array.from(lostAccumulatedDomains.values()).join(', ')}.`
+            : `Reconnected after ${reason}.`,
         at: Date.now(),
       };
     } catch (error) {
+      if (!isCurrentGeneration(generation)) {
+        return;
+      }
       const message = error instanceof Error ? error.message : String(error);
       lastError = message;
       healing = { outcome: 'failed', message, at: Date.now() };
@@ -586,11 +620,16 @@ export const createAgentSession = (options: {
       await disposeServices();
       notifyTerminated();
     } finally {
-      recoveryPromise = null;
+      if (generation === connectionGeneration) {
+        recoveryPromise = null;
+      }
     }
   };
 
-  const handleSocketClosed = (reason: string): void => {
+  const handleSocketClosed = (reason: string, generation: number): void => {
+    if (generation !== connectionGeneration) {
+      return;
+    }
     logDisconnected();
     bindingName = null;
     bootstrapped = false;
@@ -636,7 +675,7 @@ export const createAgentSession = (options: {
       (candidate) => reason.includes(candidate),
     );
     if (recoveryReason) {
-      recoveryPromise ??= recover(recoveryReason);
+      recoveryPromise ??= recover(recoveryReason, generation);
       return;
     }
 
@@ -726,10 +765,7 @@ export const createAgentSession = (options: {
       }
 
       const devToolsMessage = bindingPayload.message as DevToolsPluginMessage;
-      if (
-        devToolsMessage.type === 'plugin-mounted' ||
-        devToolsMessage.type === 'register-tool'
-      ) {
+      if (devToolsMessage.type === 'register-tool') {
         notePluginReadinessActivity();
       }
 
@@ -743,23 +779,25 @@ export const createAgentSession = (options: {
     }
   };
 
-  const connect = async (): Promise<void> => {
+  const connect = async (generation = connectionGeneration): Promise<void> => {
     status = 'connecting';
 
     await new Promise<void>((resolve, reject) => {
       const socket = new WebSocket(target.webSocketDebuggerUrl, {
         headers: {
-          Origin: getDebuggerWebSocketOrigin(
-            target.webSocketDebuggerUrl,
-          ),
+          Origin: getDebuggerWebSocketOrigin(target.webSocketDebuggerUrl),
         },
       });
       let settled = false;
       ws = socket;
 
       socket.once('open', () => {
+        if (!isCurrentGeneration(generation)) {
+          socket.close();
+          return;
+        }
         settled = true;
-        status = 'connected';
+        status = 'connecting';
         connectedAt = Date.now();
         lastError = undefined;
         touch();
@@ -794,10 +832,16 @@ export const createAgentSession = (options: {
       });
 
       socket.on('message', (rawMessage: unknown) => {
+        if (generation !== connectionGeneration) {
+          return;
+        }
         handleSocketMessage(String(rawMessage));
       });
 
       socket.once('error', (error: unknown) => {
+        if (generation !== connectionGeneration) {
+          return;
+        }
         lastError = error instanceof Error ? error.message : String(error);
         if (!settled) {
           reject(error);
@@ -808,7 +852,7 @@ export const createAgentSession = (options: {
         if (ws === socket) {
           ws = null;
         }
-        handleSocketClosed(getCloseReason(reason));
+        handleSocketClosed(getCloseReason(reason), generation);
         if (!settled) {
           reject(
             new Error('CDP websocket closed before session initialization'),
@@ -847,6 +891,14 @@ export const createAgentSession = (options: {
     args: unknown,
   ): Promise<unknown> => {
     if (status !== 'connected') {
+      const recovery = recoveryPromise;
+      if (
+        recovery &&
+        ['getTree', 'getMessages', 'listRequests'].includes(toolName)
+      ) {
+        await recovery;
+        return await callTool(toolName, args);
+      }
       throw new Error(
         `Session "${options.target.id}" is not connected to a device`,
       );
@@ -862,24 +914,52 @@ export const createAgentSession = (options: {
 
     touch();
 
-    if (toolName === 'startProfiling') {
-      activeAccumulatedDomains.set('stopProfiling', 'profiling data');
-    }
-    if (toolName === 'startRecording') {
-      activeAccumulatedDomains.set('stopRecording', 'network recording');
-    }
-
-    for (const service of localServices) {
-      const result = await service.callTool(toolName, args);
-      if (result !== undefined) {
-        if (toolName === 'stopProfiling' || toolName === 'stopRecording') {
-          activeAccumulatedDomains.delete(toolName);
-        }
-        return result;
+    const trackSuccessfulToolCall = (): void => {
+      const startedBy = new Map([
+        ['startProfiling', ['stopProfiling', 'profiling data']],
+        ['startRecording', ['stopRecording', 'network recording']],
+        ['startTrace', ['stopTrace', 'performance trace']],
+        ['startSampling', ['stopSampling', 'memory sampling']],
+      ]);
+      const started = startedBy.get(toolName);
+      if (started) {
+        activeAccumulatedDomains.set(started[0], started[1]);
       }
-    }
+      if (
+        [
+          'stopProfiling',
+          'stopRecording',
+          'stopTrace',
+          'stopSampling',
+        ].includes(toolName)
+      ) {
+        activeAccumulatedDomains.delete(toolName);
+      }
+    };
 
-    return await handler.callTool(toolName, args);
+    try {
+      for (const service of localServices) {
+        const result = await service.callTool(toolName, args);
+        if (result !== undefined) {
+          trackSuccessfulToolCall();
+          return result;
+        }
+      }
+
+      const result = await handler.callTool(toolName, args);
+      trackSuccessfulToolCall();
+      return result;
+    } catch (error) {
+      const recovery = recoveryPromise;
+      if (
+        recovery &&
+        ['getTree', 'getMessages', 'listRequests'].includes(toolName)
+      ) {
+        await recovery;
+        return await callTool(toolName, args);
+      }
+      throw error;
+    }
   };
 
   const start = async (): Promise<void> => {
@@ -889,6 +969,16 @@ export const createAgentSession = (options: {
     try {
       await connect();
     } catch (error) {
+      // A stale page can be rejected before the websocket ever opens. The
+      // close handler has already started recovery in that case, so make the
+      // initial create request observe that healing attempt instead of making
+      // the manager tear the session down.
+      if (recoveryPromise) {
+        await recoveryPromise;
+        if (status === 'connected') {
+          return;
+        }
+      }
       rejectStartReadiness(
         error instanceof Error ? error : new Error(String(error)),
       );
@@ -905,6 +995,7 @@ export const createAgentSession = (options: {
     }
 
     stopped = true;
+    connectionGeneration += 1;
     recoveryPromise = null;
     clearBootstrapTimer();
     clearPluginReadiness();

--- a/packages/middleware/src/agent/session.ts
+++ b/packages/middleware/src/agent/session.ts
@@ -589,6 +589,25 @@ export const createAgentSession = (options: {
       : new Error('The app did not reconnect to Metro');
   };
 
+  const teardownConnection = (): void => {
+    bindingName = null;
+    bootstrapped = false;
+    connectedAt = undefined;
+    rejectStartReadiness(
+      new Error('CDP connection closed before bootstrap completed'),
+    );
+    handler.disconnectDevice(options.target.id);
+    for (const service of localServices) {
+      service.onDisconnected();
+    }
+    for (const [commandId, pending] of pendingCommands.entries()) {
+      pendingCommands.delete(commandId);
+      pending.reject(new Error('CDP connection closed'));
+    }
+    clearBootstrapTimer();
+    clearPluginReadiness();
+  };
+
   const recover = async (reason: string, generation: number): Promise<void> => {
     status = 'connecting';
     try {
@@ -616,6 +635,7 @@ export const createAgentSession = (options: {
           }
           const failedSocket = ws;
           if (failedSocket && failedSocket.readyState !== WebSocket.CLOSED) {
+            teardownConnection();
             activeSocketAttempt += 1;
             ws = null;
             await new Promise<void>((resolve) => {

--- a/packages/middleware/src/agent/session.ts
+++ b/packages/middleware/src/agent/session.ts
@@ -128,6 +128,9 @@ export const createAgentSession = (options: {
   let pluginReadiness: PluginReadiness | null = null;
   let recoveryPromise: Promise<void> | null = null;
   let connectionGeneration = 0;
+  let socketAttempt = 0;
+  let activeSocketAttempt = 0;
+  let expectedPluginToolNames = new Set<string>();
   let healing: AgentSessionInfo['healing'];
   const activeAccumulatedDomains = new Map<string, string>();
   const lostAccumulatedDomains = new Map<string, string>();
@@ -249,6 +252,10 @@ export const createAgentSession = (options: {
     }
 
     clearPluginReadiness();
+    if (expectedPluginToolNames.size === 0) {
+      resolveStartReadiness();
+      return;
+    }
     pluginReadiness = {
       quietTimer: null,
       timeoutTimer: setTimeout(() => {
@@ -266,7 +273,16 @@ export const createAgentSession = (options: {
       return;
     }
 
-    schedulePluginReadinessQuietTimer();
+    const registeredToolNames = new Set(
+      handler.getTools(options.target.id).map((tool) => tool.name),
+    );
+    if (
+      Array.from(expectedPluginToolNames).every((name) =>
+        registeredToolNames.has(name),
+      )
+    ) {
+      schedulePluginReadinessQuietTimer();
+    }
   };
 
   const isCurrentGeneration = (generation: number): boolean =>
@@ -502,15 +518,16 @@ export const createAgentSession = (options: {
       await sendCommand('Runtime.evaluate', {
         expression: `void ${RUNTIME_GLOBAL}.initializeDomain("rozenite")`,
       });
+      bootstrapped = true;
+      // Arm before notifying the plugin: registration may be synchronous.
+      beginPluginReadinessWait();
       await sendAgentSessionReady();
       await sendCommand('Runtime.evaluate', {
         expression: `void ${RUNTIME_GLOBAL}.initializeDomain("react-devtools")`,
       });
 
-      bootstrapped = true;
       lastError = undefined;
       touch();
-      beginPluginReadinessWait();
     } catch (error) {
       lastError = error instanceof Error ? error.message : String(error);
       scheduleBootstrap();
@@ -657,7 +674,6 @@ export const createAgentSession = (options: {
       return;
     }
 
-    rememberLostAccumulatedState();
     if (reason.includes(DEVTOOLS_TOOK_CONNECTION_REASON)) {
       status = 'stopped';
       stopped = true;
@@ -675,6 +691,10 @@ export const createAgentSession = (options: {
       (candidate) => reason.includes(candidate),
     );
     if (recoveryReason) {
+      expectedPluginToolNames = new Set(
+        handler.getTools(options.target.id).map((tool) => tool.name),
+      );
+      rememberLostAccumulatedState();
       recoveryPromise ??= recover(recoveryReason, generation);
       return;
     }
@@ -739,15 +759,7 @@ export const createAgentSession = (options: {
 
     const consoleMessage = extractConsoleMessage(message);
     if (consoleMessage) {
-      activeAccumulatedDomains.set('getMessages', 'console messages');
       handler.captureConsoleMessage(options.target.id, consoleMessage);
-    }
-
-    if (
-      typeof message.method === 'string' &&
-      message.method.startsWith('Network.')
-    ) {
-      activeAccumulatedDomains.set('listRequests', 'network recording');
     }
 
     const bindingPayload = parseRozeniteBindingPayload(message);
@@ -765,11 +777,10 @@ export const createAgentSession = (options: {
       }
 
       const devToolsMessage = bindingPayload.message as DevToolsPluginMessage;
+      handler.handleDeviceMessage(options.target.id, devToolsMessage);
       if (devToolsMessage.type === 'register-tool') {
         notePluginReadinessActivity();
       }
-
-      handler.handleDeviceMessage(options.target.id, devToolsMessage);
     } else if (bindingPayload.domain === 'react-devtools') {
       for (const service of localServices) {
         if (service.captureReactDevToolsMessage) {
@@ -789,10 +800,16 @@ export const createAgentSession = (options: {
         },
       });
       let settled = false;
+      const attempt = ++socketAttempt;
+      activeSocketAttempt = attempt;
       ws = socket;
 
       socket.once('open', () => {
-        if (!isCurrentGeneration(generation)) {
+        if (
+          !isCurrentGeneration(generation) ||
+          ws !== socket ||
+          activeSocketAttempt !== attempt
+        ) {
           socket.close();
           return;
         }
@@ -825,21 +842,29 @@ export const createAgentSession = (options: {
             lastError = startupError.message;
             clearBootstrapTimer();
             rejectStartReadiness(startupError);
-            ws?.close();
+            socket.close();
             reject(startupError);
           }
         })();
       });
 
       socket.on('message', (rawMessage: unknown) => {
-        if (generation !== connectionGeneration) {
+        if (
+          generation !== connectionGeneration ||
+          ws !== socket ||
+          activeSocketAttempt !== attempt
+        ) {
           return;
         }
         handleSocketMessage(String(rawMessage));
       });
 
       socket.once('error', (error: unknown) => {
-        if (generation !== connectionGeneration) {
+        if (
+          generation !== connectionGeneration ||
+          ws !== socket ||
+          activeSocketAttempt !== attempt
+        ) {
           return;
         }
         lastError = error instanceof Error ? error.message : String(error);
@@ -849,9 +874,8 @@ export const createAgentSession = (options: {
       });
 
       socket.once('close', (_code: unknown, reason: unknown) => {
-        if (ws === socket) {
-          ws = null;
-        }
+        if (ws !== socket || activeSocketAttempt !== attempt) return;
+        ws = null;
         handleSocketClosed(getCloseReason(reason), generation);
         if (!settled) {
           reject(

--- a/packages/middleware/src/agent/session.ts
+++ b/packages/middleware/src/agent/session.ts
@@ -279,7 +279,9 @@ export const createAgentSession = (options: {
     }
 
     const registeredToolNames = new Set(
-      handler.getTools(options.target.id).map((tool) => tool.name),
+      handler
+        .getRegisteredPluginTools(options.target.id)
+        .map((tool) => tool.name),
     );
     if (
       Array.from(expectedPluginToolNames).every((name) =>
@@ -612,6 +614,19 @@ export const createAgentSession = (options: {
           if (!isCurrentGeneration(generation)) {
             return;
           }
+          const failedSocket = ws;
+          if (failedSocket && failedSocket.readyState !== WebSocket.CLOSED) {
+            activeSocketAttempt += 1;
+            ws = null;
+            await new Promise<void>((resolve) => {
+              const timeout = setTimeout(resolve, 250);
+              failedSocket.once('close', () => {
+                clearTimeout(timeout);
+                resolve();
+              });
+              failedSocket.close();
+            });
+          }
           if (attempt === 2) {
             throw error;
           }
@@ -665,7 +680,9 @@ export const createAgentSession = (options: {
     );
 
     const previousPluginToolNames = new Set(
-      handler.getTools(options.target.id).map((tool) => tool.name),
+      handler
+        .getRegisteredPluginTools(options.target.id)
+        .map((tool) => tool.name),
     );
     handler.disconnectDevice(options.target.id);
 

--- a/packages/middleware/src/agent/session.ts
+++ b/packages/middleware/src/agent/session.ts
@@ -29,6 +29,18 @@ const DISPATCHER_INIT_MAX_ATTEMPTS = 20;
 const DISPATCHER_INIT_RETRY_MS = 250;
 const PLUGIN_READINESS_QUIET_WINDOW_MS = 50;
 const PLUGIN_READINESS_MAX_WAIT_MS = 250;
+const RECOVERY_RETRY_DELAY_MS = 500;
+const RECOVERY_MAX_ATTEMPTS = 16;
+
+const RECOVERABLE_CLOSE_REASONS = new Set([
+  '[RECREATING_DEVICE]',
+  '[PAGE_NOT_FOUND]',
+  '[CONNECTION_LOST]',
+]);
+const DEVTOOLS_TOOK_CONNECTION_REASON = '[NEW_DEBUGGER_OPENED]';
+
+const getCloseReason = (reason: unknown): string =>
+  Buffer.isBuffer(reason) ? reason.toString() : String(reason ?? '');
 
 const getDebuggerWebSocketOrigin = (webSocketDebuggerUrl: string): string => {
   const url = new URL(webSocketDebuggerUrl);
@@ -87,10 +99,12 @@ export const createAgentSession = (options: {
   host: string;
   port: number;
   target: MetroTarget;
+  resolveTarget?: (deviceId: string) => Promise<MetroTarget>;
   cliVersion?: string;
   metroVersion?: string;
   onTerminated?: (sessionId: string) => void;
 }) => {
+  let target = options.target;
   const handler = createAgentMessageHandler();
   const artifacts = createAgentArtifacts(
     options.projectRoot,
@@ -112,6 +126,10 @@ export const createAgentSession = (options: {
   let disconnectLogged = false;
   let startReadiness: StartReadiness | null = null;
   let pluginReadiness: PluginReadiness | null = null;
+  let recoveryPromise: Promise<void> | null = null;
+  let healing: AgentSessionInfo['healing'];
+  const activeAccumulatedDomains = new Map<string, string>();
+  const lostAccumulatedDomains = new Map<string, string>();
 
   const pendingCommands = new Map<number, PendingCommand>();
   const cdpEventListeners = new Map<
@@ -129,7 +147,7 @@ export const createAgentSession = (options: {
 
   const getSessionInfoFields = () => ({
     sessionId: options.target.id,
-    pageId: options.target.pageId,
+    pageId: target.pageId,
     deviceId: options.target.id,
   });
 
@@ -493,7 +511,86 @@ export const createAgentSession = (options: {
     await Promise.all(localServices.map((service) => service.dispose()));
   };
 
-  const handleSocketClosed = (): void => {
+  const rememberLostAccumulatedState = (): void => {
+    for (const [toolName, domain] of activeAccumulatedDomains) {
+      lostAccumulatedDomains.set(toolName, domain);
+    }
+    activeAccumulatedDomains.clear();
+  };
+
+  const waitForRecoveryTarget = async (): Promise<MetroTarget> => {
+    if (!options.resolveTarget) {
+      throw new Error('This session cannot resolve a fresh Metro target');
+    }
+
+    let lastRecoveryError: unknown;
+    for (let attempt = 1; attempt <= RECOVERY_MAX_ATTEMPTS; attempt += 1) {
+      try {
+        return await options.resolveTarget(options.target.id);
+      } catch (error) {
+        lastRecoveryError = error;
+        if (attempt < RECOVERY_MAX_ATTEMPTS) {
+          await new Promise<void>((resolve) => {
+            setTimeout(resolve, RECOVERY_RETRY_DELAY_MS);
+          });
+        }
+      }
+    }
+
+    throw lastRecoveryError instanceof Error
+      ? lastRecoveryError
+      : new Error('The app did not reconnect to Metro');
+  };
+
+  const recover = async (reason: string): Promise<void> => {
+    status = 'connecting';
+    try {
+      // Metro can still be publishing the replacement page when it first
+      // closes the old debugger socket. Retry one fresh connection after the
+      // target-resolution backoff above instead of treating that race as a
+      // terminal session failure.
+      let connected = false;
+      let lastConnectError: unknown;
+      for (let attempt = 1; attempt <= 2 && !connected; attempt += 1) {
+        try {
+          target = await waitForRecoveryTarget();
+          const readinessPromise = createStartReadiness();
+          void readinessPromise.catch(() => undefined);
+          await connect();
+          await readinessPromise;
+          connected = true;
+        } catch (error) {
+          lastConnectError = error;
+          if (stopped || attempt === 2) {
+            throw error;
+          }
+          await new Promise<void>((resolve) => {
+            setTimeout(resolve, RECOVERY_RETRY_DELAY_MS);
+          });
+        }
+      }
+      if (!connected) {
+        throw lastConnectError;
+      }
+      healing = {
+        outcome: 'recovered',
+        message: `Reconnected after ${reason}. Accumulated state from the previous app instance was lost.`,
+        at: Date.now(),
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      lastError = message;
+      healing = { outcome: 'failed', message, at: Date.now() };
+      status = 'stopped';
+      stopped = true;
+      await disposeServices();
+      notifyTerminated();
+    } finally {
+      recoveryPromise = null;
+    }
+  };
+
+  const handleSocketClosed = (reason: string): void => {
     logDisconnected();
     bindingName = null;
     bootstrapped = false;
@@ -515,17 +612,37 @@ export const createAgentSession = (options: {
 
     clearBootstrapTimer();
     clearPluginReadiness();
-    status = 'stopped';
-
     if (stopped) {
+      status = 'stopped';
       notifyTerminated();
       return;
     }
 
+    rememberLostAccumulatedState();
+    if (reason.includes(DEVTOOLS_TOOK_CONNECTION_REASON)) {
+      status = 'stopped';
+      stopped = true;
+      const message =
+        'React Native DevTools took the connection — close it and retry.';
+      lastError = message;
+      healing = { outcome: 'blocked', message, at: Date.now() };
+      void disposeServices().finally(() => {
+        notifyTerminated();
+      });
+      return;
+    }
+
+    const recoveryReason = Array.from(RECOVERABLE_CLOSE_REASONS).find(
+      (candidate) => reason.includes(candidate),
+    );
+    if (recoveryReason) {
+      recoveryPromise ??= recover(recoveryReason);
+      return;
+    }
+
+    status = 'stopped';
     stopped = true;
-    void disposeServices().finally(() => {
-      notifyTerminated();
-    });
+    void disposeServices().finally(() => notifyTerminated());
   };
 
   const handleSocketMessage = (rawMessage: string): void => {
@@ -583,7 +700,15 @@ export const createAgentSession = (options: {
 
     const consoleMessage = extractConsoleMessage(message);
     if (consoleMessage) {
+      activeAccumulatedDomains.set('getMessages', 'console messages');
       handler.captureConsoleMessage(options.target.id, consoleMessage);
+    }
+
+    if (
+      typeof message.method === 'string' &&
+      message.method.startsWith('Network.')
+    ) {
+      activeAccumulatedDomains.set('listRequests', 'network recording');
     }
 
     const bindingPayload = parseRozeniteBindingPayload(message);
@@ -622,10 +747,10 @@ export const createAgentSession = (options: {
     status = 'connecting';
 
     await new Promise<void>((resolve, reject) => {
-      const socket = new WebSocket(options.target.webSocketDebuggerUrl, {
+      const socket = new WebSocket(target.webSocketDebuggerUrl, {
         headers: {
           Origin: getDebuggerWebSocketOrigin(
-            options.target.webSocketDebuggerUrl,
+            target.webSocketDebuggerUrl,
           ),
         },
       });
@@ -679,8 +804,11 @@ export const createAgentSession = (options: {
         }
       });
 
-      socket.once('close', () => {
-        handleSocketClosed();
+      socket.once('close', (_code: unknown, reason: unknown) => {
+        if (ws === socket) {
+          ws = null;
+        }
+        handleSocketClosed(getCloseReason(reason));
         if (!settled) {
           reject(
             new Error('CDP websocket closed before session initialization'),
@@ -695,15 +823,16 @@ export const createAgentSession = (options: {
     host: options.host,
     port: options.port,
     deviceId: options.target.id,
-    deviceName: options.target.name,
-    appId: options.target.appId,
-    pageId: options.target.pageId,
+    deviceName: target.name,
+    appId: target.appId,
+    pageId: target.pageId,
     status,
     createdAt,
     lastActivityAt,
     ...(connectedAt ? { connectedAt } : {}),
     ...(lastError ? { lastError } : {}),
-    toolCount: getToolCount(options.target, handler, localServices),
+    ...(healing ? { healing } : {}),
+    toolCount: getToolCount(target, handler, localServices),
   });
 
   const getTools = () => {
@@ -723,11 +852,29 @@ export const createAgentSession = (options: {
       );
     }
 
+    const lostDomain = lostAccumulatedDomains.get(toolName);
+    if (lostDomain) {
+      lostAccumulatedDomains.delete(toolName);
+      throw new Error(
+        `AGENT_SESSION_STATE_LOST: ${lostDomain} was lost while the app relaunched. Retry this operation to collect new state.`,
+      );
+    }
+
     touch();
+
+    if (toolName === 'startProfiling') {
+      activeAccumulatedDomains.set('stopProfiling', 'profiling data');
+    }
+    if (toolName === 'startRecording') {
+      activeAccumulatedDomains.set('stopRecording', 'network recording');
+    }
 
     for (const service of localServices) {
       const result = await service.callTool(toolName, args);
       if (result !== undefined) {
+        if (toolName === 'stopProfiling' || toolName === 'stopRecording') {
+          activeAccumulatedDomains.delete(toolName);
+        }
         return result;
       }
     }
@@ -758,6 +905,7 @@ export const createAgentSession = (options: {
     }
 
     stopped = true;
+    recoveryPromise = null;
     clearBootstrapTimer();
     clearPluginReadiness();
     rejectStartReadiness(
@@ -783,5 +931,7 @@ export const createAgentSession = (options: {
     getInfo,
     getTools,
     callTool,
+    isReusable: (nextTarget: MetroTarget) =>
+      status === 'connected' && target.pageId === nextTarget.pageId,
   };
 };


### PR DESCRIPTION
## Summary

- recover agent sessions after Metro reports a recreated, missing, or temporarily disconnected target while preserving the stable session ID
- gate healed sessions on bootstrap and exact plugin re-registration, cancel/tear down superseded attempts, and hard-stop when React Native DevTools takes the debugger connection
- replay transparent reads after healing while surfacing retryable, operation-specific state-loss errors for profiling, recording, tracing, and sampling
- expose healing state through session info and prevent stale or terminal sessions from being silently reused

## Tests

- `pnpm --filter @rozenite/middleware test` — 64/64 passed
- focused agent session/session-manager tests — 33/33 passed
- ESLint passed
- Prettier passed
- `git diff --check` passed
- `pnpm --filter @rozenite/agent-shared typecheck` passed

The middleware typecheck could not be used as a clean local signal in the worktree because its existing `node_modules` links `@rozenite/agent-shared` to the primary checkout's older source. The branch's agent-shared package typechecks independently; CI will validate a clean workspace install.

## Android emulator verification

Verified with the installed playground APK while serving rebuilt CLI/middleware and Metro from this branch:

- created session `b265923f6a413a208bffa8758ec6b1d66b9c1b64`
- React `getTree` and storage-plugin `list-storages` succeeded before relaunch
- started profiling, force-stopped and relaunched the app without restarting Metro, then waited about 8 seconds
- `session show` and `session list` reported the same session ID as connected
- the first `stopProfiling` returned `AGENT_SESSION_STATE_LOST` and explicitly named lost profiling data
- React and storage-plugin calls succeeded again after healing

The emulator runtime reused page ID `1` across the force-stop/relaunch, so a changed numeric page ID was not observable; the disconnect/recovery path was demonstrated by the retained session and relaunch-specific state-loss result.

Closes #317
