### PR TITLE
feat: enable pnpm global virtual store

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,8 @@ packages:
   - apps/*
   - website
 
+enableGlobalVirtualStore: true
+
 catalog:
   react: "19.2.3"
   react-dom: "19.2.3"


### PR DESCRIPTION
## Description

Enables pnpm's global virtual store for the workspace. New worktrees with matching dependency graphs can reuse the shared virtual dependency graph instead of creating a separate one.

This reduces the disk space and bootstrapping time needed to set up an additional worktree while preserving the monorepo's existing workspace layout.

## Related Issue

Closes #336

## Context

The setting is enabled in `pnpm-workspace.yaml`, as required for project installs. pnpm currently marks the feature experimental, so this focused change validates the repository's install, build, Metro, and iOS playground workflow before broader adoption.

## Testing

- `pnpm install`
- `pnpm build:all` (29/29 tasks successful)
- Started Metro from `apps/playground` on port 8081
- Verified the already-installed iPhone 17 Pro playground app connected and bundled successfully from the isolated worktree