### PR TITLE
fix: react.stopProfiling throws when no active profiling session

### DIFF
--- a/.changeset/stopprofiling-no-active-session.md
+++ b/.changeset/stopprofiling-no-active-session.md
@@ -1,0 +1,6 @@
+---
+"@rozenite/middleware": patch
+"rozenite": patch
+---
+
+Fix `react.stopProfiling` agent tool returning an empty success result instead of erroring when called with no active profiling session. It now throws `No active profiling session for this session`, matching the guard used by the other stop-style agent tools (`network.stopRecording`, `performance.stopTrace`, `memory.stopSampling`).

--- a/packages/cli/src/commands/agent/runtime/react/__tests__/store.test.ts
+++ b/packages/cli/src/commands/agent/runtime/react/__tests__/store.test.ts
@@ -167,3 +167,144 @@ describe('CLI React tree store labels', () => {
     });
   });
 });
+
+type MockPhase = 'idle' | 'profiling' | 'processing';
+
+const createConfigurableProfilingBridge = (options: {
+  initialPhase?: MockPhase;
+  initialDataForRoots?: Map<
+    number,
+    { commitData: Array<{ duration: number; timestamp: number }> }
+  >;
+  drainAfterStatusCalls?: number;
+  dataOnDrain?: Map<
+    number,
+    { commitData: Array<{ duration: number; timestamp: number }> }
+  >;
+}) => {
+  let phase: MockPhase = options.initialPhase ?? 'idle';
+  let dataForRoots = options.initialDataForRoots ?? new Map();
+  let statusCallCount = 0;
+
+  return {
+    ingest: () => null,
+    send: () => undefined,
+    startProfiling: () => {
+      phase = 'profiling';
+    },
+    stopProfiling: () => {
+      phase = 'idle';
+    },
+    reloadAndProfile: () => undefined,
+    getProfilingStatus: () => {
+      statusCallCount += 1;
+      if (
+        phase === 'processing' &&
+        options.drainAfterStatusCalls !== undefined &&
+        statusCallCount > options.drainAfterStatusCalls
+      ) {
+        phase = 'idle';
+        if (options.dataOnDrain) {
+          dataForRoots = options.dataOnDrain;
+        }
+      }
+
+      return {
+        supportsProfiling: true,
+        supportsReloadAndProfile: false,
+        isProfilingStarted: phase === 'profiling',
+        isProcessingData: phase === 'processing',
+        hasProfilingData: dataForRoots.size > 0,
+        rootsWithData: dataForRoots.size,
+        rootsCount: dataForRoots.size,
+      };
+    },
+    getProfilingDataSnapshot: () => ({
+      phase,
+      dataForRoots,
+      conflictingRootIds: new Set<number>(),
+      participatingRendererIds: new Set([1]),
+      pendingRendererIds: new Set<number>(),
+      receivedRendererIds: new Set([1]),
+    }),
+    getCommitData: () => {
+      throw new Error('No commit data');
+    },
+  };
+};
+
+describe('React stopProfiling guard', () => {
+  it('throws when stopProfiling is called with no active session', async () => {
+    const bridge = createConfigurableProfilingBridge({ initialPhase: 'idle' });
+    const store = createReactTreeStore({
+      createBridge: async () => bridge,
+    });
+    store.registerDevice(DEVICE_ID, { sendMessage: () => undefined });
+
+    await expect(store.stopProfiling(DEVICE_ID, {})).rejects.toThrow(
+      'No active profiling session for this session',
+    );
+  });
+
+  it('still collects data when profiling self-stopped and is still draining', async () => {
+    const dataOnDrain = new Map([
+      [1, { commitData: [{ duration: 5, timestamp: 100 }] }],
+    ]);
+    const bridge = createConfigurableProfilingBridge({
+      initialPhase: 'processing',
+      drainAfterStatusCalls: 2,
+      dataOnDrain,
+    });
+    const store = createReactTreeStore({
+      createBridge: async () => bridge,
+    });
+    store.registerDevice(DEVICE_ID, { sendMessage: () => undefined });
+
+    const result = await store.stopProfiling(DEVICE_ID, {
+      waitForDataMs: 200,
+    });
+
+    expect(result).toMatchObject({
+      session: { totalCommits: 1 },
+      renders: { count: 1 },
+    });
+    expect(result).not.toHaveProperty('partial');
+  });
+
+  it('returns already-collected data for an already-complete session', async () => {
+    const initialDataForRoots = new Map([
+      [1, { commitData: [{ duration: 8, timestamp: 200 }] }],
+    ]);
+    const bridge = createConfigurableProfilingBridge({
+      initialPhase: 'idle',
+      initialDataForRoots,
+    });
+    const store = createReactTreeStore({
+      createBridge: async () => bridge,
+    });
+    store.registerDevice(DEVICE_ID, { sendMessage: () => undefined });
+
+    const result = await store.stopProfiling(DEVICE_ID, {});
+
+    expect(result).toMatchObject({
+      session: { totalCommits: 1 },
+      renders: { count: 1 },
+    });
+  });
+
+  it('returns a real zero-commit measurement after start then stop with no re-renders', async () => {
+    const bridge = createConfigurableProfilingBridge({ initialPhase: 'idle' });
+    const store = createReactTreeStore({
+      createBridge: async () => bridge,
+    });
+    store.registerDevice(DEVICE_ID, { sendMessage: () => undefined });
+
+    await store.startProfiling(DEVICE_ID, {});
+    const result = await store.stopProfiling(DEVICE_ID, {});
+
+    expect(result).toMatchObject({
+      session: { totalCommits: 0 },
+      renders: { count: 0 },
+    });
+  });
+});

