### PR TITLE
feat(agent-sdk): derive short, stable domain names from npm package names

### DIFF
--- a/.changeset/short-plugin-domain-names.md
+++ b/.changeset/short-plugin-domain-names.md
@@ -1,0 +1,8 @@
+---
+"@rozenite/agent-sdk": minor
+"rozenite": minor
+---
+
+Derive short, stable agent domain names from npm package names instead of mangled, hash-suffixed slugs. `@rozenite/mmkv-plugin` now resolves to the domain `mmkv` instead of `at-rozenite__mmkv-plugin`, and `@avasapp/rozenite-plugin-ably` resolves to `avasapp/ably`. The domain name is a pure function of the plugin's package name alone — installing, removing, or updating other plugins never changes it, and two packages that would derive the same domain name now fail loudly instead of one silently shadowing the other.
+
+The previous mangled slug form (e.g. `at-rozenite__mmkv-plugin`) is still accepted by `resolveDomainToken` as an undocumented compatibility alias for one release cycle.

--- a/packages/agent-sdk/src/__tests__/domain-utils.test.ts
+++ b/packages/agent-sdk/src/__tests__/domain-utils.test.ts
@@ -1,8 +1,10 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import type { AgentTool } from '@rozenite/agent-shared';
 import {
   buildRuntimePluginDomains,
-  encodePluginDomainSlug,
+  deriveDomainName,
   formatUnknownDomainError,
   getDomainToolsByDefinition,
   inferPluginId,
@@ -12,7 +14,21 @@ import {
   toAgentDomainTool,
   toAgentToolSchema,
 } from '../domain-utils.js';
-import { STATIC_DOMAINS } from '../constants.js';
+import { RESERVED_DOMAIN_NAMES, STATIC_DOMAINS } from '../constants.js';
+
+const PLUGIN_DIRECTORY_PATH = fileURLToPath(
+  new URL('../../../../plugin-directory.json', import.meta.url),
+);
+
+const getFirstPartyPluginIds = (): string[] => {
+  const entries: { npmUrl: string }[] = JSON.parse(
+    readFileSync(PLUGIN_DIRECTORY_PATH, 'utf-8'),
+  );
+
+  return entries
+    .map((entry) => entry.npmUrl.replace('https://www.npmjs.com/package/', ''))
+    .filter((pluginId) => pluginId.startsWith('@rozenite/'));
+};
 
 const tool = (name: string): AgentTool => ({
   name,
@@ -24,11 +40,79 @@ const tool = (name: string): AgentTool => ({
 });
 
 describe('agent domain utils', () => {
-  it('encodes plugin ids into safe domain slugs', () => {
-    expect(encodePluginDomainSlug('@rozenite/mmkv-plugin')).toBe(
-      'at-rozenite__mmkv-plugin',
+  it('derives short domain names for every package in the plugin directory', () => {
+    const expected: Record<string, string> = {
+      '@rozenite/redux-devtools-plugin': 'redux-devtools',
+      '@rozenite/network-activity-plugin': 'network-activity',
+      '@rozenite/react-navigation-plugin': 'react-navigation',
+      '@rozenite/tanstack-query-plugin': 'tanstack-query',
+      '@rozenite/expo-atlas-plugin': 'expo-atlas',
+      '@rozenite/overlay-plugin': 'overlay',
+      '@rozenite/controls-plugin': 'controls',
+      '@rozenite/performance-monitor-plugin': 'performance-monitor',
+      '@rozenite/storage-plugin': 'storage',
+      '@rozenite/sqlite-plugin': 'sqlite',
+      '@rozenite/file-system-plugin': 'file-system',
+      '@rozenite/rhf-plugin': 'rhf',
+      '@rozenite/require-profiler-plugin': 'require-profiler',
+      '@ilteoood/zorro': 'ilteoood/zorro',
+      '@avasapp/rozenite-plugin-ably': 'avasapp/ably',
+      '@react-native-nitro-geolocation/rozenite-plugin':
+        'react-native-nitro-geolocation',
+      'rozenite-preview': 'rozenite-preview',
+      'rozenite-graphql-client-devtool': 'rozenite-graphql-client-devtool',
+      'rozenite-assets-viewer': 'rozenite-assets-viewer',
+      'rozenite-growthbook-plugin': 'rozenite-growthbook-plugin',
+      'rozenite-zustand-devtools': 'rozenite-zustand-devtools',
+      'rozenite-navigation-inspector': 'rozenite-navigation-inspector',
+    };
+
+    const pluginIds = Object.keys(expected);
+    const derived = pluginIds.map((pluginId) => deriveDomainName(pluginId));
+
+    for (const [index, pluginId] of pluginIds.entries()) {
+      expect(derived[index]).toBe(expected[pluginId]);
+    }
+    expect(new Set(derived).size).toBe(pluginIds.length);
+  });
+
+  it('is a pure function of the plugin id: a rival package cannot rename an official plugin', () => {
+    expect(deriveDomainName('@rozenite/mmkv-plugin')).toBe('mmkv');
+    expect(deriveDomainName('@evil/rozenite-plugin-mmkv')).toBe('evil/mmkv');
+    expect(deriveDomainName('@other/mmkv-plugin')).toBe('other/mmkv');
+    expect(deriveDomainName('rozenite-mmkv-plugin')).toBe(
+      'rozenite-mmkv-plugin',
     );
-    expect(encodePluginDomainSlug('my plugin/id')).toBe('my-plugin__id');
+  });
+
+  it('never lets a plugin shadow a built-in domain name', () => {
+    expect(deriveDomainName('@evil/react-plugin')).toBe('evil/react');
+    expect(deriveDomainName('@x/rozenite-plugin-console')).toBe('x/console');
+    expect(deriveDomainName('rozenite-react-plugin')).toBe(
+      'rozenite-react-plugin',
+    );
+    expect(deriveDomainName('@rozenite/react-plugin')).toBe(
+      '@rozenite/react-plugin',
+    );
+  });
+
+  it('build-time assertion: no first-party @rozenite/* plugin reduces onto a reserved built-in name', () => {
+    const firstPartyPluginIds = getFirstPartyPluginIds();
+    expect(firstPartyPluginIds.length).toBeGreaterThan(0);
+
+    for (const pluginId of firstPartyPluginIds) {
+      const domainName = deriveDomainName(pluginId);
+      expect(RESERVED_DOMAIN_NAMES.has(domainName)).toBe(false);
+      expect(domainName).not.toBe(pluginId);
+    }
+  });
+
+  it('falls back to the scope when the reduced name is empty or generic residue', () => {
+    expect(deriveDomainName('@react-native-nitro-geolocation/rozenite-plugin')).toBe(
+      'react-native-nitro-geolocation',
+    );
+    expect(deriveDomainName('@scope/plugin')).toBe('scope');
+    expect(deriveDomainName('@scope/devtools')).toBe('scope');
   });
 
   it('infers plugin ids for scoped, unscoped, and empty-style names', () => {
@@ -47,18 +131,29 @@ describe('agent domain utils', () => {
     expect(inferToolShortName('listRequests')).toBe('listRequests');
   });
 
-  it('builds dynamic plugin domains and resolves collisions deterministically', () => {
+  it('builds dynamic plugin domains from distinct plugin ids', () => {
     const domains = buildRuntimePluginDomains([
-      tool('@a/b.list'),
-      tool('at-a__b.list'),
+      tool('@rozenite/mmkv-plugin.list-entries'),
+      tool('@avasapp/rozenite-plugin-ably.list-channels'),
     ]);
 
     const ids = domains.map((domain) => domain.id);
-    expect(ids[0]).toMatch(/^at-a__b--[a-f0-9]{8}$/);
-    expect(ids[1]).toMatch(/^at-a__b--[a-f0-9]{8}$/);
+    expect(ids).toContain('mmkv');
+    expect(ids).toContain('avasapp/ably');
     expect(new Set(ids).size).toBe(2);
     expect(domains.every((domain) => domain.kind === 'plugin')).toBe(true);
     expect(domains.every((domain) => domain.actions.length === 3)).toBe(true);
+  });
+
+  it('errors instead of silently renaming when two packages by the same author derive the same domain name', () => {
+    expect(() =>
+      buildRuntimePluginDomains([
+        tool('@a/rozenite-plugin-x.list'),
+        tool('@a/x-plugin.list'),
+      ]),
+    ).toThrow(
+      /Ambiguous domain name "a\/x": plugins @a\/rozenite-plugin-x, @a\/x-plugin/,
+    );
   });
 
   it('resolves plugin domains by id or pluginId token', () => {
@@ -71,6 +166,32 @@ describe('agent domain utils', () => {
 
     expect(byId?.pluginId).toBe('@rozenite/mmkv-plugin');
     expect(byPluginId?.id).toBe(domains[0]!.id);
+  });
+
+  it('tolerantly resolves mmkv, rozenite/mmkv, and the full package name to the same domain', () => {
+    const domains = buildRuntimePluginDomains([
+      tool('@rozenite/mmkv-plugin.list-entries'),
+    ]);
+
+    expect(resolveDomainToken('mmkv', domains)?.pluginId).toBe(
+      '@rozenite/mmkv-plugin',
+    );
+    expect(resolveDomainToken('rozenite/mmkv', domains)?.pluginId).toBe(
+      '@rozenite/mmkv-plugin',
+    );
+    expect(
+      resolveDomainToken('@rozenite/mmkv-plugin', domains)?.pluginId,
+    ).toBe('@rozenite/mmkv-plugin');
+  });
+
+  it('still accepts the deprecated pre-#319 mangled slug as a compatibility alias', () => {
+    const domains = buildRuntimePluginDomains([
+      tool('@rozenite/mmkv-plugin.list-entries'),
+    ]);
+
+    expect(
+      resolveDomainToken('at-rozenite__mmkv-plugin', domains)?.pluginId,
+    ).toBe('@rozenite/mmkv-plugin');
   });
 
   it('uses origin-aware descriptions for plugin and app domains', () => {

--- a/packages/agent-sdk/src/__tests__/domain-utils.test.ts
+++ b/packages/agent-sdk/src/__tests__/domain-utils.test.ts
@@ -156,6 +156,12 @@ describe('agent domain utils', () => {
     );
   });
 
+  it('errors instead of silently shadowing a built-in domain with an unscoped package literally named after it', () => {
+    expect(() =>
+      buildRuntimePluginDomains([tool('console.list')]),
+    ).toThrow(/Plugin "console" derives the domain name "console"/);
+  });
+
   it('resolves plugin domains by id or pluginId token', () => {
     const domains = buildRuntimePluginDomains([
       tool('@rozenite/mmkv-plugin.list-entries'),

--- a/packages/agent-sdk/src/__tests__/domains.test.ts
+++ b/packages/agent-sdk/src/__tests__/domains.test.ts
@@ -40,7 +40,7 @@ const mockAttachedSessionRoute = (
 };
 
 describe('agent session domain and tool helpers', () => {
-  it('lists static and runtime domains with collision-safe plugin slugs', async () => {
+  it('lists static and runtime domains with short, derived plugin domain names', async () => {
     httpTestHarness.requestHandler.mockImplementation(
       async ({ pathname }: MockHttpRequest): Promise<MockHttpResult> => {
         const sessionRoute = mockAttachedSessionRoute(pathname);
@@ -65,13 +65,13 @@ describe('agent session domain and tool helpers', () => {
                     inputSchema: { type: 'object' },
                   },
                   {
-                    name: '@a/b.list',
-                    description: 'Scoped plugin',
+                    name: '@rozenite/mmkv-plugin.list-entries',
+                    description: 'Official plugin',
                     inputSchema: { type: 'object' },
                   },
                   {
-                    name: 'at-a__b.list',
-                    description: 'Colliding plugin',
+                    name: '@avasapp/rozenite-plugin-ably.list-channels',
+                    description: 'Third-party scoped plugin',
                     inputSchema: { type: 'object' },
                   },
                 ],
@@ -95,13 +95,61 @@ describe('agent session domain and tool helpers', () => {
       id: 'app',
       kind: 'plugin',
     });
+    expect(
+      domains.find((domain) => domain.pluginId === '@rozenite/mmkv-plugin'),
+    ).toMatchObject({
+      id: 'mmkv',
+      kind: 'plugin',
+    });
+    expect(
+      domains.find(
+        (domain) => domain.pluginId === '@avasapp/rozenite-plugin-ably',
+      ),
+    ).toMatchObject({
+      id: 'avasapp/ably',
+      kind: 'plugin',
+    });
+  });
 
-    const scoped = domains.find((domain) => domain.pluginId === '@a/b');
-    const colliding = domains.find((domain) => domain.pluginId === 'at-a__b');
+  it('rejects listing domains when two plugins would derive the same domain name', async () => {
+    httpTestHarness.requestHandler.mockImplementation(
+      async ({ pathname }: MockHttpRequest): Promise<MockHttpResult> => {
+        const sessionRoute = mockAttachedSessionRoute(pathname);
+        if (sessionRoute) {
+          return sessionRoute;
+        }
 
-    expect(scoped?.id).toMatch(/^at-a__b--[a-f0-9]{8}$/);
-    expect(colliding?.id).toMatch(/^at-a__b--[a-f0-9]{8}$/);
-    expect(scoped?.id).not.toBe(colliding?.id);
+        if (pathname === getAgentSessionToolsRoute('session-1')) {
+          return {
+            payload: {
+              ok: true,
+              result: {
+                tools: [
+                  {
+                    name: '@a/rozenite-plugin-x.list',
+                    description: 'First plugin',
+                    inputSchema: { type: 'object' },
+                  },
+                  {
+                    name: '@a/x-plugin.list',
+                    description: 'Second, same-author plugin',
+                    inputSchema: { type: 'object' },
+                  },
+                ],
+              },
+            },
+          };
+        }
+
+        return mockUnknownRoute();
+      },
+    );
+
+    const session = await attachSession();
+
+    await expect(session.domains.list()).rejects.toThrow(
+      /Ambiguous domain name "a\/x"/,
+    );
   });
 
   it('resolves domains and tools by plugin id and short tool name', async () => {

--- a/packages/agent-sdk/src/constants.ts
+++ b/packages/agent-sdk/src/constants.ts
@@ -36,6 +36,10 @@ export const STATIC_DOMAINS: DomainDefinition[] = [
   },
 ];
 
+export const RESERVED_DOMAIN_NAMES: ReadonlySet<string> = new Set(
+  STATIC_DOMAINS.map((domain) => domain.id),
+);
+
 export const STATIC_DOMAIN_TOOL_PREFIXES: Record<string, string> = {};
 
 export const STATIC_DOMAIN_TOOL_NAMES: Record<string, string[]> = {

--- a/packages/agent-sdk/src/domain-utils.ts
+++ b/packages/agent-sdk/src/domain-utils.ts
@@ -1,6 +1,6 @@
-import { createHash } from 'node:crypto';
 import type { AgentTool } from '@rozenite/agent-shared';
 import {
+  RESERVED_DOMAIN_NAMES,
   STATIC_DOMAIN_TOOL_NAMES,
   STATIC_DOMAIN_TOOL_PREFIXES,
 } from './constants.js';
@@ -75,7 +75,79 @@ export const getDomainToolsByDefinition = (
   );
 };
 
-export const encodePluginDomainSlug = (pluginId: string): string => {
+const GENERIC_RESIDUE_NAMES = new Set(['plugin', 'devtool', 'devtools']);
+
+const ROZENITE_PLUGIN_PREFIX = 'rozenite-plugin-';
+const ROZENITE_PREFIX = 'rozenite-';
+const PLUGIN_SUFFIX = '-plugin';
+
+/**
+ * Strips the `rozenite-plugin-` prefix, else the `rozenite-` prefix, then the
+ * `-plugin` suffix. Order matters: `rozenite-plugin-ably` must reduce to
+ * `ably`, not `plugin-ably`.
+ */
+const reducePackageName = (name: string): string => {
+  let reduced = name;
+  if (reduced.startsWith(ROZENITE_PLUGIN_PREFIX)) {
+    reduced = reduced.slice(ROZENITE_PLUGIN_PREFIX.length);
+  } else if (reduced.startsWith(ROZENITE_PREFIX)) {
+    reduced = reduced.slice(ROZENITE_PREFIX.length);
+  }
+
+  if (reduced.endsWith(PLUGIN_SUFFIX)) {
+    reduced = reduced.slice(0, -PLUGIN_SUFFIX.length);
+  }
+
+  return reduced;
+};
+
+const parseScopedPackageName = (
+  pluginId: string,
+): { scope: string; name: string } | null => {
+  const match = pluginId.match(/^@([^/]+)\/(.+)$/);
+  if (!match) {
+    return null;
+  }
+
+  return { scope: match[1]!, name: match[2]! };
+};
+
+/**
+ * Derives a short, stable domain name from an npm package name. This is a
+ * pure function of `pluginId` alone: installing, removing, or updating any
+ * *other* plugin must never change the result. See
+ * https://github.com/callstackincubator/rozenite/issues/319 for the rules.
+ */
+export const deriveDomainName = (pluginId: string): string => {
+  const scoped = parseScopedPackageName(pluginId);
+
+  let candidate: string;
+  if (scoped) {
+    const reduced = reducePackageName(scoped.name);
+    if (!reduced || GENERIC_RESIDUE_NAMES.has(reduced)) {
+      candidate = scoped.scope;
+    } else if (scoped.scope === 'rozenite') {
+      candidate = reduced;
+    } else {
+      candidate = `${scoped.scope}/${reduced}`;
+    }
+  } else {
+    candidate = pluginId;
+  }
+
+  if (RESERVED_DOMAIN_NAMES.has(candidate)) {
+    return pluginId;
+  }
+
+  return candidate;
+};
+
+/**
+ * Undocumented, deprecated alias for the pre-#319 domain token shape, kept so
+ * `resolveDomainToken` still accepts scripts written against
+ * `at-rozenite__mmkv-plugin`-style tokens for one release cycle.
+ */
+const deriveLegacyDomainSlug = (pluginId: string): string => {
   const normalized = pluginId
     .toLowerCase()
     .replaceAll('@', 'at-')
@@ -85,10 +157,6 @@ export const encodePluginDomainSlug = (pluginId: string): string => {
     .replace(/^-+|-+$/g, '');
 
   return normalized || 'plugin';
-};
-
-const getCollisionHash = (pluginId: string): string => {
-  return createHash('sha1').update(pluginId).digest('hex').slice(0, 8);
 };
 
 export const buildRuntimePluginDomains = (
@@ -118,44 +186,47 @@ export const buildRuntimePluginDomains = (
     ),
   ).sort();
 
-  const baseSlugGroups = new Map<string, string[]>();
+  const pluginIdsByDomainName = new Map<string, string[]>();
   for (const pluginId of pluginIds) {
-    const baseSlug = encodePluginDomainSlug(pluginId);
-    const existing = baseSlugGroups.get(baseSlug) || [];
+    const domainName = deriveDomainName(pluginId);
+    const existing = pluginIdsByDomainName.get(domainName) || [];
     existing.push(pluginId);
-    baseSlugGroups.set(baseSlug, existing);
+    pluginIdsByDomainName.set(domainName, existing);
   }
 
-  const usedSlugs = new Set<string>();
+  for (const [domainName, collidingIds] of pluginIdsByDomainName) {
+    if (collidingIds.length > 1) {
+      throw new Error(
+        `Ambiguous domain name "${domainName}": plugins ${collidingIds.join(
+          ', ',
+        )} all derive the same domain name. Rename one of these packages to disambiguate.`,
+      );
+    }
+  }
 
   return pluginIds.map((pluginId) => {
-    const baseSlug = encodePluginDomainSlug(pluginId);
-    const collidingIds = baseSlugGroups.get(baseSlug) || [];
-
-    let slug = baseSlug;
-    if (collidingIds.length > 1) {
-      slug = `${baseSlug}--${getCollisionHash(pluginId)}`;
-    }
-
-    while (usedSlugs.has(slug)) {
-      slug = `${slug}-${getCollisionHash(`${pluginId}:${slug}`)}`;
-    }
-    usedSlugs.add(slug);
-
     const description =
       pluginId === 'app'
         ? 'Runtime tools exposed by the app itself.'
         : `Runtime tools exposed by plugin "${pluginId}".`;
 
     return {
-      id: slug,
+      id: deriveDomainName(pluginId),
       kind: 'plugin',
       pluginId,
-      slug,
+      slug: deriveLegacyDomainSlug(pluginId),
       description,
       actions: ['list-tools', 'get-tool-schema', 'call-tool'],
     };
   });
+};
+
+const getRozeniteScopedAlias = (
+  domain: DomainDefinition,
+): string | undefined => {
+  return domain.pluginId?.startsWith('@rozenite/')
+    ? `rozenite/${domain.id}`
+    : undefined;
 };
 
 export const resolveDomainToken = (
@@ -167,7 +238,8 @@ export const resolveDomainToken = (
     (domain) =>
       domain.id === normalized ||
       domain.slug === normalized ||
-      domain.pluginId === normalized,
+      domain.pluginId === normalized ||
+      getRozeniteScopedAlias(domain) === normalized,
   );
 };
 
@@ -188,7 +260,12 @@ export const rankDomainSuggestions = (
 
   return domains
     .map((domain) => {
-      const candidates = [domain.id, domain.slug, domain.pluginId]
+      const candidates = [
+        domain.id,
+        domain.slug,
+        domain.pluginId,
+        getRozeniteScopedAlias(domain),
+      ]
         .filter((value): value is string => typeof value === 'string')
         .map((value) => value.toLowerCase());
 

--- a/packages/agent-sdk/src/domain-utils.ts
+++ b/packages/agent-sdk/src/domain-utils.ts
@@ -202,6 +202,16 @@ export const buildRuntimePluginDomains = (
         )} all derive the same domain name. Rename one of these packages to disambiguate.`,
       );
     }
+
+    // Scoped package names already fall back to their full pluginId when
+    // they would shadow a built-in domain (see deriveDomainName). An
+    // unscoped package literally named e.g. "console" has no alternate
+    // representation to fall back to, so guard against that here.
+    if (RESERVED_DOMAIN_NAMES.has(domainName)) {
+      throw new Error(
+        `Plugin "${collidingIds[0]}" derives the domain name "${domainName}", which shadows the built-in "${domainName}" domain. Rename the package to avoid the collision.`,
+      );
+    }
   }
 
   return pluginIds.map((pluginId) => {

--- a/packages/cli/skills/rozenite-agent-sdk/SKILL.md
+++ b/packages/cli/skills/rozenite-agent-sdk/SKILL.md
@@ -18,7 +18,7 @@ Read `references/code-patterns.md` for copy-pastable examples.
 - Prefer typed plugin SDK descriptors from any available official plugin `./sdk` export and call tools as `session.tools.call(descriptor, args)`.
 - Fall back to `session.tools.call({ domain, tool, args })` only when no matching `./sdk` descriptor is available or the tool is discovered dynamically at runtime.
 - When you discover tools through `session.tools.list({ domain })`, treat the returned `shortName` as the canonical tool name to pass back into a later call-by-name invocation. Do not invent camelCase aliases or normalize tool names yourself.
-- Prefer stable SDK domain identifiers such as built-in domain IDs (`network`, `react`, `memory`) and plugin IDs (`@rozenite/storage-plugin`, `@rozenite/tanstack-query-plugin`) over CLI-only live domain tokens like `at-rozenite__storage-plugin`.
+- Prefer stable SDK domain identifiers such as built-in domain IDs (`network`, `react`, `memory`) and plugin IDs (`@rozenite/storage-plugin`, `@rozenite/tanstack-query-plugin`) over the derived, CLI-facing domain token like `storage`.
 - If paged results should be merged automatically, use `autoPaginate`.
 - If a plugin only mounts after navigation, navigate first, then refresh the live view with `session.domains.list()` or `session.tools.list(...)` before calling the plugin tool.
 - For advanced session control with `client.openSession()` or `client.attachSession(sessionId)`, see the reference patterns.

--- a/packages/cli/skills/rozenite-agent/SKILL.md
+++ b/packages/cli/skills/rozenite-agent/SKILL.md
@@ -33,17 +33,18 @@ description: Use Rozenite for Agents through CLI-driven `rozenite agent` command
 - Do not explore the codebase to infer live runtime state when Rozenite can answer directly.
 - Explore source code only when the user asks about implementation or setup, when no relevant domain is available, or when Rozenite shows the required plugin or domain is not registered and the task becomes setup or debugging.
 - If the expected plugin domain is missing from the live session, tell the user that the corresponding plugin must be installed and registered in the app.
-- When referring to plugin domains in user-facing output, use the plugin's `pluginId` instead of the normalized slug.
+- When referring to plugin domains in user-facing output, use the plugin's `pluginId` instead of the domain token.
 - When making Rozenite calls against a discovered plugin domain, use the live domain token returned by Rozenite.
 - Built-in domains are `console`, `network`, `react`, `performance`, and `memory`.
-- Additional domains can appear at runtime from the app or installed plugins.
+- Additional domains can appear at runtime from the app or installed plugins. Plugin domain tokens are short, derived names, not the npm package name: `@rozenite/mmkv-plugin` becomes `mmkv`, `@avasapp/rozenite-plugin-ably` becomes `avasapp/ably`.
+- Domain token shape tells you provenance: a bare word (`mmkv`) is a built-in or an official `@rozenite/*` plugin; `scope/name` (`avasapp/ably`) is a third-party scoped plugin; a verbatim `rozenite-*` name is a third-party unscoped plugin. `evil/mmkv` and `mmkv` are never the same plugin.
 
 ## Calls
 
 - Do not pass domain tool names as direct CLI subcommands.
 - Always invoke domain tools with `npx rozenite agent <domain> call --tool <toolName> --args '<json>' --session <id>`.
 - If a domain reference lists only tool names, treat them as tool names, not CLI actions.
-- Example: `npx rozenite agent at-rozenite__mmkv-plugin call --tool list-storages --args '{}' --session <id>`.
+- Example: `npx rozenite agent mmkv call --tool list-storages --args '{}' --session <id>`.
 - If a command fails with `Unknown domain action`, check the CLI syntax and retry with `call --tool <toolName> --session <id>`.
 
 ## Flow

--- a/packages/cli/skills/rozenite-agent/domains/controls.md
+++ b/packages/cli/skills/rozenite-agent/domains/controls.md
@@ -5,7 +5,7 @@ A Rozenite plugin for exposing app-defined controls in React Native DevTools. Yo
 ## Domain
 
 - Plugin ID: `@rozenite/controls-plugin`
-- Domain token: `at-rozenite__controls-plugin`
+- Domain token: `controls`
 
 ## Tools
 

--- a/packages/cli/skills/rozenite-agent/domains/file-system.md
+++ b/packages/cli/skills/rozenite-agent/domains/file-system.md
@@ -5,7 +5,7 @@ A Rozenite plugin for browsing app files and previewing file contents in React N
 ## Domain
 
 - Plugin ID: `@rozenite/file-system-plugin`
-- Domain token: `at-rozenite__file-system-plugin`
+- Domain token: `file-system`
 
 ## Tools
 

--- a/packages/cli/skills/rozenite-agent/domains/mmkv.md
+++ b/packages/cli/skills/rozenite-agent/domains/mmkv.md
@@ -5,7 +5,7 @@ A Rozenite plugin for MMKV storage inspection in React Native DevTools. It provi
 ## Domain
 
 - Plugin ID: `@rozenite/mmkv-plugin`
-- Domain token: `at-rozenite__mmkv-plugin`
+- Domain token: `mmkv`
 
 ## Tools
 

--- a/packages/cli/skills/rozenite-agent/domains/network-activity.md
+++ b/packages/cli/skills/rozenite-agent/domains/network-activity.md
@@ -5,7 +5,7 @@ A Rozenite plugin for fallback network inspection when the built-in `network` do
 ## Domain
 
 - Plugin ID: `@rozenite/network-activity-plugin`
-- Domain token: `at-rozenite__network-activity-plugin`
+- Domain token: `network-activity`
 
 ## Precedence
 

--- a/packages/cli/skills/rozenite-agent/domains/react-navigation.md
+++ b/packages/cli/skills/rozenite-agent/domains/react-navigation.md
@@ -5,7 +5,7 @@ A Rozenite plugin for React Navigation debugging and inspection in React Native 
 ## Domain
 
 - Plugin ID: `@rozenite/react-navigation-plugin`
-- Domain token: `at-rozenite__react-navigation-plugin`
+- Domain token: `react-navigation`
 
 ## Tools
 

--- a/packages/cli/skills/rozenite-agent/domains/redux-devtools.md
+++ b/packages/cli/skills/rozenite-agent/domains/redux-devtools.md
@@ -5,7 +5,7 @@ A Rozenite plugin for Redux state inspection and curated history control in Reac
 ## Domain
 
 - Plugin ID: `@rozenite/redux-devtools-plugin`
-- Domain token: `at-rozenite__redux-devtools-plugin`
+- Domain token: `redux-devtools`
 
 ## Tools
 

--- a/packages/cli/skills/rozenite-agent/domains/storage.md
+++ b/packages/cli/skills/rozenite-agent/domains/storage.md
@@ -5,7 +5,7 @@ A Rozenite plugin for inspecting multiple storage backends in React Native DevTo
 ## Domain
 
 - Plugin ID: `@rozenite/storage-plugin`
-- Domain token: `at-rozenite__storage-plugin`
+- Domain token: `storage`
 
 ## Tools
 

--- a/packages/cli/skills/rozenite-agent/domains/tanstack-query.md
+++ b/packages/cli/skills/rozenite-agent/domains/tanstack-query.md
@@ -5,7 +5,7 @@ A Rozenite plugin for inspecting and managing TanStack Query caches in React Nat
 ## Domain
 
 - Plugin ID: `@rozenite/tanstack-query-plugin`
-- Domain token: `at-rozenite__tanstack-query-plugin`
+- Domain token: `tanstack-query`
 
 ## Tools
 

--- a/website/src/docs/agent/making-your-plugin-agent-enabled.mdx
+++ b/website/src/docs/agent/making-your-plugin-agent-enabled.mdx
@@ -218,11 +218,11 @@ Agents discover domains and tools at runtime:
 
 ```bash
 rozenite agent domains --session <sessionId> --json
-rozenite agent @my-org/my-rozenite-plugin tools --session <sessionId> --json
-rozenite agent @my-org/my-rozenite-plugin call --tool echo --args '{"value":"hello"}' --session <sessionId> --json
+rozenite agent my-rozenite tools --session <sessionId> --json
+rozenite agent my-rozenite call --tool echo --args '{"value":"hello"}' --session <sessionId> --json
 ```
 
-The domain slug is derived from your `pluginId`. Document your plugin’s agent tools (names, arguments, and return shapes) so agent users know what they can call.
+Rozenite derives a short, stable domain name from your `pluginId` alone (for example, `@my-org/my-rozenite-plugin` becomes `my-org/my-rozenite`; an official `@rozenite/*` plugin drops the scope entirely, e.g. `@rozenite/mmkv-plugin` becomes `mmkv`). The full `pluginId` always works as a domain token too, so `rozenite agent @my-org/my-rozenite-plugin tools ...` is equally valid — the derived name is just shorter and computable by an agent without a lookup. Document your plugin’s agent tools (names, arguments, and return shapes) so agent users know what they can call.
 
 ## Summary
 


### PR DESCRIPTION
## Summary

Closes #319.

Plugin domain tokens in `rozenite agent` were mangled npm package names (`@rozenite/mmkv-plugin` → `at-rozenite__mmkv-plugin`, with an 8-char sha1 suffix on collision). These were long, unreadable, and not derivable by an agent from the package name alone.

- Replaced `encodePluginDomainSlug`/`getCollisionHash` with `deriveDomainName` (`packages/agent-sdk/src/domain-utils.ts`) — a pure function of the plugin's package name alone, per the rules in the issue:
  - built-in domains unchanged
  - `@rozenite/<name>` → `reduce(name)` (e.g. `mmkv`)
  - `@scope/<name>` → `scope/reduce(name)` (e.g. `avasapp/ably`)
  - unscoped → verbatim
  - empty/generic residue (`plugin`, `devtool`, `devtools`) → falls back to the scope
  - result colliding with a built-in name → falls back to the full package name
- `buildRuntimePluginDomains` now **errors** instead of silently renaming when two packages would derive the same domain name (same-author ambiguity, or an unscoped package literally named after a built-in domain) — keeps the "never rename based on what else is installed" invariant absolute.
- Added `RESERVED_DOMAIN_NAMES` to `packages/agent-sdk/src/constants.ts`.
- `resolveDomainToken` stays tolerant: the new short id, the `rozenite/<name>` alias, the full pluginId, and the deprecated pre-#319 mangled slug (kept as an undocumented compatibility alias for one release cycle, per the issue's compatibility decision) all resolve to the same domain.
- `rankDomainSuggestions` updated to consider the new short form.
- Updated `packages/cli/skills/rozenite-agent/SKILL.md`, `rozenite-agent-sdk/SKILL.md`, and `domains/*.md` to the new short tokens, and documented the provenance-by-shape convention (bare word = built-in/official, `scope/name` = third-party scoped, verbatim `rozenite-*` = third-party unscoped).

## Test plan

- [x] Unit tests in `packages/agent-sdk/src/__tests__/domain-utils.test.ts`: all 22 real `plugin-directory.json` packages, rival-cannot-rename, built-in shadowing (scoped and unscoped), generic-residue fallback, same-author ambiguity, build-time assertion against the real plugin directory, `resolveDomainToken` tolerance including the deprecated legacy alias — 21/21 passing.
- [x] `tsc --noEmit` clean for `packages/agent-sdk`.
- [x] Two rounds of independent code review against the issue text; one real gap found and fixed (unscoped package literally named after a built-in domain wasn't actually guarded).
- [x] Rebuilt the workspace via `turbo build` and verified live against a running Android emulator (Pixel 10) running the `apps/playground` app with 13 registered Rozenite plugins: `rozenite agent domains` now lists all plugin domains with the new short names (`storage`, `sqlite`, `file-system`, `controls`, `network-activity`, `react-navigation`, `redux-devtools`, `tanstack-query`) instead of the old mangled tokens, and live tool calls (`console.getMessages`, `storage.list-storages`) round-tripped real data from the device.