### PR TITLE
ci(cli): run the CLI test suite in CI

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "build": "vite build",
     "typecheck": "tsc -p tsconfig.lib.json --noEmit",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "vitest --run --passWithNoTests"
   },
   "files": [
     "dist",

--- a/packages/cli/src/__tests__/agent-command-output.test.ts
+++ b/packages/cli/src/__tests__/agent-command-output.test.ts
@@ -91,7 +91,7 @@ describe('agent command output', () => {
       '{"items":[{"id":"device-1","name":"iPhone"}]}\n',
     );
     expect(mocks.createAgentClient).toHaveBeenCalledWith({
-      host: 'localhost',
+      host: '127.0.0.1',
       port: 8081,
     });
   });
@@ -131,7 +131,7 @@ describe('agent command output', () => {
     mocks.transport.createSession.mockResolvedValue({
       session: {
         id: 'device-1',
-        host: 'localhost',
+        host: '127.0.0.1',
         port: 8081,
         deviceId: 'device-1',
         deviceName: 'iPhone',
@@ -172,7 +172,7 @@ describe('agent command output', () => {
     mocks.transport.createSession.mockResolvedValue({
       session: {
         id: 'device-1',
-        host: 'localhost',
+        host: '127.0.0.1',
         port: 8081,
         deviceId: 'device-1',
         deviceName: 'iPhone',
@@ -212,7 +212,7 @@ describe('agent command output', () => {
     mocks.transport.createSession.mockResolvedValue({
       session: {
         id: 'device-1',
-        host: 'localhost',
+        host: '127.0.0.1',
         port: 8081,
         deviceId: 'device-1',
         deviceName: 'iPhone',

--- a/packages/cli/src/__tests__/config-wrapper.test.ts
+++ b/packages/cli/src/__tests__/config-wrapper.test.ts
@@ -261,7 +261,7 @@ describe('wrapConfigFile', () => {
           "const { withRozenite } = require('@rozenite/metro');"
         );
         expect(wrappedContent).toContain(
-          'withRozenite(getDefaultConfig(__dirname))'
+          "withRozenite(getDefaultConfig(__dirname), { enabled: process.env.WITH_ROZENITE === 'true' })"
         );
         expect(validateJavaScript(wrappedContent)).toBe(true);
       });
@@ -333,7 +333,7 @@ describe('wrapConfigFile', () => {
           "import { withRozenite } from '@rozenite/metro';"
         );
         expect(wrappedContent).toContain(
-          'export default withRozenite(getDefaultConfig(__dirname))'
+          "export default withRozenite(getDefaultConfig(__dirname), { enabled: process.env.WITH_ROZENITE === 'true' })"
         );
         expect(validateJavaScript(wrappedContent)).toBe(true);
       });
@@ -405,7 +405,7 @@ describe('wrapConfigFile', () => {
           "const { withRozenite } = require('@rozenite/repack');"
         );
         expect(wrappedContent).toContain(
-          'withRozenite(getDefaultConfig(__dirname))'
+          "withRozenite(getDefaultConfig(__dirname), { enabled: process.env.WITH_ROZENITE === 'true' })"
         );
         expect(validateJavaScript(wrappedContent)).toBe(true);
       });
@@ -459,7 +459,7 @@ describe('wrapConfigFile', () => {
           "import { withRozenite } from '@rozenite/repack';"
         );
         expect(wrappedContent).toContain(
-          'export default withRozenite(getDefaultConfig(process.cwd()))'
+          "export default withRozenite(getDefaultConfig(process.cwd()), { enabled: process.env.WITH_ROZENITE === 'true' })"
         );
         expect(validateJavaScript(wrappedContent)).toBe(true);
       });
@@ -727,7 +727,7 @@ export default getDefaultConfig(__dirname);`;
         "import { withRozenite } from '@rozenite/metro';"
       );
       expect(wrappedContent).toContain(
-        'export default withRozenite(getDefaultConfig(__dirname))'
+        "export default withRozenite(getDefaultConfig(__dirname), { enabled: process.env.WITH_ROZENITE === 'true' })"
       );
       expect(validateJavaScript(wrappedContent)).toBe(true);
     });


### PR DESCRIPTION
## Description

`packages/cli` had no `test` script, so `pnpm turbo run typecheck build lint test --affected` in CI resolved its test task to nothing (`rozenite#test -> <NONEXISTENT>`) and its 10 test files never ran.

This adds the missing script and fixes the six stale expectations that had accumulated behind the gap:

- **5 in `config-wrapper.test.ts`** — `427c1515` (`feat(cli): add 'enabled' when wrapping config (#108)`) intentionally started emitting `{ enabled: process.env.WITH_ROZENITE === 'true' }`, and touched only the implementation.
- **1 in `agent-command-output.test.ts`** — `7b00844e` (`fix: align agent websocket origin (#307)`) changed `DEFAULT_AGENT_HOST` from `localhost` to `127.0.0.1`, updating `packages/middleware`'s tests but not this one.

In both cases the implementation is correct and the test was stale, so the expectations were updated rather than the code.

## Related Issue

Closes #330

## Context

The stale-test fixes come first, as separate commits, so the suite is green before it is switched on — otherwise this lands a red build.

`turbo.json` needs no change: its generic `test` task already declares `dependsOn: ["^build", "build"]`, the same dependency shape `typecheck` needs to build workspace deps first.

Worth landing before #322, which adds a substantial number of CLI tests that would otherwise also not run.

Two notes for the reviewer:

- No version plan. This is test and CI configuration only — no publishable package behavior changes.
- #330 lists four other task/package pairs that also silently resolve to nothing, including `@rozenite/agent-bridge#test`, which has a real test file CI has never executed. Those are left for a follow-up rather than widened into this PR.

## Testing

- `npx turbo run typecheck lint test --force` across the whole repo: **100 successful, 100 total**, with `rozenite#test` now present and passing 73 tests across 10 files.
- Confirmed `npx turbo run test --filter=rozenite --dry=json` reports `rozenite#test -> vitest --run --passWithNoTests` instead of `<NONEXISTENT>`.
- Verified each stale-test root cause with `git show --stat` on the two originating commits, to confirm the implementation was intentional and the test was simply never updated.