--- a/packages/cli/src/commands/agent/runtime/react/store.ts
+++ b/packages/cli/src/commands/agent/runtime/react/store.ts
@@ -778,6 +778,14 @@ export const createReactTreeStore = (
     const bridge = await ensureProfilingBridge(state);
     const statusBeforeStop = bridge.getProfilingStatus();
 
+    if (
+      !statusBeforeStop.isProfilingStarted &&
+      !statusBeforeStop.isProcessingData &&
+      !statusBeforeStop.hasProfilingData
+    ) {
+      throw new Error('No active profiling session for this session');
+    }
+
     if (statusBeforeStop.isProfilingStarted) {
       bridge.stopProfiling();
     }

--- a/packages/middleware/src/agent/runtime/react/__tests__/store.test.ts
+++ b/packages/middleware/src/agent/runtime/react/__tests__/store.test.ts
@@ -512,3 +512,142 @@ describe('React tree store getComponent', () => {
     );
   });
 });
+
+type MockPhase = 'idle' | 'profiling' | 'processing';
+
+const createConfigurableProfilingBridge = (options: {
+  initialPhase?: MockPhase;
+  initialDataForRoots?: Map<
+    number,
+    { commitData: Array<{ duration: number; timestamp: number }> }
+  >;
+  drainAfterStatusCalls?: number;
+  dataOnDrain?: Map<
+    number,
+    { commitData: Array<{ duration: number; timestamp: number }> }
+  >;
+}) => {
+  let phase: MockPhase = options.initialPhase ?? 'idle';
+  let dataForRoots = options.initialDataForRoots ?? new Map();
+  let statusCallCount = 0;
+
+  return {
+    ingest: () => null,
+    send: () => undefined,
+    startProfiling: () => {
+      phase = 'profiling';
+    },
+    stopProfiling: () => {
+      phase = 'idle';
+    },
+    reloadAndProfile: () => undefined,
+    getProfilingStatus: () => {
+      statusCallCount += 1;
+      if (
+        phase === 'processing' &&
+        options.drainAfterStatusCalls !== undefined &&
+        statusCallCount > options.drainAfterStatusCalls
+      ) {
+        phase = 'idle';
+        if (options.dataOnDrain) {
+          dataForRoots = options.dataOnDrain;
+        }
+      }
+
+      return {
+        supportsProfiling: true,
+        supportsReloadAndProfile: false,
+        isProfilingStarted: phase === 'profiling',
+        isProcessingData: phase === 'processing',
+        hasProfilingData: dataForRoots.size > 0,
+        rootsWithData: dataForRoots.size,
+        rootsCount: dataForRoots.size,
+      };
+    },
+    getProfilingDataSnapshot: () => ({
+      phase,
+      dataForRoots,
+      conflictingRootIds: new Set<number>(),
+      participatingRendererIds: new Set([1]),
+      pendingRendererIds: new Set<number>(),
+      receivedRendererIds: new Set([1]),
+    }),
+    getCommitData: () => {
+      throw new Error('No commit data');
+    },
+  };
+};
+
+describe('React stopProfiling guard', () => {
+  it('throws when stopProfiling is called with no active session', async () => {
+    const bridge = createConfigurableProfilingBridge({ initialPhase: 'idle' });
+    const store = createReactTreeStore({
+      createBridge: async () => bridge,
+    });
+    store.registerDevice(DEVICE_ID, { sendMessage: () => undefined });
+
+    await expect(store.stopProfiling(DEVICE_ID, {})).rejects.toThrow(
+      'No active profiling session for this session',
+    );
+  });
+
+  it('still collects data when profiling self-stopped and is still draining', async () => {
+    const dataOnDrain = new Map([
+      [1, { commitData: [{ duration: 5, timestamp: 100 }] }],
+    ]);
+    const bridge = createConfigurableProfilingBridge({
+      initialPhase: 'processing',
+      drainAfterStatusCalls: 2,
+      dataOnDrain,
+    });
+    const store = createReactTreeStore({
+      createBridge: async () => bridge,
+    });
+    store.registerDevice(DEVICE_ID, { sendMessage: () => undefined });
+
+    const result = await store.stopProfiling(DEVICE_ID, { waitForDataMs: 200 });
+
+    expect(result).toMatchObject({
+      session: { totalCommits: 1 },
+      renders: { count: 1 },
+    });
+    expect(result).not.toHaveProperty('partial');
+  });
+
+  it('returns already-collected data for an already-complete session', async () => {
+    const initialDataForRoots = new Map([
+      [1, { commitData: [{ duration: 8, timestamp: 200 }] }],
+    ]);
+    const bridge = createConfigurableProfilingBridge({
+      initialPhase: 'idle',
+      initialDataForRoots,
+    });
+    const store = createReactTreeStore({
+      createBridge: async () => bridge,
+    });
+    store.registerDevice(DEVICE_ID, { sendMessage: () => undefined });
+
+    const result = await store.stopProfiling(DEVICE_ID, {});
+
+    expect(result).toMatchObject({
+      session: { totalCommits: 1 },
+      renders: { count: 1 },
+    });
+  });
+
+  it('returns a real zero-commit measurement after start then stop with no re-renders', async () => {
+    const bridge = createConfigurableProfilingBridge({ initialPhase: 'idle' });
+    const store = createReactTreeStore({
+      createBridge: async () => bridge,
+    });
+    store.registerDevice(DEVICE_ID, { sendMessage: () => undefined });
+
+    await store.startProfiling(DEVICE_ID, {});
+    const result = await store.stopProfiling(DEVICE_ID, {});
+
+    expect(result).toMatchObject({
+      session: { totalCommits: 0 },
+      renders: { count: 0 },
+    });
+  });
+});

