### PR TITLE
fix(middleware): reset network capture buffer on disconnect

### DIFF
--- a/.changeset/network-reset-on-disconnect.md
+++ b/.changeset/network-reset-on-disconnect.md
@@ -1,0 +1,5 @@
+---
+"@rozenite/middleware": patch
+---
+
+Fix network agent domain not resetting the captured request buffer on disconnect, which allowed a rebind (e.g. after an app relaunch) to serve requests from the previous app run and resume pagination cursors into the wrong buffer.

--- a/packages/middleware/src/__tests__/agent-local-domains.test.ts
+++ b/packages/middleware/src/__tests__/agent-local-domains.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
-import { createMemoryDomainService } from '../agent/local-domains.js';
+import {
+  createMemoryDomainService,
+  createNetworkDomainService,
+} from '../agent/local-domains.js';
 
 const waitForWriteCalls = async (
   fn: { mock: { calls: unknown[] } },
@@ -124,5 +127,82 @@ describe('memory domain service', () => {
 
     expect(finalize).toHaveBeenCalledTimes(1);
     expect(abort).not.toHaveBeenCalled();
+  });
+});
+
+describe('network domain service', () => {
+  it('clears the captured request buffer and bumps the generation on disconnect', async () => {
+    const listeners = new Map<
+      string,
+      Set<(params: Record<string, unknown>) => void | Promise<void>>
+    >();
+
+    const subscribeToCDPEvent = (
+      method: string,
+      listener: (params: Record<string, unknown>) => void | Promise<void>,
+    ) => {
+      const entries = listeners.get(method) || new Set();
+      entries.add(listener);
+      listeners.set(method, entries);
+
+      return () => {
+        entries.delete(listener);
+        if (entries.size === 0) {
+          listeners.delete(method);
+        }
+      };
+    };
+
+    const emit = (method: string, params: Record<string, unknown>) => {
+      for (const listener of listeners.get(method) || []) {
+        void listener(params);
+      }
+    };
+
+    const service = createNetworkDomainService({
+      getSessionInfo: () => ({
+        sessionId: 'device-1',
+        pageId: 'page-1',
+        deviceId: 'device-1',
+      }),
+      sendCommand: async () => ({}),
+      subscribeToCDPEvent,
+    });
+
+    await service.callTool('startRecording', {});
+    emit('Network.requestWillBeSent', {
+      requestId: 'req-1',
+      request: { url: 'https://example.com', method: 'GET' },
+    });
+
+    const statusBeforeDisconnect = await service.callTool(
+      'getRecordingStatus',
+      {},
+    );
+    expect(statusBeforeDisconnect).toMatchObject({
+      recording: {
+        requestCount: 1,
+        generation: 1,
+      },
+    });
+
+    service.onDisconnected();
+
+    const statusAfterDisconnect = await service.callTool(
+      'getRecordingStatus',
+      {},
+    );
+    expect(statusAfterDisconnect).toMatchObject({
+      recording: {
+        isRecording: false,
+        requestCount: 0,
+        generation: 2,
+      },
+    });
+
+    const listResult = (await service.callTool('listRequests', {})) as {
+      items: unknown[];
+    };
+    expect(listResult.items).toEqual([]);
   });
 });

--- a/packages/middleware/src/agent/local-domains.ts
+++ b/packages/middleware/src/agent/local-domains.ts
@@ -1841,6 +1841,7 @@ export const createNetworkDomainService = (deps: {
       clearSubscriptions();
       state.isRecording = false;
       state.enabled = false;
+      resetCapture();
     },
     dispose: async () => {
       clearSubscriptions();


### PR DESCRIPTION
## Summary

- Network's `onDisconnected` cleared `isRecording`/`enabled` but never called `resetCapture()`, so `state.requests`/`requestOrder` kept the pre-relaunch buffer and `state.generation` was never bumped.
- After a rebind (e.g. app relaunch), `listRequests` returned requests captured from the previous app run with nothing marking them stale, and a cursor issued before the relaunch stayed silently valid, resuming into a buffer it was never issued against (cursor scope is `network:requests:${state.generation}`).
- Calling `resetCapture()` from `onDisconnected` fixes both, since the generation bump comes along with it.

Split out of #317 per [this review comment](https://github.com/callstackincubator/rozenite/issues/317#issuecomment-5106841236) — the rest of that issue's disconnect handling (performance, react, memory, console domains) already resets state correctly; this was the one gap specific to network.

Fixes #324

## Test plan

- [x] Added a unit test in `agent-local-domains.test.ts` covering that `onDisconnected` clears the captured request buffer and bumps `generation`
- [x] `pnpm test` — 58/58 passing
- [x] `pnpm typecheck`
- [x] `pnpm lint`