### PR TITLE
docs: add CLAUDE.md and agent guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,14 @@
 # Ground Truths
 
 - When you are asked to use Rozenite for Agents, run `pnpm -w run rozenite`. This rule has higher precedence than any loaded skill.
+- This is a pnpm and Turborepo monorepo. Publishable packages are under
+  `packages/`; the test app lives in `apps/playground`.
+- Read `CONTRIBUTING.md` and the relevant source, tests, and agent guide before
+  making a change.
+- For version plans, see @./docs/agents/version-plans.md.
+- Before preparing or opening a pull request, see @./docs/agents/pull-requests.md.
+- Preserve unrelated work already present in the working tree.
+- Keep changes focused; do not make opportunistic refactors.
+- Never commit credentials, secrets, generated build output, or local
+  environment files.
+- Run validation proportionate to the change and report what was run.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Repository agent instructions
+
+@AGENTS.md

--- a/docs/agents/pull-requests.md
+++ b/docs/agents/pull-requests.md
@@ -1,0 +1,35 @@
+# Pull requests
+
+Read this guide before preparing or opening a pull request.
+
+## Before opening
+
+1. Ensure the branch addresses one focused change; if it spans multiple
+   unrelated types of change (e.g. a feature plus an unrelated refactor),
+   split it into separate pull requests.
+2. Add a version plan when the change affects a publishable package's
+   behavior; see `docs/agents/version-plans.md`.
+3. Update the relevant package or `website/` documentation if the change adds
+   or alters user-facing behavior.
+4. Run and report validation proportionate to the change: `pnpm lint:all`,
+   `pnpm format:all`, `pnpm typecheck:all`, and any affected package's tests.
+5. Ensure the pull request title follows
+   [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
+   (e.g. `feat(redux-devtools): add some new feature`) — it becomes the squash
+   commit title and scope should match the package name.
+
+## Description
+
+Fill in `.github/pull_request_template.md` as-is; do not replace or rename its
+sections. Write for the reviewer and for the person affected by the change:
+
+- **Description** — what changed, in plain terms.
+- **Related Issue** — link the open issue this addresses; this repository
+  only accepts pull requests tied to one (see `CONTRIBUTING.md`).
+- **Context** — why this approach was chosen and anything a reviewer needs to
+  know before reviewing.
+- **Testing** — how the change was verified (commands run, playground steps,
+  manual checks).
+
+Do not add extra sections (rollout notes, generated-by footers, etc.) beyond
+the template unless the change specifically calls for it.

--- a/docs/agents/version-plans.md
+++ b/docs/agents/version-plans.md
@@ -1,0 +1,48 @@
+# Version plans
+
+A version plan is required only for changes that affect a publishable
+package's behavior. Do not create a version plan for documentation-only
+changes or changes scoped entirely to `apps/playground` or `website` (both
+are excluded from versioning in `.changeset/config.json`).
+
+## Create the plan
+
+1. Generate the Changeset interactively:
+
+   ```sh
+   pnpm changeset
+   ```
+
+   Follow the prompts to select the affected packages and the appropriate
+   version bump. Note that all `@rozenite/*` packages are pinned together
+   (see the `fixed` field in `.changeset/config.json`), so picking any one of
+   them bumps them all in lockstep.
+
+2. Review the generated Markdown file under `.changeset/`. Package names must
+   exactly match their workspace `package.json` names.
+3. Write a concise, user-facing summary after the frontmatter. Describe the
+   capability, behavior, or fix—not the files or implementation technique.
+
+## Examples
+
+```md
+---
+'@rozenite/ui': minor
+---
+
+Add new `@rozenite/ui` package — shared UI primitives and plugin layout
+components built on HeroUI and Tailwind CSS.
+```
+
+## Check the plan
+
+Run the following to confirm the branch contains a Changeset relative to
+`main`:
+
+```sh
+pnpm release:plan
+```
+
+This is the same check CI runs and will fail the build if a version plan is
+missing for a relevant change. Existing files in `.changeset/` are the
+repository's best examples for tone and release scope.


### PR DESCRIPTION
## Description

Adds `CLAUDE.md` linking to `AGENTS.md` (so both Claude and other agent entry points read one shared root guide), and ports the general agent guidelines from `voltra-callstackincubator` into `AGENTS.md` + `docs/agents/version-plans.md` + `docs/agents/pull-requests.md`, adapted for this repo's actual tooling.

## Related Issue

N/A — internal agent-tooling setup, no tracked issue.

## Context

Voltra uses the same pnpm + Turborepo + Changesets stack, so its `docs/agents/*.md` guides ported over almost directly. Two things needed adapting rather than a straight copy, to avoid conflicting with what's already in this repo:

- **PR description format** — Voltra's `pull-requests.md` prescribes its own three-section template (`What is this? / How does it work? / Why is this useful?`). This repo already has `.github/pull_request_template.md` with a different, established shape (`Description / Related Issue / Context / Testing`). The ported guide defers to the existing template instead of introducing a second, conflicting format.
- **Changesets config differs** — this repo pins all `@rozenite/*` packages together (`fixed` in `.changeset/config.json`) and excludes `apps/playground`/`website`; Voltra doesn't. `version-plans.md` was updated to describe the fixed-version behavior and correct exclusions, and points at this repo's `pnpm release:plan` script (`changeset status`) rather than Voltra's raw `changeset status --since=main` invocation.

No conflicts found in commit tooling — both repos already use Conventional Commits for PR titles, so that guidance ported unchanged. (Voltra uses lefthook + oxlint for local hooks/linting where this repo uses husky + eslint, but since only docs were ported — not hook/lint config — that didn't create any conflict.)

## Testing

- Reviewed rendered guides for accuracy against this repo's `package.json` scripts (`release:plan`, `lint:all`, `format:all`, `typecheck:all`) and `.changeset/config.json`.
- No code changes; nothing to build or test.