--- a/packages/middleware/src/agent/runtime/react/store.ts
+++ b/packages/middleware/src/agent/runtime/react/store.ts
@@ -905,6 +905,14 @@ export const createReactTreeStore = (options?: {
     const bridge = await ensureProfilingBridge(state);
     const statusBeforeStop = bridge.getProfilingStatus();
 
+    if (
+      !statusBeforeStop.isProfilingStarted &&
+      !statusBeforeStop.isProcessingData &&
+      !statusBeforeStop.hasProfilingData
+    ) {
+      throw new Error('No active profiling session for this session');
+    }
+
     if (statusBeforeStop.isProfilingStarted) {
       bridge.stopProfiling();
     }


### PR DESCRIPTION
## Summary
- `react.stopProfiling` previously returned a **successful** result with `renders.count: 0` when called with no preceding `startProfiling` (or after the profiling state was discarded, e.g. by an auto-heal rebind), instead of erroring. This is silent and confident: an agent has no way to tell an empty result apart from a genuine zero-render measurement.
- Adds a guard, mirrored in both the `@rozenite/middleware` and `rozenite` (CLI) copies of `react/store.ts`, that throws `No active profiling session for this session` only when `isProfilingStarted`, `isProcessingData`, and `hasProfilingData` are all false — i.e. the profiling phase is genuinely `idle` with nothing accumulated. This matches the guard already used by `network.stopRecording`, `performance.stopTrace`, and `memory.stopSampling`.
- The legitimate self-stopped-and-still-draining flow and the already-complete-session flow are unaffected, and a real `startProfiling` → `stopProfiling` with zero re-renders still returns `count: 0` successfully.

Fixes callstackincubator/rozenite#323

## Test plan
- [x] Added tests in both packages: throws with no active session; still collects data when self-stopped and draining; returns already-collected data for an already-complete session; returns a genuine zero-commit result after start→stop with no re-renders
- [x] `vitest run` passes for `@rozenite/middleware` and `rozenite` (`packages/cli`)
- [x] `tsc --noEmit` passes for both packages