### PR TITLE
feat(plugin-bridge): add RPC layer with delivery guarantees

### DIFF
--- a/.changeset/rpc-abstraction.md
+++ b/.changeset/rpc-abstraction.md
@@ -1,0 +1,8 @@
+---
+'@rozenite/plugin-bridge': minor
+---
+
+Add `createRozeniteRpc` to `@rozenite/plugin-bridge` — a request/response RPC
+layer on top of `RozeniteDevToolsClient` with acknowledgement, heartbeats,
+timeouts, retries, cancellation, and a typed error union
+(`RozeniteProtocolError` / `RozeniteHandlerError`).

--- a/packages/plugin-bridge/package.json
+++ b/packages/plugin-bridge/package.json
@@ -3,6 +3,7 @@
   "version": "1.13.0",
   "description": "Communication layer for React Native DevTools plugins across React Native and web environments",
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/plugin-bridge/src/index.ts
+++ b/packages/plugin-bridge/src/index.ts
@@ -4,3 +4,21 @@ export type { Subscription } from './types';
 export type { UseRozeniteDevToolsClientOptions } from './useRozeniteDevToolsClient';
 export { getRozeniteDevToolsClient } from './client';
 export { UnsupportedPlatformError, MissingRozeniteForWebError } from './errors';
+export { createRozeniteRpc } from './rpc/index.js';
+export {
+  isProtocolError,
+  isHandlerError,
+  RozeniteProtocolError,
+  RozeniteHandlerError,
+  ROZENITE_RPC_MESSAGE_TYPE,
+} from './rpc/index.js';
+export type {
+  ProtocolErrorCode,
+  RemoteErrorInfo,
+  RozeniteRpcError,
+  InvokeOptions,
+  InvokeArgs,
+  RozeniteRpc,
+  RpcContext,
+  RpcMethods,
+} from './rpc/index.js';

--- a/packages/plugin-bridge/src/index.ts
+++ b/packages/plugin-bridge/src/index.ts
@@ -17,8 +17,9 @@ export type {
   RemoteErrorInfo,
   RozeniteRpcError,
   InvokeOptions,
-  InvokeArgs,
+  InvokeParams,
   RozeniteRpc,
   RpcContext,
   RpcMethods,
+  RpcMethodHandle,
 } from './rpc/index.js';

--- a/packages/plugin-bridge/src/rpc/create-rozenite-rpc.test.ts
+++ b/packages/plugin-bridge/src/rpc/create-rozenite-rpc.test.ts
@@ -1,0 +1,418 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRozeniteRpc } from './create-rozenite-rpc.js';
+import { isHandlerError, isProtocolError } from './errors.js';
+import type { RozeniteHandlerError, RozeniteProtocolError } from './errors.js';
+import { ROZENITE_RPC_MESSAGE_TYPE } from './frames.js';
+import { RozeniteRpc } from './types.js';
+import { createFakeClientPair } from './test-utils.js';
+
+// The behavior tests below intentionally use a loose method map — they
+// exercise runtime protocol behavior, which doesn't depend on the static
+// method-map typing. Compile-time inference (arg count per method, unknown
+// method names) is covered separately in `rpc-types.test.ts`.
+type AnyMethods = Record<string, (...args: any[]) => any>;
+
+// `AnyMethods` gives every method the same signature, so `InvokeArgs`
+// always picks the "params required" branch — fine for the calls in this
+// file that pass params, but too strict for the zero-arg calls we also want
+// to exercise (`invoke('ping')`). Route those through this untyped helper
+// instead of fighting the type system for a runtime-behavior test.
+const invokeLoose = (
+  rpc: RozeniteRpc<AnyMethods>,
+  method: string,
+  ...args: unknown[]
+): Promise<unknown> =>
+  (rpc.invoke as (...a: unknown[]) => Promise<unknown>)(method, ...args);
+
+const requestFramesOf = (sendMock: {
+  mock: { calls: unknown[][] };
+}): { id: string; method: string }[] =>
+  sendMock.mock.calls
+    .filter(([type]) => type === ROZENITE_RPC_MESSAGE_TYPE)
+    .map(([, frame]) => frame as { kind: string; id: string; method: string })
+    .filter((frame) => frame.kind === 'request');
+
+describe('createRozeniteRpc', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('reserves rozenite:rpc as its message type', () => {
+    expect(ROZENITE_RPC_MESSAGE_TYPE).toBe('rozenite:rpc');
+  });
+
+  it('happy path: resolves with the handler result', async () => {
+    const { clientA, clientB } = createFakeClientPair();
+    const rpcA = createRozeniteRpc<AnyMethods>(clientA);
+    const rpcB = createRozeniteRpc<AnyMethods>(clientB);
+
+    rpcB.handle('getUser', async ({ id }: { id: string }) => ({
+      id,
+      name: 'Ada',
+    }));
+
+    const result = await rpcA.invoke('getUser', { id: '42' });
+
+    expect(result).toEqual({ id: '42', name: 'Ada' });
+  });
+
+  it('invoke("name") works for zero-arg methods', async () => {
+    const { clientA, clientB } = createFakeClientPair();
+    const rpcA = createRozeniteRpc<AnyMethods>(clientA);
+    const rpcB = createRozeniteRpc<AnyMethods>(clientB);
+
+    rpcB.handle('ping', async () => 'pong');
+
+    await expect(invokeLoose(rpcA, 'ping')).resolves.toBe('pong');
+  });
+
+  it('invoke("name", { options }) applies options for a zero-arg method', async () => {
+    const { clientA, clientB } = createFakeClientPair();
+    const rpcA = createRozeniteRpc<AnyMethods>(clientA);
+    const rpcB = createRozeniteRpc<AnyMethods>(clientB);
+
+    let receivedParams: unknown = 'not-called';
+    rpcB.handle('ping', async (params: unknown) => {
+      receivedParams = params;
+      return 'pong';
+    });
+
+    await rpcA.invoke('ping', { timeoutMs: 15_000 });
+
+    // The single trailing argument was recognized as `options`, not `params`.
+    expect(receivedParams).toBeUndefined();
+  });
+
+  it('rejects with METHOD_NOT_FOUND for an unregistered method', async () => {
+    const { clientA, clientB } = createFakeClientPair();
+    const rpcA = createRozeniteRpc<AnyMethods>(clientA);
+    createRozeniteRpc<AnyMethods>(clientB); // listening, but nothing registered
+
+    const error = (await invokeLoose(rpcA, 'missing').catch(
+      (e) => e,
+    )) as RozeniteProtocolError;
+
+    expect(isProtocolError(error)).toBe(true);
+    expect(error.code).toBe('METHOD_NOT_FOUND');
+    expect(error.method).toBe('missing');
+  });
+
+  it('ACK_TIMEOUT without retry when nobody is listening', async () => {
+    const { clientA } = createFakeClientPair(); // no peer rpc instance at all
+
+    const rpcA = createRozeniteRpc<AnyMethods>(clientA);
+    const promise = rpcA.invoke('ping', undefined, {
+      ackTimeoutMs: 1_000,
+      retries: 0,
+    });
+    const errorPromise = promise.catch((e) => e);
+
+    await vi.advanceTimersByTimeAsync(1_100);
+
+    const error = (await errorPromise) as RozeniteProtocolError;
+    expect(isProtocolError(error)).toBe(true);
+    expect(error.code).toBe('ACK_TIMEOUT');
+    expect(requestFramesOf(clientA.send as never)).toHaveLength(1);
+  });
+
+  it('ACK_TIMEOUT retries once by default, using a fresh id', async () => {
+    const { clientA } = createFakeClientPair();
+
+    const rpcA = createRozeniteRpc<AnyMethods>(clientA);
+    const promise = rpcA.invoke('ping', undefined, { ackTimeoutMs: 1_000 });
+    const errorPromise = promise.catch((e) => e);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(requestFramesOf(clientA.send as never)).toHaveLength(2);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    const error = (await errorPromise) as RozeniteProtocolError;
+    expect(error.code).toBe('ACK_TIMEOUT');
+
+    const frames = requestFramesOf(clientA.send as never);
+    expect(frames).toHaveLength(2);
+    expect(frames[0].id).not.toBe(frames[1].id);
+  });
+
+  it('STALLED after missed heartbeats', async () => {
+    const { clientA, clientB, dropBtoA } = createFakeClientPair();
+    const rpcA = createRozeniteRpc<AnyMethods>(clientA);
+    const rpcB = createRozeniteRpc<AnyMethods>(clientB);
+
+    rpcB.handle('slow', () => new Promise(() => {})); // never resolves
+
+    const promise = rpcA.invoke('slow', undefined, {
+      staleTimeoutMs: 3_000,
+      heartbeatMs: 1_000,
+      timeoutMs: 60_000,
+    });
+    const errorPromise = promise.catch((e) => e);
+
+    // Let the ack through, then go dark.
+    await vi.advanceTimersByTimeAsync(0);
+    dropBtoA(true);
+
+    await vi.advanceTimersByTimeAsync(3_100);
+
+    const error = (await errorPromise) as RozeniteProtocolError;
+    expect(isProtocolError(error)).toBe(true);
+    expect(error.code).toBe('STALLED');
+  });
+
+  it('TIMEOUT on a never-resolving handler that keeps heartbeating', async () => {
+    const { clientA, clientB } = createFakeClientPair();
+    const rpcA = createRozeniteRpc<AnyMethods>(clientA);
+    const rpcB = createRozeniteRpc<AnyMethods>(clientB);
+
+    rpcB.handle('never', () => new Promise(() => {}));
+
+    const promise = rpcA.invoke('never', undefined, {
+      timeoutMs: 5_000,
+      heartbeatMs: 1_000,
+      staleTimeoutMs: 3_000,
+    });
+    const errorPromise = promise.catch((e) => e);
+
+    // Heartbeats every 1s keep staleTimeoutMs (3s) from tripping, but the
+    // absolute cap (5s) still fires.
+    await vi.advanceTimersByTimeAsync(5_100);
+
+    const error = (await errorPromise) as RozeniteProtocolError;
+    expect(isProtocolError(error)).toBe(true);
+    expect(error.code).toBe('TIMEOUT');
+  });
+
+  it('a slow-but-heartbeating handler does not trip staleTimeoutMs', async () => {
+    const { clientA, clientB } = createFakeClientPair();
+    const rpcA = createRozeniteRpc<AnyMethods>(clientA);
+    const rpcB = createRozeniteRpc<AnyMethods>(clientB);
+
+    let resolveHandler: (value: string) => void = () => {};
+    rpcB.handle(
+      'slow',
+      () =>
+        new Promise<string>((resolve) => {
+          resolveHandler = resolve;
+        }),
+    );
+
+    const promise = rpcA.invoke('slow', undefined, {
+      staleTimeoutMs: 3_000,
+      heartbeatMs: 1_000,
+      timeoutMs: 60_000,
+    });
+
+    // Elapse well past staleTimeoutMs, in increments, while heartbeats keep
+    // arriving and resetting the stale timer.
+    for (let i = 0; i < 5; i++) {
+      await vi.advanceTimersByTimeAsync(1_000);
+    }
+
+    resolveHandler('done');
+    await vi.advanceTimersByTimeAsync(0);
+
+    await expect(promise).resolves.toBe('done');
+  });
+
+  it('caller AbortSignal cancels the call and aborts ctx.signal', async () => {
+    const { clientA, clientB } = createFakeClientPair();
+    const rpcA = createRozeniteRpc<AnyMethods>(clientA);
+    const rpcB = createRozeniteRpc<AnyMethods>(clientB);
+
+    let handlerAborted = false;
+    rpcB.handle('longRunning', (_params: unknown, ctx) => {
+      ctx.signal.addEventListener('abort', () => {
+        handlerAborted = true;
+      });
+      return new Promise(() => {});
+    });
+
+    const controller = new AbortController();
+    const promise = rpcA.invoke('longRunning', undefined, {
+      signal: controller.signal,
+    });
+    const errorPromise = promise.catch((e) => e);
+
+    await vi.advanceTimersByTimeAsync(0); // flush request + ack
+
+    controller.abort();
+    await vi.advanceTimersByTimeAsync(0); // flush cancel frame
+
+    const error = (await errorPromise) as RozeniteProtocolError;
+    expect(isProtocolError(error)).toBe(true);
+    expect(error.code).toBe('CANCELLED');
+    expect(handlerAborted).toBe(true);
+  });
+
+  it('drops a late result that arrives after cancellation', async () => {
+    const { clientA, clientB } = createFakeClientPair();
+    const rpcA = createRozeniteRpc<AnyMethods>(clientA);
+    const rpcB = createRozeniteRpc<AnyMethods>(clientB);
+
+    let resolveHandler: (value: string) => void = () => {};
+    rpcB.handle(
+      'op',
+      () =>
+        new Promise<string>((resolve) => {
+          resolveHandler = resolve;
+        }),
+    );
+
+    const controller = new AbortController();
+    const promise = rpcA.invoke('op', undefined, {
+      signal: controller.signal,
+    });
+    const errorPromise = promise.catch((e) => e);
+
+    await vi.advanceTimersByTimeAsync(0);
+    controller.abort();
+    await vi.advanceTimersByTimeAsync(0);
+
+    const error = (await errorPromise) as RozeniteProtocolError;
+    expect(error.code).toBe('CANCELLED');
+
+    const sendCallsBefore = (
+      clientB.send as unknown as { mock: { calls: unknown[] } }
+    ).mock.calls.length;
+
+    // The handler settles well after the caller gave up. It must be
+    // silently discarded — no frame is sent for it, and nothing throws.
+    resolveHandler('too late');
+    await vi.advanceTimersByTimeAsync(0);
+
+    const sendCallsAfter = (
+      clientB.send as unknown as { mock: { calls: unknown[] } }
+    ).mock.calls.length;
+    expect(sendCallsAfter).toBe(sendCallsBefore);
+  });
+
+  it('propagates the handler error name and message', async () => {
+    const { clientA, clientB } = createFakeClientPair();
+    const rpcA = createRozeniteRpc<AnyMethods>(clientA);
+    const rpcB = createRozeniteRpc<AnyMethods>(clientB);
+
+    rpcB.handle('boom', () => {
+      throw new TypeError('bad input');
+    });
+
+    const error = (await invokeLoose(rpcA, 'boom').catch(
+      (e) => e,
+    )) as RozeniteHandlerError;
+
+    expect(isHandlerError(error)).toBe(true);
+    expect(error.remote.name).toBe('TypeError');
+    expect(error.remote.message).toBe('bad input');
+    expect(error.message).toBe('boom failed: bad input');
+    expect(error.method).toBe('boom');
+  });
+
+  it('attaches remote.stack only in development', async () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+    try {
+      const { clientA, clientB } = createFakeClientPair();
+      const rpcA = createRozeniteRpc<AnyMethods>(clientA);
+      const rpcB = createRozeniteRpc<AnyMethods>(clientB);
+      rpcB.handle('boom', () => {
+        throw new Error('dev stack check');
+      });
+
+      process.env.NODE_ENV = 'development';
+      const devError = (await invokeLoose(rpcA, 'boom').catch(
+        (e) => e,
+      )) as RozeniteHandlerError;
+      expect(devError.remote.stack).toBeTypeOf('string');
+    } finally {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+  });
+
+  it('omits remote.stack in production', async () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+    try {
+      const { clientA, clientB } = createFakeClientPair();
+      const rpcA = createRozeniteRpc<AnyMethods>(clientA);
+      const rpcB = createRozeniteRpc<AnyMethods>(clientB);
+      rpcB.handle('boom', () => {
+        throw new Error('prod stack check');
+      });
+
+      process.env.NODE_ENV = 'production';
+      const prodError = (await invokeLoose(rpcA, 'boom').catch(
+        (e) => e,
+      )) as RozeniteHandlerError;
+      expect(prodError.remote.stack).toBeUndefined();
+    } finally {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+  });
+
+  it('turns a non-cloneable result into SERIALIZATION_ERROR', async () => {
+    const { clientA, clientB } = createFakeClientPair();
+    const rpcA = createRozeniteRpc<AnyMethods>(clientA);
+    const rpcB = createRozeniteRpc<AnyMethods>(clientB);
+
+    rpcB.handle('badResult', () => ({ fn: () => 'not cloneable' }));
+
+    const error = (await invokeLoose(rpcA, 'badResult').catch(
+      (e) => e,
+    )) as RozeniteProtocolError;
+
+    expect(isProtocolError(error)).toBe(true);
+    expect(error.code).toBe('SERIALIZATION_ERROR');
+  });
+
+  it('close() rejects in-flight calls with CLIENT_CLOSED', async () => {
+    const { clientA, clientB } = createFakeClientPair();
+    const rpcA = createRozeniteRpc<AnyMethods>(clientA);
+    const rpcB = createRozeniteRpc<AnyMethods>(clientB);
+
+    rpcB.handle('op', () => new Promise(() => {}));
+
+    const promise = invokeLoose(rpcA, 'op');
+    const errorPromise = promise.catch((e) => e);
+    await vi.advanceTimersByTimeAsync(0); // flush ack
+
+    rpcA.close();
+
+    const error = (await errorPromise) as RozeniteProtocolError;
+    expect(isProtocolError(error)).toBe(true);
+    expect(error.code).toBe('CLIENT_CLOSED');
+  });
+
+  it('throws when registering a second handler for the same method', () => {
+    const { clientB } = createFakeClientPair();
+    const rpcB = createRozeniteRpc<AnyMethods>(clientB);
+
+    rpcB.handle('x', () => 'ok');
+
+    expect(() => rpcB.handle('x', () => 'ok2')).toThrow();
+  });
+
+  it('delivers ctx.progress() values via onProgress', async () => {
+    const { clientA, clientB } = createFakeClientPair();
+    const rpcA = createRozeniteRpc<AnyMethods>(clientA);
+    const rpcB = createRozeniteRpc<AnyMethods>(clientB);
+
+    rpcB.handle('withProgress', (_params: unknown, ctx) => {
+      ctx.progress(50);
+      return new Promise((resolve) => {
+        setTimeout(() => resolve('done'), 2_000);
+      });
+    });
+
+    const progressValues: unknown[] = [];
+    const promise = rpcA.invoke('withProgress', undefined, {
+      heartbeatMs: 1_000,
+      onProgress: (value) => progressValues.push(value),
+    });
+
+    await vi.advanceTimersByTimeAsync(2_100);
+
+    await expect(promise).resolves.toBe('done');
+    expect(progressValues).toContain(50);
+  });
+});

--- a/packages/plugin-bridge/src/rpc/create-rozenite-rpc.test.ts
+++ b/packages/plugin-bridge/src/rpc/create-rozenite-rpc.test.ts
@@ -3,7 +3,7 @@ import { createRozeniteRpc } from './create-rozenite-rpc.js';
 import { isHandlerError, isProtocolError } from './errors.js';
 import type { RozeniteHandlerError, RozeniteProtocolError } from './errors.js';
 import { ROZENITE_RPC_MESSAGE_TYPE } from './frames.js';
-import { RozeniteRpc } from './types.js';
+import { InvokeOptions, RozeniteRpc } from './types.js';
 import { createFakeClientPair } from './test-utils.js';
 
 // The behavior tests below intentionally use a loose method map — they
@@ -12,17 +12,23 @@ import { createFakeClientPair } from './test-utils.js';
 // method names) is covered separately in `rpc-types.test.ts`.
 type AnyMethods = Record<string, (...args: any[]) => any>;
 
-// `AnyMethods` gives every method the same signature, so `InvokeArgs`
-// always picks the "params required" branch — fine for the calls in this
-// file that pass params, but too strict for the zero-arg calls we also want
-// to exercise (`invoke('ping')`). Route those through this untyped helper
-// instead of fighting the type system for a runtime-behavior test.
+// `AnyMethods` gives every method the same `(...args: any[]) => any)`
+// signature, so `InvokeParams` always picks the "params required" branch —
+// fine for calls that pass params, but too strict for the zero-arg calls we
+// also want to exercise (`method('ping').invoke()`). Route those through
+// this untyped helper instead of fighting the type system for a
+// runtime-behavior test.
 const invokeLoose = (
   rpc: RozeniteRpc<AnyMethods>,
-  method: string,
-  ...args: unknown[]
+  methodName: string,
+  options?: InvokeOptions,
+  ...params: unknown[]
 ): Promise<unknown> =>
-  (rpc.invoke as (...a: unknown[]) => Promise<unknown>)(method, ...args);
+  (
+    rpc.method(methodName, options) as unknown as {
+      invoke: (...a: unknown[]) => Promise<unknown>;
+    }
+  ).invoke(...params);
 
 const requestFramesOf = (sendMock: {
   mock: { calls: unknown[][] };
@@ -55,12 +61,12 @@ describe('createRozeniteRpc', () => {
       name: 'Ada',
     }));
 
-    const result = await rpcA.invoke('getUser', { id: '42' });
+    const result = await invokeLoose(rpcA, 'getUser', undefined, { id: '42' });
 
     expect(result).toEqual({ id: '42', name: 'Ada' });
   });
 
-  it('invoke("name") works for zero-arg methods', async () => {
+  it('method("name").invoke() works for zero-arg methods', async () => {
     const { clientA, clientB } = createFakeClientPair();
     const rpcA = createRozeniteRpc<AnyMethods>(clientA);
     const rpcB = createRozeniteRpc<AnyMethods>(clientB);
@@ -70,7 +76,7 @@ describe('createRozeniteRpc', () => {
     await expect(invokeLoose(rpcA, 'ping')).resolves.toBe('pong');
   });
 
-  it('invoke("name", { options }) applies options for a zero-arg method', async () => {
+  it('options passed to method() apply to the call, independent of params', async () => {
     const { clientA, clientB } = createFakeClientPair();
     const rpcA = createRozeniteRpc<AnyMethods>(clientA);
     const rpcB = createRozeniteRpc<AnyMethods>(clientB);
@@ -81,10 +87,21 @@ describe('createRozeniteRpc', () => {
       return 'pong';
     });
 
-    await rpcA.invoke('ping', { timeoutMs: 15_000 });
+    await invokeLoose(rpcA, 'ping', { timeoutMs: 15_000 });
 
-    // The single trailing argument was recognized as `options`, not `params`.
     expect(receivedParams).toBeUndefined();
+  });
+
+  it('a handle can be reused across multiple invoke() calls', async () => {
+    const { clientA, clientB } = createFakeClientPair();
+    const rpcA = createRozeniteRpc<AnyMethods>(clientA);
+    const rpcB = createRozeniteRpc<AnyMethods>(clientB);
+
+    rpcB.handle('echo', async (params: unknown) => params);
+
+    const echo = rpcA.method('echo', { timeoutMs: 15_000 });
+    await expect(echo.invoke('a')).resolves.toBe('a');
+    await expect(echo.invoke('b')).resolves.toBe('b');
   });
 
   it('rejects with METHOD_NOT_FOUND for an unregistered method', async () => {
@@ -105,7 +122,7 @@ describe('createRozeniteRpc', () => {
     const { clientA } = createFakeClientPair(); // no peer rpc instance at all
 
     const rpcA = createRozeniteRpc<AnyMethods>(clientA);
-    const promise = rpcA.invoke('ping', undefined, {
+    const promise = invokeLoose(rpcA, 'ping', {
       ackTimeoutMs: 1_000,
       retries: 0,
     });
@@ -123,7 +140,7 @@ describe('createRozeniteRpc', () => {
     const { clientA } = createFakeClientPair();
 
     const rpcA = createRozeniteRpc<AnyMethods>(clientA);
-    const promise = rpcA.invoke('ping', undefined, { ackTimeoutMs: 1_000 });
+    const promise = invokeLoose(rpcA, 'ping', { ackTimeoutMs: 1_000 });
     const errorPromise = promise.catch((e) => e);
 
     await vi.advanceTimersByTimeAsync(1_000);
@@ -145,7 +162,7 @@ describe('createRozeniteRpc', () => {
 
     rpcB.handle('slow', () => new Promise(() => {})); // never resolves
 
-    const promise = rpcA.invoke('slow', undefined, {
+    const promise = invokeLoose(rpcA, 'slow', {
       staleTimeoutMs: 3_000,
       heartbeatMs: 1_000,
       timeoutMs: 60_000,
@@ -170,7 +187,7 @@ describe('createRozeniteRpc', () => {
 
     rpcB.handle('never', () => new Promise(() => {}));
 
-    const promise = rpcA.invoke('never', undefined, {
+    const promise = invokeLoose(rpcA, 'never', {
       timeoutMs: 5_000,
       heartbeatMs: 1_000,
       staleTimeoutMs: 3_000,
@@ -200,7 +217,7 @@ describe('createRozeniteRpc', () => {
         }),
     );
 
-    const promise = rpcA.invoke('slow', undefined, {
+    const promise = invokeLoose(rpcA, 'slow', {
       staleTimeoutMs: 3_000,
       heartbeatMs: 1_000,
       timeoutMs: 60_000,
@@ -232,7 +249,7 @@ describe('createRozeniteRpc', () => {
     });
 
     const controller = new AbortController();
-    const promise = rpcA.invoke('longRunning', undefined, {
+    const promise = invokeLoose(rpcA, 'longRunning', {
       signal: controller.signal,
     });
     const errorPromise = promise.catch((e) => e);
@@ -263,9 +280,7 @@ describe('createRozeniteRpc', () => {
     );
 
     const controller = new AbortController();
-    const promise = rpcA.invoke('op', undefined, {
-      signal: controller.signal,
-    });
+    const promise = invokeLoose(rpcA, 'op', { signal: controller.signal });
     const errorPromise = promise.catch((e) => e);
 
     await vi.advanceTimersByTimeAsync(0);
@@ -390,29 +405,5 @@ describe('createRozeniteRpc', () => {
     rpcB.handle('x', () => 'ok');
 
     expect(() => rpcB.handle('x', () => 'ok2')).toThrow();
-  });
-
-  it('delivers ctx.progress() values via onProgress', async () => {
-    const { clientA, clientB } = createFakeClientPair();
-    const rpcA = createRozeniteRpc<AnyMethods>(clientA);
-    const rpcB = createRozeniteRpc<AnyMethods>(clientB);
-
-    rpcB.handle('withProgress', (_params: unknown, ctx) => {
-      ctx.progress(50);
-      return new Promise((resolve) => {
-        setTimeout(() => resolve('done'), 2_000);
-      });
-    });
-
-    const progressValues: unknown[] = [];
-    const promise = rpcA.invoke('withProgress', undefined, {
-      heartbeatMs: 1_000,
-      onProgress: (value) => progressValues.push(value),
-    });
-
-    await vi.advanceTimersByTimeAsync(2_100);
-
-    await expect(promise).resolves.toBe('done');
-    expect(progressValues).toContain(50);
   });
 });

--- a/packages/plugin-bridge/src/rpc/create-rozenite-rpc.ts
+++ b/packages/plugin-bridge/src/rpc/create-rozenite-rpc.ts
@@ -1,0 +1,549 @@
+import { RozeniteDevToolsClient } from '../client.js';
+import { Subscription } from '../types.js';
+import { isDev } from './dev.js';
+import { RozeniteHandlerError, RozeniteProtocolError } from './errors.js';
+import {
+  AckFrame,
+  CancelFrame,
+  ErrorFrame,
+  HeartbeatFrame,
+  RequestFrame,
+  ResultFrame,
+  ROZENITE_RPC_MESSAGE_TYPE,
+  RpcFrame,
+} from './frames.js';
+import { isCloneable } from './serialization.js';
+import { InvokeOptions, RozeniteRpc, RpcContext, RpcMethods } from './types.js';
+
+const DEFAULT_ACK_TIMEOUT_MS = 5_000;
+const DEFAULT_HEARTBEAT_MS = 2_000;
+const DEFAULT_STALE_TIMEOUT_MS = 6_000;
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_RETRIES = 1;
+
+// Every recognized key of `InvokeOptions`. Used at runtime to tell apart a
+// single trailing `options` argument from a single trailing `params`
+// argument for zero-arg methods — see `invoke` below for why this is
+// necessary.
+const OPTION_KEYS = new Set<string>([
+  'signal',
+  'ackTimeoutMs',
+  'heartbeatMs',
+  'staleTimeoutMs',
+  'timeoutMs',
+  'retries',
+  'onProgress',
+]);
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const looksLikeInvokeOptions = (value: unknown): value is InvokeOptions => {
+  if (!isPlainObject(value)) {
+    return false;
+  }
+  const keys = Object.keys(value);
+  return keys.length === 0 || keys.every((key) => OPTION_KEYS.has(key));
+};
+
+// The client that carries RPC frames. RPC only needs `send`/`onMessage` for
+// a single reserved message type plus `close`, but consumers pass in a
+// `RozeniteDevToolsClient<TEventMap>` scoped to their own plugin event map
+// (which doesn't — and shouldn't — know about `'rozenite:rpc'`). We accept
+// `any` here at the boundary and narrow internally, rather than fighting
+// generic variance on a type the caller doesn't otherwise care about.
+type RpcTransport = RozeniteDevToolsClient<any>;
+
+type PendingCall = {
+  method: string;
+  onAck: () => void;
+  onHeartbeat: (frame: HeartbeatFrame) => void;
+  onResult: (frame: ResultFrame) => void;
+  onError: (frame: ErrorFrame) => void;
+};
+
+type ActiveHandlerCall = {
+  controller: AbortController;
+  interval: ReturnType<typeof setInterval> | null;
+  settled: boolean;
+  discarded: boolean;
+  hasProgress: boolean;
+  latestProgress: unknown;
+};
+
+type NormalizedError = {
+  name: string;
+  message: string;
+  stack?: string;
+  data?: unknown;
+};
+
+const normalizeThrown = (thrown: unknown): NormalizedError => {
+  if (thrown instanceof Error) {
+    const data =
+      'data' in thrown
+        ? (thrown as unknown as { data?: unknown }).data
+        : undefined;
+    return {
+      name: thrown.name,
+      message: thrown.message,
+      stack: isDev() ? thrown.stack : undefined,
+      data,
+    };
+  }
+
+  return {
+    name: 'Error',
+    message: String(thrown),
+    data: thrown,
+  };
+};
+
+const buildErrorFromFrame = (
+  method: string,
+  frame: ErrorFrame,
+): RozeniteProtocolError | RozeniteHandlerError => {
+  if (frame.source === 'protocol') {
+    return new RozeniteProtocolError(method, frame.code, frame.message);
+  }
+
+  return new RozeniteHandlerError(method, {
+    name: frame.name,
+    message: frame.message,
+    stack: frame.stack,
+    data: frame.data,
+  });
+};
+
+/**
+ * Creates a symmetric RPC layer on top of an existing
+ * `RozeniteDevToolsClient`. Both peers (device and panel) can register
+ * handlers and invoke methods on each other.
+ *
+ * Reserves the message type `'rozenite:rpc'` on `client` — a plugin's own
+ * event map must not use that type.
+ */
+export const createRozeniteRpc = <M extends RpcMethods>(
+  client: RpcTransport,
+): RozeniteRpc<M> => {
+  const clientPrefix = Math.random().toString(36).slice(2, 10);
+  let counter = 0;
+  const nextId = () => `${clientPrefix}:${counter++}`;
+
+  const handlers = new Map<
+    string,
+    (params: unknown, ctx: RpcContext) => unknown
+  >();
+  const pending = new Map<string, PendingCall>();
+  const activeCalls = new Map<string, ActiveHandlerCall>();
+  let closed = false;
+
+  const send = (frame: RpcFrame): void => {
+    client.send(ROZENITE_RPC_MESSAGE_TYPE, frame);
+  };
+
+  // --- Receiver side (handling incoming `request`/`cancel` frames) ---
+
+  const settleHandlerCall = (id: string, frame: ErrorFrame | ResultFrame) => {
+    const call = activeCalls.get(id);
+    if (!call || call.settled || call.discarded) {
+      return;
+    }
+    call.settled = true;
+    if (call.interval != null) {
+      clearInterval(call.interval);
+      call.interval = null;
+    }
+    activeCalls.delete(id);
+    send(frame);
+  };
+
+  const handleRequest = (frame: RequestFrame) => {
+    // Ack synchronously, before invoking the handler.
+    send({ kind: 'ack', id: frame.id });
+
+    const handler = handlers.get(frame.method);
+    if (!handler) {
+      send({
+        kind: 'error',
+        id: frame.id,
+        source: 'protocol',
+        code: 'METHOD_NOT_FOUND',
+        message: `No handler registered for method "${frame.method}".`,
+      });
+      return;
+    }
+
+    const controller = new AbortController();
+    const call: ActiveHandlerCall = {
+      controller,
+      interval: null,
+      settled: false,
+      discarded: false,
+      hasProgress: false,
+      latestProgress: undefined,
+    };
+    activeCalls.set(frame.id, call);
+
+    const ctx: RpcContext = {
+      signal: controller.signal,
+      progress: (value: unknown) => {
+        call.hasProgress = true;
+        call.latestProgress = value;
+      },
+    };
+
+    call.interval = setInterval(() => {
+      const heartbeat: HeartbeatFrame = { kind: 'heartbeat', id: frame.id };
+      if (call.hasProgress) {
+        heartbeat.progress = call.latestProgress;
+        call.hasProgress = false;
+      }
+      send(heartbeat);
+    }, frame.heartbeatMs);
+
+    Promise.resolve()
+      .then(() => handler(frame.params, ctx))
+      .then(
+        (value) => {
+          if (!isCloneable(value)) {
+            settleHandlerCall(frame.id, {
+              kind: 'error',
+              id: frame.id,
+              source: 'protocol',
+              code: 'SERIALIZATION_ERROR',
+              message: `Result of "${frame.method}" is not structured-cloneable.`,
+            });
+            return;
+          }
+          settleHandlerCall(frame.id, { kind: 'result', id: frame.id, value });
+        },
+        (thrown) => {
+          const normalized = normalizeThrown(thrown);
+          if (normalized.data !== undefined && !isCloneable(normalized.data)) {
+            settleHandlerCall(frame.id, {
+              kind: 'error',
+              id: frame.id,
+              source: 'protocol',
+              code: 'SERIALIZATION_ERROR',
+              message: `Error data thrown by "${frame.method}" is not structured-cloneable.`,
+            });
+            return;
+          }
+          settleHandlerCall(frame.id, {
+            kind: 'error',
+            id: frame.id,
+            source: 'handler',
+            name: normalized.name,
+            message: normalized.message,
+            stack: normalized.stack,
+            data: normalized.data,
+          });
+        },
+      );
+  };
+
+  const handleCancel = (frame: CancelFrame) => {
+    const call = activeCalls.get(frame.id);
+    if (!call) {
+      return;
+    }
+    call.discarded = true;
+    if (call.interval != null) {
+      clearInterval(call.interval);
+      call.interval = null;
+    }
+    activeCalls.delete(frame.id);
+    call.controller.abort();
+  };
+
+  // --- Caller side (handling incoming `ack`/`heartbeat`/`result`/`error`) ---
+
+  const handleAck = (frame: AckFrame) => pending.get(frame.id)?.onAck();
+  const handleHeartbeat = (frame: HeartbeatFrame) =>
+    pending.get(frame.id)?.onHeartbeat(frame);
+  const handleResult = (frame: ResultFrame) =>
+    pending.get(frame.id)?.onResult(frame);
+  const handleError = (frame: ErrorFrame) =>
+    pending.get(frame.id)?.onError(frame);
+
+  const handleFrame = (frame: RpcFrame) => {
+    switch (frame.kind) {
+      case 'request':
+        return handleRequest(frame);
+      case 'ack':
+        return handleAck(frame);
+      case 'heartbeat':
+        return handleHeartbeat(frame);
+      case 'result':
+        return handleResult(frame);
+      case 'error':
+        return handleError(frame);
+      case 'cancel':
+        return handleCancel(frame);
+    }
+  };
+
+  const subscription: Subscription = client.onMessage(
+    ROZENITE_RPC_MESSAGE_TYPE,
+    (payload: unknown) => handleFrame(payload as RpcFrame),
+  );
+
+  const performInvoke = (
+    method: string,
+    params: unknown,
+    options: InvokeOptions,
+  ): Promise<unknown> => {
+    const ackTimeoutMs = options.ackTimeoutMs ?? DEFAULT_ACK_TIMEOUT_MS;
+    const heartbeatMs = options.heartbeatMs ?? DEFAULT_HEARTBEAT_MS;
+    const staleTimeoutMs = options.staleTimeoutMs ?? DEFAULT_STALE_TIMEOUT_MS;
+    const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const retries = options.retries ?? DEFAULT_RETRIES;
+    const { signal, onProgress } = options;
+
+    return new Promise<unknown>((resolve, reject) => {
+      if (closed) {
+        reject(
+          new RozeniteProtocolError(
+            method,
+            'CLIENT_CLOSED',
+            `Cannot invoke "${method}": the RPC client is closed.`,
+          ),
+        );
+        return;
+      }
+
+      if (signal?.aborted) {
+        reject(
+          new RozeniteProtocolError(
+            method,
+            'CANCELLED',
+            `"${method}" was cancelled before it was sent.`,
+          ),
+        );
+        return;
+      }
+
+      let settled = false;
+      let currentId: string | null = null;
+
+      const finish = (fn: () => void) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        if (signal) {
+          signal.removeEventListener('abort', onAbort);
+        }
+        fn();
+      };
+
+      const onAbort = () => {
+        if (currentId != null) {
+          send({ kind: 'cancel', id: currentId });
+        }
+        cleanupAttempt();
+        finish(() =>
+          reject(
+            new RozeniteProtocolError(
+              method,
+              'CANCELLED',
+              `"${method}" was cancelled.`,
+            ),
+          ),
+        );
+      };
+
+      if (signal) {
+        signal.addEventListener('abort', onAbort);
+      }
+
+      let cleanupAttempt = (): void => {};
+
+      const attempt = (retriesLeft: number) => {
+        const id = nextId();
+        currentId = id;
+
+        let ackTimer: ReturnType<typeof setTimeout> | null = null;
+        let staleTimer: ReturnType<typeof setTimeout> | null = null;
+        let totalTimer: ReturnType<typeof setTimeout> | null = null;
+
+        cleanupAttempt = () => {
+          if (ackTimer != null) clearTimeout(ackTimer);
+          if (staleTimer != null) clearTimeout(staleTimer);
+          if (totalTimer != null) clearTimeout(totalTimer);
+          pending.delete(id);
+        };
+
+        const rearmStale = () => {
+          if (staleTimer != null) {
+            clearTimeout(staleTimer);
+            staleTimer = null;
+          }
+          if (staleTimeoutMs === Infinity) {
+            return;
+          }
+          staleTimer = setTimeout(() => {
+            send({ kind: 'cancel', id });
+            cleanupAttempt();
+            finish(() =>
+              reject(
+                new RozeniteProtocolError(
+                  method,
+                  'STALLED',
+                  `"${method}" stopped responding (no ack/heartbeat within ${staleTimeoutMs}ms).`,
+                ),
+              ),
+            );
+          }, staleTimeoutMs);
+        };
+
+        if (timeoutMs !== Infinity) {
+          totalTimer = setTimeout(() => {
+            send({ kind: 'cancel', id });
+            cleanupAttempt();
+            finish(() =>
+              reject(
+                new RozeniteProtocolError(
+                  method,
+                  'TIMEOUT',
+                  `"${method}" did not settle within ${timeoutMs}ms.`,
+                ),
+              ),
+            );
+          }, timeoutMs);
+        }
+
+        ackTimer = setTimeout(() => {
+          pending.delete(id);
+          if (totalTimer != null) {
+            clearTimeout(totalTimer);
+            totalTimer = null;
+          }
+          if (retriesLeft > 0) {
+            attempt(retriesLeft - 1);
+            return;
+          }
+          finish(() =>
+            reject(
+              new RozeniteProtocolError(
+                method,
+                'ACK_TIMEOUT',
+                `"${method}" was not acknowledged within ${ackTimeoutMs}ms.`,
+              ),
+            ),
+          );
+        }, ackTimeoutMs);
+
+        pending.set(id, {
+          method,
+          onAck: () => {
+            if (ackTimer != null) {
+              clearTimeout(ackTimer);
+              ackTimer = null;
+            }
+            rearmStale();
+          },
+          onHeartbeat: (frame) => {
+            rearmStale();
+            if ('progress' in frame) {
+              onProgress?.(frame.progress);
+            }
+          },
+          onResult: (frame) => {
+            cleanupAttempt();
+            finish(() => resolve(frame.value));
+          },
+          onError: (frame) => {
+            cleanupAttempt();
+            finish(() => reject(buildErrorFromFrame(method, frame)));
+          },
+        });
+
+        send({ kind: 'request', id, method, params, heartbeatMs });
+      };
+
+      attempt(retries);
+    });
+  };
+
+  const invoke = (method: string, ...args: unknown[]): Promise<unknown> => {
+    let params: unknown;
+    let options: InvokeOptions;
+
+    if (args.length >= 2) {
+      params = args[0];
+      options = (args[1] as InvokeOptions | undefined) ?? {};
+    } else if (args.length === 1) {
+      // A single trailing argument is ambiguous at runtime: for a zero-arg
+      // method it's `options`, for a with-params method it's `params`. `M`
+      // is erased by the time this function runs, so we recognize `options`
+      // structurally (every own key is a known `InvokeOptions` key).
+      if (looksLikeInvokeOptions(args[0])) {
+        params = undefined;
+        options = args[0] as InvokeOptions;
+      } else {
+        params = args[0];
+        options = {};
+      }
+    } else {
+      params = undefined;
+      options = {};
+    }
+
+    return performInvoke(method, params, options);
+  };
+
+  const handle = (
+    method: string,
+    handler: (params: unknown, ctx: RpcContext) => unknown,
+  ): Subscription => {
+    if (handlers.has(method)) {
+      throw new Error(
+        `A handler for method "${method}" is already registered.`,
+      );
+    }
+    handlers.set(method, handler);
+
+    return {
+      remove: () => {
+        handlers.delete(method);
+      },
+    };
+  };
+
+  const close = (): void => {
+    if (closed) {
+      return;
+    }
+    closed = true;
+
+    subscription.remove();
+    handlers.clear();
+
+    for (const [id, call] of pending) {
+      call.onError({
+        kind: 'error',
+        id,
+        source: 'protocol',
+        code: 'CLIENT_CLOSED',
+        message: `Cannot complete "${call.method}": the RPC client is closed.`,
+      });
+    }
+    pending.clear();
+
+    for (const call of activeCalls.values()) {
+      if (call.interval != null) {
+        clearInterval(call.interval);
+      }
+      call.controller.abort();
+    }
+    activeCalls.clear();
+  };
+
+  return {
+    invoke: invoke as RozeniteRpc<M>['invoke'],
+    handle: handle as RozeniteRpc<M>['handle'],
+    close,
+  };
+};

--- a/packages/plugin-bridge/src/rpc/create-rozenite-rpc.ts
+++ b/packages/plugin-bridge/src/rpc/create-rozenite-rpc.ts
@@ -21,31 +21,6 @@ const DEFAULT_STALE_TIMEOUT_MS = 6_000;
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_RETRIES = 1;
 
-// Every recognized key of `InvokeOptions`. Used at runtime to tell apart a
-// single trailing `options` argument from a single trailing `params`
-// argument for zero-arg methods — see `invoke` below for why this is
-// necessary.
-const OPTION_KEYS = new Set<string>([
-  'signal',
-  'ackTimeoutMs',
-  'heartbeatMs',
-  'staleTimeoutMs',
-  'timeoutMs',
-  'retries',
-  'onProgress',
-]);
-
-const isPlainObject = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null && !Array.isArray(value);
-
-const looksLikeInvokeOptions = (value: unknown): value is InvokeOptions => {
-  if (!isPlainObject(value)) {
-    return false;
-  }
-  const keys = Object.keys(value);
-  return keys.length === 0 || keys.every((key) => OPTION_KEYS.has(key));
-};
-
 // The client that carries RPC frames. RPC only needs `send`/`onMessage` for
 // a single reserved message type plus `close`, but consumers pass in a
 // `RozeniteDevToolsClient<TEventMap>` scoped to their own plugin event map
@@ -67,8 +42,6 @@ type ActiveHandlerCall = {
   interval: ReturnType<typeof setInterval> | null;
   settled: boolean;
   discarded: boolean;
-  hasProgress: boolean;
-  latestProgress: unknown;
 };
 
 type NormalizedError = {
@@ -180,25 +153,15 @@ export const createRozeniteRpc = <M extends RpcMethods>(
       interval: null,
       settled: false,
       discarded: false,
-      hasProgress: false,
-      latestProgress: undefined,
     };
     activeCalls.set(frame.id, call);
 
     const ctx: RpcContext = {
       signal: controller.signal,
-      progress: (value: unknown) => {
-        call.hasProgress = true;
-        call.latestProgress = value;
-      },
     };
 
     call.interval = setInterval(() => {
       const heartbeat: HeartbeatFrame = { kind: 'heartbeat', id: frame.id };
-      if (call.hasProgress) {
-        heartbeat.progress = call.latestProgress;
-        call.hasProgress = false;
-      }
       send(heartbeat);
     }, frame.heartbeatMs);
 
@@ -299,7 +262,7 @@ export const createRozeniteRpc = <M extends RpcMethods>(
     const staleTimeoutMs = options.staleTimeoutMs ?? DEFAULT_STALE_TIMEOUT_MS;
     const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     const retries = options.retries ?? DEFAULT_RETRIES;
-    const { signal, onProgress } = options;
+    const { signal } = options;
 
     return new Promise<unknown>((resolve, reject) => {
       if (closed) {
@@ -444,11 +407,8 @@ export const createRozeniteRpc = <M extends RpcMethods>(
             }
             rearmStale();
           },
-          onHeartbeat: (frame) => {
+          onHeartbeat: () => {
             rearmStale();
-            if ('progress' in frame) {
-              onProgress?.(frame.progress);
-            }
           },
           onResult: (frame) => {
             cleanupAttempt();
@@ -467,32 +427,10 @@ export const createRozeniteRpc = <M extends RpcMethods>(
     });
   };
 
-  const invoke = (method: string, ...args: unknown[]): Promise<unknown> => {
-    let params: unknown;
-    let options: InvokeOptions;
-
-    if (args.length >= 2) {
-      params = args[0];
-      options = (args[1] as InvokeOptions | undefined) ?? {};
-    } else if (args.length === 1) {
-      // A single trailing argument is ambiguous at runtime: for a zero-arg
-      // method it's `options`, for a with-params method it's `params`. `M`
-      // is erased by the time this function runs, so we recognize `options`
-      // structurally (every own key is a known `InvokeOptions` key).
-      if (looksLikeInvokeOptions(args[0])) {
-        params = undefined;
-        options = args[0] as InvokeOptions;
-      } else {
-        params = args[0];
-        options = {};
-      }
-    } else {
-      params = undefined;
-      options = {};
-    }
-
-    return performInvoke(method, params, options);
-  };
+  const method = (methodName: string, options: InvokeOptions = {}) => ({
+    invoke: (...params: unknown[]): Promise<unknown> =>
+      performInvoke(methodName, params[0], options),
+  });
 
   const handle = (
     method: string,
@@ -542,7 +480,7 @@ export const createRozeniteRpc = <M extends RpcMethods>(
   };
 
   return {
-    invoke: invoke as RozeniteRpc<M>['invoke'],
+    method: method as RozeniteRpc<M>['method'],
     handle: handle as RozeniteRpc<M>['handle'],
     close,
   };

--- a/packages/plugin-bridge/src/rpc/dev-types.d.ts
+++ b/packages/plugin-bridge/src/rpc/dev-types.d.ts
@@ -1,0 +1,12 @@
+// Ambient declaration for the React Native / Metro global.
+//
+// `packages/web/globals.d.ts` declares `__DEV__` for the web bundle, but
+// plugin-bridge is isomorphic (device + panel) and has no equivalent. We
+// declare it here as possibly-undefined so `typeof __DEV__ !== 'undefined'`
+// works whether or not the runtime actually defines it (Metro/Hermes define
+// it, plain Node and browsers do not).
+declare global {
+  var __DEV__: boolean | undefined;
+}
+
+export {};

--- a/packages/plugin-bridge/src/rpc/dev.ts
+++ b/packages/plugin-bridge/src/rpc/dev.ts
@@ -1,0 +1,16 @@
+/**
+ * Whether we're running in a development build.
+ *
+ * `__DEV__` is checked first so Metro dead-code-strips the branch on release
+ * builds; `process.env.NODE_ENV` covers the panel (web) and Node. We
+ * deliberately do not use `import.meta.env` — this package also emits CJS.
+ *
+ * This must only be used on the RPC *receiver* side, where a handler's
+ * error is thrown — a production device must never put a stack trace on
+ * the wire.
+ */
+export const isDev = (): boolean =>
+  typeof __DEV__ !== 'undefined'
+    ? Boolean(__DEV__)
+    : typeof process !== 'undefined' &&
+      process.env?.['NODE_ENV'] !== 'production';

--- a/packages/plugin-bridge/src/rpc/errors.ts
+++ b/packages/plugin-bridge/src/rpc/errors.ts
@@ -1,0 +1,73 @@
+export type ProtocolErrorCode =
+  | 'ACK_TIMEOUT'
+  | 'STALLED'
+  | 'TIMEOUT'
+  | 'CANCELLED'
+  | 'METHOD_NOT_FOUND'
+  | 'SERIALIZATION_ERROR'
+  | 'CLIENT_CLOSED';
+
+export type RemoteErrorInfo = {
+  name: string;
+  message: string;
+  /** Only ever populated in development builds — see `./dev.ts`. */
+  stack?: string;
+  /** Handler-supplied. Must be structured-cloneable. */
+  data?: unknown;
+};
+
+/**
+ * A failure of the RPC transport/protocol itself — the handler provably
+ * never ran, or its result/error could not be delivered. Carries no
+ * payload and no remote stack, because the failure isn't in user code.
+ */
+export class RozeniteProtocolError extends Error {
+  readonly kind = 'protocol' as const;
+  readonly method: string;
+  readonly code: ProtocolErrorCode;
+
+  constructor(method: string, code: ProtocolErrorCode, message: string) {
+    super(message);
+    this.name = 'RozeniteProtocolError';
+    this.method = method;
+    this.code = code;
+  }
+}
+
+/**
+ * The remote handler ran and threw. `message` and `this.stack` describe the
+ * *caller* (so you always see who invoked); the remote's own name, message,
+ * stack (dev only) and data live under `remote`.
+ */
+export class RozeniteHandlerError extends Error {
+  readonly kind = 'handler' as const;
+  readonly method: string;
+  readonly remote: RemoteErrorInfo;
+
+  constructor(method: string, remote: RemoteErrorInfo) {
+    super(`${method} failed: ${remote.message}`);
+    this.name = 'RozeniteHandlerError';
+    this.method = method;
+    this.remote = remote;
+  }
+}
+
+export type RozeniteRpcError = RozeniteProtocolError | RozeniteHandlerError;
+
+const hasKind = (
+  error: unknown,
+): error is { kind: unknown } & Record<string, unknown> =>
+  typeof error === 'object' && error !== null && 'kind' in error;
+
+/**
+ * Narrow on `kind`, not `instanceof` — the panel and the device are separate
+ * bundles, so `instanceof` only happens to work when the error was
+ * constructed by the same bundle that's checking it.
+ */
+export const isProtocolError = (
+  error: unknown,
+): error is RozeniteProtocolError =>
+  hasKind(error) && error.kind === 'protocol';
+
+export const isHandlerError = (error: unknown): error is RozeniteHandlerError =>
+  hasKind(error) && error.kind === 'handler';

--- a/packages/plugin-bridge/src/rpc/frames.ts
+++ b/packages/plugin-bridge/src/rpc/frames.ts
@@ -25,8 +25,6 @@ export type AckFrame = {
 export type HeartbeatFrame = {
   kind: 'heartbeat';
   id: string;
-  /** Piggybacks the latest `ctx.progress()` value, if any was reported. */
-  progress?: unknown;
 };
 
 export type ResultFrame = {

--- a/packages/plugin-bridge/src/rpc/frames.ts
+++ b/packages/plugin-bridge/src/rpc/frames.ts
@@ -1,0 +1,70 @@
+import { ProtocolErrorCode } from './errors.js';
+
+/**
+ * The single message type RPC reserves on the underlying
+ * `RozeniteDevToolsClient`. All RPC frames ride inside its payload — no
+ * changes to `Channel` or to the message envelope are needed. A plugin's own
+ * event map must not use this type.
+ */
+export const ROZENITE_RPC_MESSAGE_TYPE = 'rozenite:rpc';
+
+export type RequestFrame = {
+  kind: 'request';
+  id: string;
+  method: string;
+  params?: unknown;
+  /** Caller-dictated heartbeat cadence, sent so the receiver knows the rate. */
+  heartbeatMs: number;
+};
+
+export type AckFrame = {
+  kind: 'ack';
+  id: string;
+};
+
+export type HeartbeatFrame = {
+  kind: 'heartbeat';
+  id: string;
+  /** Piggybacks the latest `ctx.progress()` value, if any was reported. */
+  progress?: unknown;
+};
+
+export type ResultFrame = {
+  kind: 'result';
+  id: string;
+  value: unknown;
+};
+
+export type ProtocolErrorFrame = {
+  kind: 'error';
+  id: string;
+  source: 'protocol';
+  code: ProtocolErrorCode;
+  message: string;
+};
+
+export type HandlerErrorFrame = {
+  kind: 'error';
+  id: string;
+  source: 'handler';
+  name: string;
+  message: string;
+  /** Dev only — see `./dev.ts`. */
+  stack?: string;
+  data?: unknown;
+};
+
+export type ErrorFrame = ProtocolErrorFrame | HandlerErrorFrame;
+
+export type CancelFrame = {
+  kind: 'cancel';
+  id: string;
+};
+
+export type RpcFrame =
+  | RequestFrame
+  | AckFrame
+  | HeartbeatFrame
+  | ResultFrame
+  | ErrorFrame
+  | CancelFrame;

--- a/packages/plugin-bridge/src/rpc/index.ts
+++ b/packages/plugin-bridge/src/rpc/index.ts
@@ -13,8 +13,9 @@ export type {
 export { ROZENITE_RPC_MESSAGE_TYPE } from './frames.js';
 export type {
   InvokeOptions,
-  InvokeArgs,
+  InvokeParams,
   RozeniteRpc,
   RpcContext,
   RpcMethods,
+  RpcMethodHandle,
 } from './types.js';

--- a/packages/plugin-bridge/src/rpc/index.ts
+++ b/packages/plugin-bridge/src/rpc/index.ts
@@ -1,0 +1,20 @@
+export { createRozeniteRpc } from './create-rozenite-rpc.js';
+export {
+  isProtocolError,
+  isHandlerError,
+  RozeniteProtocolError,
+  RozeniteHandlerError,
+} from './errors.js';
+export type {
+  ProtocolErrorCode,
+  RemoteErrorInfo,
+  RozeniteRpcError,
+} from './errors.js';
+export { ROZENITE_RPC_MESSAGE_TYPE } from './frames.js';
+export type {
+  InvokeOptions,
+  InvokeArgs,
+  RozeniteRpc,
+  RpcContext,
+  RpcMethods,
+} from './types.js';

--- a/packages/plugin-bridge/src/rpc/rpc-types.test.ts
+++ b/packages/plugin-bridge/src/rpc/rpc-types.test.ts
@@ -16,11 +16,13 @@ type TestMethods = {
 };
 
 function checksParamsAndResultInference(rpc: RozeniteRpc<TestMethods>) {
-  expectTypeOf(rpc.invoke('getUser', { id: '1' })).resolves.toEqualTypeOf<{
+  expectTypeOf(
+    rpc.method('getUser').invoke({ id: '1' }),
+  ).resolves.toEqualTypeOf<{
     id: string;
     name: string;
   }>();
-  expectTypeOf(rpc.invoke('ping')).resolves.toEqualTypeOf<'pong'>();
+  expectTypeOf(rpc.method('ping').invoke()).resolves.toEqualTypeOf<'pong'>();
 
   rpc.handle('getUser', (params) => {
     expectTypeOf(params).toEqualTypeOf<{ id: string }>();
@@ -28,38 +30,43 @@ function checksParamsAndResultInference(rpc: RozeniteRpc<TestMethods>) {
   });
 }
 
-function checksZeroArgOverloads(rpc: RozeniteRpc<TestMethods>) {
-  rpc.invoke('ping');
-  rpc.invoke('ping', { timeoutMs: 1_000 });
+function checksZeroArgHandleAcceptsNoParams(rpc: RozeniteRpc<TestMethods>) {
+  rpc.method('ping').invoke();
+
+  // @ts-expect-error -- `ping` takes no params; `invoke` accepts none.
+  rpc.method('ping').invoke({ id: '1' });
 }
 
-function checksParamsAreRequiredWhenDeclared(rpc: RozeniteRpc<TestMethods>) {
-  rpc.invoke('getUser', { id: '1' });
-  rpc.invoke('getUser', { id: '1' }, { timeoutMs: 1_000 });
+function checksOptionsLiveOnlyOnMethod(rpc: RozeniteRpc<TestMethods>) {
+  rpc.method('ping', { timeoutMs: 1_000 }).invoke();
+  rpc.method('getUser', { timeoutMs: 1_000 }).invoke({ id: '1' });
 
-  // @ts-expect-error -- getUser requires a `params` argument.
-  rpc.invoke('getUser');
+  // @ts-expect-error -- `getUser` requires a `params` argument.
+  rpc.method('getUser').invoke();
+
+  // @ts-expect-error -- options belong on `method()`, not `invoke()`.
+  rpc.method('getUser').invoke({ id: '1' }, { timeoutMs: 1_000 });
 }
 
 function checksUnknownMethodNamesAreATypeError(rpc: RozeniteRpc<TestMethods>) {
   // @ts-expect-error -- "doesNotExist" is not a key of TestMethods.
-  rpc.invoke('doesNotExist');
+  rpc.method('doesNotExist');
 
   // @ts-expect-error -- same for handle().
   rpc.handle('doesNotExist', () => {});
 }
 
 describe('RozeniteRpc types', () => {
-  it('infers params and result from the method map', () => {
+  it('infers params and result through the method handle', () => {
     expectTypeOf(checksParamsAndResultInference).toBeFunction();
   });
 
-  it('zero-arg methods accept invoke("name") and invoke("name", { timeoutMs })', () => {
-    expectTypeOf(checksZeroArgOverloads).toBeFunction();
+  it('method("zeroArg").invoke() is valid, invoke(params) is a type error', () => {
+    expectTypeOf(checksZeroArgHandleAcceptsNoParams).toBeFunction();
   });
 
-  it('methods with params require params to be passed', () => {
-    expectTypeOf(checksParamsAreRequiredWhenDeclared).toBeFunction();
+  it('options live only on method(); passing them to invoke() is a type error', () => {
+    expectTypeOf(checksOptionsLiveOnlyOnMethod).toBeFunction();
   });
 
   it('unknown method names are a type error', () => {

--- a/packages/plugin-bridge/src/rpc/rpc-types.test.ts
+++ b/packages/plugin-bridge/src/rpc/rpc-types.test.ts
@@ -1,0 +1,68 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import { RozeniteRpc } from './types.js';
+
+// Type-only assertions. `tsc -p tsconfig.lib.json --noEmit` (the package's
+// `typecheck` script) checks every function body below regardless of
+// whether it's ever called, so a wrong inference or a missing
+// `@ts-expect-error` fails CI the same way a broken runtime test would.
+//
+// These helpers are declared but deliberately never invoked — `rpc` is a
+// parameter, never a real value — so nothing here executes at runtime. The
+// `it` blocks exist only so this file also reads as a normal vitest suite.
+
+type TestMethods = {
+  getUser: (params: { id: string }) => Promise<{ id: string; name: string }>;
+  ping: () => Promise<'pong'>;
+};
+
+function checksParamsAndResultInference(rpc: RozeniteRpc<TestMethods>) {
+  expectTypeOf(rpc.invoke('getUser', { id: '1' })).resolves.toEqualTypeOf<{
+    id: string;
+    name: string;
+  }>();
+  expectTypeOf(rpc.invoke('ping')).resolves.toEqualTypeOf<'pong'>();
+
+  rpc.handle('getUser', (params) => {
+    expectTypeOf(params).toEqualTypeOf<{ id: string }>();
+    return Promise.resolve({ id: params.id, name: 'Ada' });
+  });
+}
+
+function checksZeroArgOverloads(rpc: RozeniteRpc<TestMethods>) {
+  rpc.invoke('ping');
+  rpc.invoke('ping', { timeoutMs: 1_000 });
+}
+
+function checksParamsAreRequiredWhenDeclared(rpc: RozeniteRpc<TestMethods>) {
+  rpc.invoke('getUser', { id: '1' });
+  rpc.invoke('getUser', { id: '1' }, { timeoutMs: 1_000 });
+
+  // @ts-expect-error -- getUser requires a `params` argument.
+  rpc.invoke('getUser');
+}
+
+function checksUnknownMethodNamesAreATypeError(rpc: RozeniteRpc<TestMethods>) {
+  // @ts-expect-error -- "doesNotExist" is not a key of TestMethods.
+  rpc.invoke('doesNotExist');
+
+  // @ts-expect-error -- same for handle().
+  rpc.handle('doesNotExist', () => {});
+}
+
+describe('RozeniteRpc types', () => {
+  it('infers params and result from the method map', () => {
+    expectTypeOf(checksParamsAndResultInference).toBeFunction();
+  });
+
+  it('zero-arg methods accept invoke("name") and invoke("name", { timeoutMs })', () => {
+    expectTypeOf(checksZeroArgOverloads).toBeFunction();
+  });
+
+  it('methods with params require params to be passed', () => {
+    expectTypeOf(checksParamsAreRequiredWhenDeclared).toBeFunction();
+  });
+
+  it('unknown method names are a type error', () => {
+    expectTypeOf(checksUnknownMethodNamesAreATypeError).toBeFunction();
+  });
+});

--- a/packages/plugin-bridge/src/rpc/serialization.ts
+++ b/packages/plugin-bridge/src/rpc/serialization.ts
@@ -1,0 +1,25 @@
+/**
+ * Whether `value` can survive the underlying transport.
+ *
+ * The transport is CDP/JSON-based today, but the protocol spec talks about
+ * "structured-cloneable" payloads, so we prefer the platform's own
+ * `structuredClone` when it's available (Node, browsers) and fall back to a
+ * `JSON.stringify` probe on runtimes that don't implement it (older Hermes).
+ */
+export const isCloneable = (value: unknown): boolean => {
+  if (typeof structuredClone === 'function') {
+    try {
+      structuredClone(value);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  try {
+    JSON.stringify(value);
+    return true;
+  } catch {
+    return false;
+  }
+};

--- a/packages/plugin-bridge/src/rpc/test-utils.ts
+++ b/packages/plugin-bridge/src/rpc/test-utils.ts
@@ -1,0 +1,89 @@
+import { vi } from 'vitest';
+import { RozeniteDevToolsClient } from '../client.js';
+
+type Listener = (payload: unknown) => void;
+
+/**
+ * A minimal in-memory pair of fake `RozeniteDevToolsClient`s: sending on one
+ * dispatches (asynchronously, like a real transport) to the other's
+ * listeners, and vice versa.
+ */
+export const createFakeClientPair = () => {
+  const listenersA = new Map<string, Set<Listener>>();
+  const listenersB = new Map<string, Set<Listener>>();
+
+  let droppedFromAtoB = false;
+  let droppedFromBtoA = false;
+  let delayAtoBMs = 0;
+  let delayBtoAMs = 0;
+
+  const dispatch = (
+    listeners: Map<string, Set<Listener>>,
+    type: string,
+    payload: unknown,
+    delayMs: number,
+  ) => {
+    const run = () => {
+      listeners.get(type)?.forEach((listener) => listener(payload));
+    };
+    if (delayMs > 0) {
+      setTimeout(run, delayMs);
+    } else {
+      // Real transports are never synchronous — queue on the (real, never
+      // faked) native microtask queue so send() never re-enters a handler
+      // synchronously.
+      Promise.resolve().then(run);
+    }
+  };
+
+  const clientA: RozeniteDevToolsClient<Record<string, unknown>> = {
+    send: vi.fn((type, payload) => {
+      if (droppedFromAtoB) return;
+      dispatch(listenersB, type as string, payload, delayAtoBMs);
+    }),
+    onMessage: vi.fn((type, listener) => {
+      const set = listenersA.get(type as string) ?? new Set();
+      set.add(listener as Listener);
+      listenersA.set(type as string, set);
+      return {
+        remove: () => set.delete(listener as Listener),
+      };
+    }),
+    close: vi.fn(),
+  };
+
+  const clientB: RozeniteDevToolsClient<Record<string, unknown>> = {
+    send: vi.fn((type, payload) => {
+      if (droppedFromBtoA) return;
+      dispatch(listenersA, type as string, payload, delayBtoAMs);
+    }),
+    onMessage: vi.fn((type, listener) => {
+      const set = listenersB.get(type as string) ?? new Set();
+      set.add(listener as Listener);
+      listenersB.set(type as string, set);
+      return {
+        remove: () => set.delete(listener as Listener),
+      };
+    }),
+    close: vi.fn(),
+  };
+
+  return {
+    clientA,
+    clientB,
+    /** Drop every frame sent from A to B (simulates B never mounting). */
+    dropAtoB: (drop: boolean) => {
+      droppedFromAtoB = drop;
+    },
+    /** Drop every frame sent from B to A. */
+    dropBtoA: (drop: boolean) => {
+      droppedFromBtoA = drop;
+    },
+    delayAtoB: (ms: number) => {
+      delayAtoBMs = ms;
+    },
+    delayBtoA: (ms: number) => {
+      delayBtoAMs = ms;
+    },
+  };
+};

--- a/packages/plugin-bridge/src/rpc/types.ts
+++ b/packages/plugin-bridge/src/rpc/types.ts
@@ -1,0 +1,44 @@
+import { Subscription } from '../types.js';
+
+export type RpcMethods = Record<string, (...args: never[]) => unknown>;
+
+export type InvokeArgs<M extends RpcMethods, K extends keyof M> =
+  Parameters<M[K]> extends []
+    ? [options?: InvokeOptions]
+    : [params: Parameters<M[K]>[0], options?: InvokeOptions];
+
+export type RpcContext = {
+  /** Aborts when the caller cancels, times out, or gives up. */
+  signal: AbortSignal;
+  /** Piggybacks on the next heartbeat frame. */
+  progress(value: unknown): void;
+};
+
+export type InvokeOptions = {
+  signal?: AbortSignal;
+  /** `request` -> `ack` window. Default `5_000`. */
+  ackTimeoutMs?: number;
+  /** Caller-dictated heartbeat cadence, sent in the request. Default `2_000`. */
+  heartbeatMs?: number;
+  /** Window since the last `ack`/`heartbeat`. Default `6_000` (3x `heartbeatMs`). */
+  staleTimeoutMs?: number;
+  /** Absolute `request` -> settle cap. Default `30_000`. Pass `Infinity` to opt out. */
+  timeoutMs?: number;
+  /** Retries `ACK_TIMEOUT` only. Default `1`. */
+  retries?: number;
+  onProgress?: (value: unknown) => void;
+};
+
+export type RozeniteRpc<M extends RpcMethods> = {
+  invoke<K extends keyof M>(
+    method: K,
+    ...args: InvokeArgs<M, K>
+  ): Promise<Awaited<ReturnType<M[K]>>>;
+
+  handle<K extends keyof M>(
+    method: K,
+    handler: (params: Parameters<M[K]>[0], ctx: RpcContext) => ReturnType<M[K]>,
+  ): Subscription;
+
+  close(): void;
+};

--- a/packages/plugin-bridge/src/rpc/types.ts
+++ b/packages/plugin-bridge/src/rpc/types.ts
@@ -2,16 +2,12 @@ import { Subscription } from '../types.js';
 
 export type RpcMethods = Record<string, (...args: never[]) => unknown>;
 
-export type InvokeArgs<M extends RpcMethods, K extends keyof M> =
-  Parameters<M[K]> extends []
-    ? [options?: InvokeOptions]
-    : [params: Parameters<M[K]>[0], options?: InvokeOptions];
+export type InvokeParams<M extends RpcMethods, K extends keyof M> =
+  Parameters<M[K]> extends [] ? [] : [params: Parameters<M[K]>[0]];
 
 export type RpcContext = {
   /** Aborts when the caller cancels, times out, or gives up. */
   signal: AbortSignal;
-  /** Piggybacks on the next heartbeat frame. */
-  progress(value: unknown): void;
 };
 
 export type InvokeOptions = {
@@ -26,14 +22,17 @@ export type InvokeOptions = {
   timeoutMs?: number;
   /** Retries `ACK_TIMEOUT` only. Default `1`. */
   retries?: number;
-  onProgress?: (value: unknown) => void;
+};
+
+export type RpcMethodHandle<M extends RpcMethods, K extends keyof M> = {
+  invoke(...params: InvokeParams<M, K>): Promise<Awaited<ReturnType<M[K]>>>;
 };
 
 export type RozeniteRpc<M extends RpcMethods> = {
-  invoke<K extends keyof M>(
+  method<K extends keyof M>(
     method: K,
-    ...args: InvokeArgs<M, K>
-  ): Promise<Awaited<ReturnType<M[K]>>>;
+    options?: InvokeOptions,
+  ): RpcMethodHandle<M, K>;
 
   handle<K extends keyof M>(
     method: K,

--- a/website/src/docs/plugin-development/_meta.json
+++ b/website/src/docs/plugin-development/_meta.json
@@ -8,5 +8,10 @@
     "type": "file",
     "name": "plugin-development",
     "label": "Plugin Development Guide"
+  },
+  {
+    "type": "file",
+    "name": "rpc",
+    "label": "RPC"
   }
 ]

--- a/website/src/docs/plugin-development/rpc.md
+++ b/website/src/docs/plugin-development/rpc.md
@@ -1,9 +1,20 @@
 # RPC
 
-`@rozenite/plugin-bridge` also exposes a request/response layer on top of the
-fire-and-forget `RozeniteDevToolsClient`. Instead of hand-rolling a
-correlation id, a matching response event, and an ad-hoc timeout every time a
-plugin needs a result back, use `createRozeniteRpc`:
+The `RozeniteDevToolsClient` you get from `getRozeniteDevToolsClient` (see the
+[Plugin Development Guide](./plugin-development.md)) is fire-and-forget:
+`send(type, payload)` and `onMessage(type, listener)`. That's the right tool
+for events, but it isn't an answer to "call this and give me a result."
+
+Every plugin that needs a result back from the other side ends up
+reinventing the same thing by hand: a correlation id, a matching response
+event type, a `Promise` stored in a map, and an ad-hoc timeout. And none of
+that hand-rolled scaffolding protects you from the case that actually causes
+support tickets — the panel isn't mounted yet, or the device peer has died,
+and your caller just hangs forever with no `Promise` ever settling.
+
+`@rozenite/plugin-bridge` ships `createRozeniteRpc` so you don't have to
+build this yourself. It gives you an awaitable call with acknowledgement,
+heartbeats, timeouts, and cancellation on top of your existing client.
 
 ```typescript
 import { getRozeniteDevToolsClient, createRozeniteRpc } from '@rozenite/plugin-bridge';
@@ -15,68 +26,108 @@ type MyMethods = {
 
 const client = await getRozeniteDevToolsClient<MyEventMap>('your-plugin-id');
 const rpc = createRozeniteRpc<MyMethods>(client);
+```
 
-// Caller side
-const contents = await rpc.invoke('readFile', { path: '/tmp/log.txt' });
+The abstraction is **symmetric**: both the device and the panel can register
+handlers with `handle()` and call methods on the same `rpc` instance.
 
-// Receiver side
+## Reserved message type
+
+RPC rides on top of your existing `RozeniteDevToolsClient` — there's no
+separate channel to set up. It reserves a single message type,
+`'rozenite:rpc'`, for its own use. Don't use `'rozenite:rpc'` as an event
+type in your own plugin's event map, or it will collide with the RPC layer.
+
+## Declaring methods
+
+Methods are declared function-shaped, so params and result are both
+inferred from a single type:
+
+```typescript
+type MyMethods = {
+  readFile: (params: { path: string }) => Promise<string>;
+  listDevices: () => Promise<Device[]>;
+};
+```
+
+## Registering a handler
+
+```typescript
 rpc.handle('readFile', async ({ path }) => {
   return fs.readFileSync(path, 'utf8');
 });
 ```
 
-The abstraction is **symmetric**: both the device and the panel can register
-handlers with `handle()` and call methods with `invoke()` on the same `rpc`
-instance.
+Registering a second handler for the same method throws immediately, at
+registration time — a method has exactly one handler on a given peer.
 
-## Reserved message type
+## Calling a method
 
-RPC rides on top of the existing `RozeniteDevToolsClient` — there's no
-separate channel or transport. It reserves a single message type,
-`'rozenite:rpc'`, and carries every RPC frame inside its payload. Your
-plugin's own event map must not use `'rozenite:rpc'` as an event name, or it
-will collide with the RPC layer.
+Calling is a two-step handle: `method()` names the method and takes the
+call's options, and `invoke()` takes the params.
+
+```typescript
+await rpc.method('getUser').invoke({ id: '42' });
+await rpc.method('listDevices').invoke();
+await rpc.method('readFile', { timeoutMs: 60_000 }).invoke({ path });
+```
+
+This is the only call form. A handle holds nothing but the method name and
+its options — no subscription, no state — so creating one per call is free,
+and reusing one across multiple calls is equally fine:
+
+```typescript
+const readFile = rpc.method('readFile', { timeoutMs: 60_000 });
+await readFile.invoke({ path: 'a' });
+await readFile.invoke({ path: 'b' });
+```
+
+Note that the handle is a plain object with an `invoke` method — it is not
+itself callable. A remote call that reads like an ordinary function call
+hides the fact that it can time out, stall, or be cancelled; `.invoke()`
+keeps that round-trip visible at the call site.
 
 ## Why a single timeout isn't enough
 
-A single constant timeout is the wrong tool for RPC: a legitimately slow
-handler trips it, while a handler that's actually gone is indistinguishable
-from one that's just slow. RPC splits **liveness** from **duration**: the
-receiver acknowledges a request immediately, then heartbeats while it
-executes. "Slow but alive" and "gone" become different, observable states.
+A single constant timeout is the wrong tool here: a legitimately slow
+handler would trip it, while a handler that's actually gone is
+indistinguishable from one that's just slow. RPC splits **liveness** from
+**duration** — the receiver acknowledges a request immediately, then sends
+heartbeats while it executes. "Slow but alive" and "gone" become different,
+observable states.
 
-### The three timers
+### The three timers and their defaults
 
-Every `invoke()` call is guarded by three independent caller-side timers:
+Every `invoke()` call is guarded by three independent, caller-side timers:
 
-| Timer | Window | Fires when |
-| --- | --- | --- |
-| `ackTimeoutMs` (default `5_000`) | `request` → `ack` | Nobody is listening, or the peer isn't mounted yet. The handler provably never ran, so this is the **only** retryable failure — `ACK_TIMEOUT`. |
-| `staleTimeoutMs` (default `6_000`, 3× `heartbeatMs`) | since the last `ack` or `heartbeat` | The peer died, or its event loop is blocked. `STALLED`. |
-| `timeoutMs` (default `30_000`) | `request` → settle | Absolute cap. Catches an async handler that never resolves (it would otherwise heartbeat forever). `TIMEOUT`. Pass `Infinity` to opt out. |
+| Option | Default | Window | Fires when |
+| --- | --- | --- | --- |
+| `ackTimeoutMs` | `5_000` | `invoke()` → acknowledged | Nobody is listening, or the peer isn't mounted yet. This is the **only** retryable failure — `ACK_TIMEOUT`. |
+| `staleTimeoutMs` | `6_000` (3× `heartbeatMs`) | since the last sign of life | The peer died, or its event loop is blocked. `STALLED`. |
+| `timeoutMs` | `30_000` | `invoke()` → settle | Absolute cap. Catches a handler that never resolves — it would otherwise heartbeat forever. `TIMEOUT`. Pass `Infinity` to opt out. |
 
-`heartbeatMs` (default `2_000`) is caller-dictated and sent along with the
-request; the receiver's heartbeat cadence follows whatever the caller asked
-for.
+`heartbeatMs` (default `2_000`) is set by the caller via `method()`'s
+options; it controls how often the receiver sends a heartbeat while handling
+that call.
 
 ### Retries
 
-`retries` (default `1`) applies **only** to `ACK_TIMEOUT`. `STALLED` and
-`TIMEOUT` never retry — the handler may have already committed side effects
-by the time either of those fires, and a handler error never retries by
-construction. Each retry uses a fresh call id; a late `ack` for an abandoned
-attempt is simply ignored.
+`retries` (default `1`) applies **only** to `ACK_TIMEOUT` — the one failure
+where the handler provably never ran. `STALLED` and `TIMEOUT` never retry,
+because by the time either fires the handler may already have committed side
+effects, and a handler error never retries by construction.
 
-The retry budget is consumed *before* `timeoutMs` is re-armed for the next
-attempt, so `retries: 1` can cost up to `ackTimeoutMs + timeoutMs` in the
-worst case: the first attempt burns a full `ackTimeoutMs` before giving up,
-and the retried attempt then gets its own full `timeoutMs` window.
+Because the retry budget is consumed before `timeoutMs` is re-armed for the
+retried attempt, `retries: 1` can cost up to `ackTimeoutMs + timeoutMs` in
+the worst case: the first attempt burns a full `ackTimeoutMs` before giving
+up, and the retry then gets its own full `timeoutMs` window.
 
 ## Cancellation
 
-Every caller-side give-up — `STALLED`, `TIMEOUT`, or the caller's own
-`AbortSignal` — sends a `cancel` frame so the handler's `ctx.signal` aborts
-instead of leaking:
+Pass an `AbortSignal` to cancel a call in flight. Every caller-side give-up —
+`STALLED`, `TIMEOUT`, or your own `AbortSignal` — aborts the handler's
+`ctx.signal` on the other side, so long-running work can stop instead of
+running to no purpose:
 
 ```typescript
 rpc.handle('longRunning', async (params, ctx) => {
@@ -89,48 +140,28 @@ rpc.handle('longRunning', async (params, ctx) => {
 });
 ```
 
-`cancel` is fire-and-forget: the caller rejects immediately and drops any
-late `result`/`error` frame for that call id. A handler that settles after
-cancellation is silently discarded — no frame is sent back, and nothing
-throws.
-
 ```typescript
 const controller = new AbortController();
-const promise = rpc.invoke('longRunning', undefined, {
-  signal: controller.signal,
-});
+const promise = rpc
+  .method('longRunning', { signal: controller.signal })
+  .invoke();
 
 controller.abort(); // -> rejects with a CANCELLED error, aborts ctx.signal
 ```
 
-## Progress
-
-A handler can piggyback a progress value on its next outgoing heartbeat:
-
-```typescript
-rpc.handle('bulkImport', async (params, ctx) => {
-  for (let i = 0; i < total; i++) {
-    await importOne(items[i]);
-    ctx.progress({ done: i + 1, total });
-  }
-});
-```
-
-```typescript
-await rpc.invoke('bulkImport', undefined, {
-  onProgress: (value) => console.log(value),
-});
-```
+The caller rejects immediately on cancellation and drops any late result
+that arrives afterwards — a handler that settles after cancellation is
+silently discarded, with no error and no dangling frame.
 
 ## Known limitation: heartbeats only prove the event loop is alive
 
-The heartbeat proves the peer's **event loop** is alive — not that the
-handler is making progress. Synchronous work blocks the heartbeat timer too,
-so a 10-second synchronous loop on either side is indistinguishable from a
-dead peer. **This design cannot detect a synchronous long-running block.**
-Make sure `staleTimeoutMs` exceeds the longest synchronous block you expect
-on either side; if you have known-blocking work, raise `staleTimeoutMs` for
-that call.
+A heartbeat proves the peer's **event loop** is alive, not that the handler
+is making progress. Synchronous work blocks the heartbeat timer too, so a
+10-second synchronous loop on either side looks exactly like a dead peer.
+This design cannot detect a synchronous long-running block — make sure
+`staleTimeoutMs` comfortably exceeds the longest synchronous stretch you
+expect on either side, and raise it per-call for handlers you know will
+block.
 
 ## Errors
 
@@ -140,13 +171,18 @@ Errors come in two shapes, discriminated by `kind`:
 export type RozeniteRpcError = RozeniteProtocolError | RozeniteHandlerError;
 ```
 
-- **`RozeniteProtocolError`** (`kind: 'protocol'`) — a transport/protocol
-  failure: `ACK_TIMEOUT`, `STALLED`, `TIMEOUT`, `CANCELLED`,
-  `METHOD_NOT_FOUND`, `SERIALIZATION_ERROR`, or `CLIENT_CLOSED`. It carries
-  no payload and no remote stack, because the failure isn't in your code.
-  Only `METHOD_NOT_FOUND` and `SERIALIZATION_ERROR` ever travel over the
-  wire as protocol frames — the rest (the three timeouts, `CANCELLED`, and
-  `CLIENT_CLOSED`) are always constructed on the caller's side.
+- **`RozeniteProtocolError`** (`kind: 'protocol'`) — the call itself failed,
+  not your handler. `error.code` is one of:
+  - `ACK_TIMEOUT` — nobody acknowledged the request in time; the handler
+    never ran.
+  - `STALLED` — the peer stopped sending any sign of life.
+  - `TIMEOUT` — the call didn't settle within the absolute cap.
+  - `CANCELLED` — the caller's `AbortSignal` fired.
+  - `METHOD_NOT_FOUND` — no handler is registered for that method on the
+    peer.
+  - `SERIALIZATION_ERROR` — the result (or error `data`) couldn't survive
+    the transport.
+  - `CLIENT_CLOSED` — `close()` was called while the call was in flight.
 - **`RozeniteHandlerError`** (`kind: 'handler'`) — the remote handler ran and
   threw. `error.message` is `` `${method} failed: ${remote.message}` `` and
   `error.stack` is **your own** call stack, so you always see who invoked
@@ -154,15 +190,15 @@ export type RozeniteRpcError = RozeniteProtocolError | RozeniteHandlerError;
   only), and any handler-supplied `data` live under `error.remote`.
 
 Narrow on `kind`, not `instanceof` — a plugin's device code and panel code
-are separate bundles, so `instanceof` only happens to work when the error was
-constructed by the bundle doing the check. Use the exported type guards
+are separate bundles, so `instanceof` only happens to work when the error
+was constructed by the bundle doing the check. Use the exported type guards
 instead:
 
 ```typescript
 import { isProtocolError, isHandlerError } from '@rozenite/plugin-bridge';
 
 try {
-  await rpc.invoke('readFile', { path });
+  await rpc.method('readFile').invoke({ path });
 } catch (error) {
   if (isProtocolError(error)) {
     // error.code: ACK_TIMEOUT | STALLED | TIMEOUT | CANCELLED |
@@ -173,16 +209,13 @@ try {
 }
 ```
 
-A result (or an error's `data`) that isn't structured-cloneable is turned
-into a `SERIALIZATION_ERROR` protocol error rather than letting the
-underlying transport throw and hang the call.
-
 ## API reference
 
 ```typescript
 const rpc = createRozeniteRpc<MyMethods>(client);
 
-rpc.invoke(method, params?, options?): Promise<Result>;
+rpc.method(method, options?): RpcMethodHandle;
+rpc.method(method, options?).invoke(params?): Promise<Result>;
 rpc.handle(method, handler): Subscription;
 rpc.close(): void;
 ```
@@ -193,12 +226,6 @@ rpc.close(): void;
 - `InvokeOptions.staleTimeoutMs?: number` — default `6_000`
 - `InvokeOptions.timeoutMs?: number` — default `30_000`, pass `Infinity` to opt out
 - `InvokeOptions.retries?: number` — default `1`, `ACK_TIMEOUT` only
-- `InvokeOptions.onProgress?: (value: unknown) => void`
 
-Registering a second handler for the same method throws immediately, at
-registration time. Calling `close()` removes the underlying message
-subscription and rejects every in-flight call with `CLIENT_CLOSED`.
-
-Out of scope for this API: streaming/`AsyncIterable` results (single-value
-results only — use `onProgress` for incremental updates) and re-entrant calls
-from inside a handler back to its own caller as part of the same request.
+Calling `close()` removes the underlying message subscription and rejects
+every in-flight call with `CLIENT_CLOSED`.

--- a/website/src/docs/plugin-development/rpc.md
+++ b/website/src/docs/plugin-development/rpc.md
@@ -1,0 +1,204 @@
+# RPC
+
+`@rozenite/plugin-bridge` also exposes a request/response layer on top of the
+fire-and-forget `RozeniteDevToolsClient`. Instead of hand-rolling a
+correlation id, a matching response event, and an ad-hoc timeout every time a
+plugin needs a result back, use `createRozeniteRpc`:
+
+```typescript
+import { getRozeniteDevToolsClient, createRozeniteRpc } from '@rozenite/plugin-bridge';
+
+type MyMethods = {
+  readFile: (params: { path: string }) => Promise<string>;
+  listDevices: () => Promise<Device[]>;
+};
+
+const client = await getRozeniteDevToolsClient<MyEventMap>('your-plugin-id');
+const rpc = createRozeniteRpc<MyMethods>(client);
+
+// Caller side
+const contents = await rpc.invoke('readFile', { path: '/tmp/log.txt' });
+
+// Receiver side
+rpc.handle('readFile', async ({ path }) => {
+  return fs.readFileSync(path, 'utf8');
+});
+```
+
+The abstraction is **symmetric**: both the device and the panel can register
+handlers with `handle()` and call methods with `invoke()` on the same `rpc`
+instance.
+
+## Reserved message type
+
+RPC rides on top of the existing `RozeniteDevToolsClient` — there's no
+separate channel or transport. It reserves a single message type,
+`'rozenite:rpc'`, and carries every RPC frame inside its payload. Your
+plugin's own event map must not use `'rozenite:rpc'` as an event name, or it
+will collide with the RPC layer.
+
+## Why a single timeout isn't enough
+
+A single constant timeout is the wrong tool for RPC: a legitimately slow
+handler trips it, while a handler that's actually gone is indistinguishable
+from one that's just slow. RPC splits **liveness** from **duration**: the
+receiver acknowledges a request immediately, then heartbeats while it
+executes. "Slow but alive" and "gone" become different, observable states.
+
+### The three timers
+
+Every `invoke()` call is guarded by three independent caller-side timers:
+
+| Timer | Window | Fires when |
+| --- | --- | --- |
+| `ackTimeoutMs` (default `5_000`) | `request` → `ack` | Nobody is listening, or the peer isn't mounted yet. The handler provably never ran, so this is the **only** retryable failure — `ACK_TIMEOUT`. |
+| `staleTimeoutMs` (default `6_000`, 3× `heartbeatMs`) | since the last `ack` or `heartbeat` | The peer died, or its event loop is blocked. `STALLED`. |
+| `timeoutMs` (default `30_000`) | `request` → settle | Absolute cap. Catches an async handler that never resolves (it would otherwise heartbeat forever). `TIMEOUT`. Pass `Infinity` to opt out. |
+
+`heartbeatMs` (default `2_000`) is caller-dictated and sent along with the
+request; the receiver's heartbeat cadence follows whatever the caller asked
+for.
+
+### Retries
+
+`retries` (default `1`) applies **only** to `ACK_TIMEOUT`. `STALLED` and
+`TIMEOUT` never retry — the handler may have already committed side effects
+by the time either of those fires, and a handler error never retries by
+construction. Each retry uses a fresh call id; a late `ack` for an abandoned
+attempt is simply ignored.
+
+The retry budget is consumed *before* `timeoutMs` is re-armed for the next
+attempt, so `retries: 1` can cost up to `ackTimeoutMs + timeoutMs` in the
+worst case: the first attempt burns a full `ackTimeoutMs` before giving up,
+and the retried attempt then gets its own full `timeoutMs` window.
+
+## Cancellation
+
+Every caller-side give-up — `STALLED`, `TIMEOUT`, or the caller's own
+`AbortSignal` — sends a `cancel` frame so the handler's `ctx.signal` aborts
+instead of leaking:
+
+```typescript
+rpc.handle('longRunning', async (params, ctx) => {
+  for await (const chunk of source) {
+    if (ctx.signal.aborted) {
+      throw new Error('aborted');
+    }
+    // ...
+  }
+});
+```
+
+`cancel` is fire-and-forget: the caller rejects immediately and drops any
+late `result`/`error` frame for that call id. A handler that settles after
+cancellation is silently discarded — no frame is sent back, and nothing
+throws.
+
+```typescript
+const controller = new AbortController();
+const promise = rpc.invoke('longRunning', undefined, {
+  signal: controller.signal,
+});
+
+controller.abort(); // -> rejects with a CANCELLED error, aborts ctx.signal
+```
+
+## Progress
+
+A handler can piggyback a progress value on its next outgoing heartbeat:
+
+```typescript
+rpc.handle('bulkImport', async (params, ctx) => {
+  for (let i = 0; i < total; i++) {
+    await importOne(items[i]);
+    ctx.progress({ done: i + 1, total });
+  }
+});
+```
+
+```typescript
+await rpc.invoke('bulkImport', undefined, {
+  onProgress: (value) => console.log(value),
+});
+```
+
+## Known limitation: heartbeats only prove the event loop is alive
+
+The heartbeat proves the peer's **event loop** is alive — not that the
+handler is making progress. Synchronous work blocks the heartbeat timer too,
+so a 10-second synchronous loop on either side is indistinguishable from a
+dead peer. **This design cannot detect a synchronous long-running block.**
+Make sure `staleTimeoutMs` exceeds the longest synchronous block you expect
+on either side; if you have known-blocking work, raise `staleTimeoutMs` for
+that call.
+
+## Errors
+
+Errors come in two shapes, discriminated by `kind`:
+
+```typescript
+export type RozeniteRpcError = RozeniteProtocolError | RozeniteHandlerError;
+```
+
+- **`RozeniteProtocolError`** (`kind: 'protocol'`) — a transport/protocol
+  failure: `ACK_TIMEOUT`, `STALLED`, `TIMEOUT`, `CANCELLED`,
+  `METHOD_NOT_FOUND`, `SERIALIZATION_ERROR`, or `CLIENT_CLOSED`. It carries
+  no payload and no remote stack, because the failure isn't in your code.
+  Only `METHOD_NOT_FOUND` and `SERIALIZATION_ERROR` ever travel over the
+  wire as protocol frames — the rest (the three timeouts, `CANCELLED`, and
+  `CLIENT_CLOSED`) are always constructed on the caller's side.
+- **`RozeniteHandlerError`** (`kind: 'handler'`) — the remote handler ran and
+  threw. `error.message` is `` `${method} failed: ${remote.message}` `` and
+  `error.stack` is **your own** call stack, so you always see who invoked
+  the call. The remote's own `name`, `message`, `stack` (development builds
+  only), and any handler-supplied `data` live under `error.remote`.
+
+Narrow on `kind`, not `instanceof` — a plugin's device code and panel code
+are separate bundles, so `instanceof` only happens to work when the error was
+constructed by the bundle doing the check. Use the exported type guards
+instead:
+
+```typescript
+import { isProtocolError, isHandlerError } from '@rozenite/plugin-bridge';
+
+try {
+  await rpc.invoke('readFile', { path });
+} catch (error) {
+  if (isProtocolError(error)) {
+    // error.code: ACK_TIMEOUT | STALLED | TIMEOUT | CANCELLED |
+    //             METHOD_NOT_FOUND | SERIALIZATION_ERROR | CLIENT_CLOSED
+  } else if (isHandlerError(error)) {
+    // error.remote.name / error.remote.message / error.remote.data
+  }
+}
+```
+
+A result (or an error's `data`) that isn't structured-cloneable is turned
+into a `SERIALIZATION_ERROR` protocol error rather than letting the
+underlying transport throw and hang the call.
+
+## API reference
+
+```typescript
+const rpc = createRozeniteRpc<MyMethods>(client);
+
+rpc.invoke(method, params?, options?): Promise<Result>;
+rpc.handle(method, handler): Subscription;
+rpc.close(): void;
+```
+
+- `InvokeOptions.signal?: AbortSignal`
+- `InvokeOptions.ackTimeoutMs?: number` — default `5_000`
+- `InvokeOptions.heartbeatMs?: number` — default `2_000`
+- `InvokeOptions.staleTimeoutMs?: number` — default `6_000`
+- `InvokeOptions.timeoutMs?: number` — default `30_000`, pass `Infinity` to opt out
+- `InvokeOptions.retries?: number` — default `1`, `ACK_TIMEOUT` only
+- `InvokeOptions.onProgress?: (value: unknown) => void`
+
+Registering a second handler for the same method throws immediately, at
+registration time. Calling `close()` removes the underlying message
+subscription and rejects every in-flight call with `CLIENT_CLOSED`.
+
+Out of scope for this API: streaming/`AsyncIterable` results (single-value
+results only — use `onProgress` for incremental updates) and re-entrant calls
+from inside a handler back to its own caller as part of the same request.

--- a/website/src/docs/plugin-development/rpc.md
+++ b/website/src/docs/plugin-development/rpc.md
@@ -24,7 +24,7 @@ type MyMethods = {
   listDevices: () => Promise<Device[]>;
 };
 
-const client = await getRozeniteDevToolsClient<MyEventMap>('your-plugin-id');
+const client = await getRozeniteDevToolsClient('your-plugin-id');
 const rpc = createRozeniteRpc<MyMethods>(client);
 ```
 
@@ -40,15 +40,9 @@ type in your own plugin's event map, or it will collide with the RPC layer.
 
 ## Declaring methods
 
-Methods are declared function-shaped, so params and result are both
-inferred from a single type:
-
-```typescript
-type MyMethods = {
-  readFile: (params: { path: string }) => Promise<string>;
-  listDevices: () => Promise<Device[]>;
-};
-```
+Methods are declared function-shaped, as in the example above, so params and
+result are both inferred from a single type. A method that takes no params is
+declared with no arguments.
 
 ## Registering a handler
 
@@ -67,7 +61,7 @@ Calling is a two-step handle: `method()` names the method and takes the
 call's options, and `invoke()` takes the params.
 
 ```typescript
-await rpc.method('getUser').invoke({ id: '42' });
+await rpc.method('readFile').invoke({ path: 'app.log' });
 await rpc.method('listDevices').invoke();
 await rpc.method('readFile', { timeoutMs: 60_000 }).invoke({ path });
 ```
@@ -81,11 +75,6 @@ const readFile = rpc.method('readFile', { timeoutMs: 60_000 });
 await readFile.invoke({ path: 'a' });
 await readFile.invoke({ path: 'b' });
 ```
-
-Note that the handle is a plain object with an `invoke` method — it is not
-itself callable. A remote call that reads like an ordinary function call
-hides the fact that it can time out, stall, or be cancelled; `.invoke()`
-keeps that round-trip visible at the call site.
 
 ## Why a single timeout isn't enough
 


### PR DESCRIPTION
## Description

Adds `createRozeniteRpc` to `@rozenite/plugin-bridge` — a request/response RPC layer built on top of the existing `RozeniteDevToolsClient` fire-and-forget messaging. Instead of every plugin hand-rolling a correlation id, a response event, and an ad-hoc timeout, plugins get:

```ts
const rpc = createRozeniteRpc<MyMethods>(client);

const result = await rpc.method('getUser').invoke({ id: '42' });
rpc.handle('getUser', async ({ id }) => ({ id, name: 'Ada' }));
```

Calling is a two-step handle: `rpc.method(name, options?)` returns a plain (non-callable) handle holding only the method name and its options, and `.invoke(params?)` takes the params. This is the only call form — options live exclusively on `method()`, params exclusively on `invoke()`, so there is no runtime disambiguation of a lone trailing argument. A handle is free to construct per call and equally fine to reuse:

```ts
const readFile = rpc.method('readFile', { timeoutMs: 60_000 });
await readFile.invoke({ path: 'a' });
await readFile.invoke({ path: 'b' });
```

The abstraction is symmetric (both device and panel can `method().invoke()`/`handle`), reserves a single message type (`'rozenite:rpc'`) on the existing client/channel, and adds no new subpath export or changes to `exports`/`vite.config.ts`.

Delivery guarantees, per the design in #350:
- Receiver acks synchronously, then heartbeats (`heartbeatMs`, caller-dictated) while the handler runs. Heartbeats carry no payload.
- Three independent caller-side timers: `ackTimeoutMs` (request → ack, retryable), `staleTimeoutMs` (since last ack/heartbeat, `STALLED`), `timeoutMs` (absolute cap, `TIMEOUT`).
- `retries` (default `1`) applies only to `ACK_TIMEOUT`; each retry uses a fresh id.
- Every caller give-up (`STALLED`/`TIMEOUT`/`AbortSignal`) sends a `cancel` frame that aborts the handler's `ctx.signal`; a late `result`/`error` after cancellation is silently discarded.
- Errors are a discriminated union — `RozeniteProtocolError` (transport/protocol failures, no remote stack) vs. `RozeniteHandlerError` (remote threw; `remote.stack` only in dev). Guarded with `isProtocolError`/`isHandlerError` (narrow on `kind`, not `instanceof`, since device and panel are separate bundles).
- Non-cloneable results/error data become `SERIALIZATION_ERROR` instead of hanging the call.
- `close()` rejects in-flight calls with `CLIENT_CLOSED` and removes the underlying subscription. Duplicate `handle()` for a method throws at registration time.

Also adds `"sideEffects": false` to `packages/plugin-bridge/package.json` (the RPC module is pure declarations plus a factory, so the flag is accurate for the package as a whole).

**Out of scope for v1** (also per #350): streaming/`AsyncIterable` results, and progress reporting (`ctx.progress()`/`onProgress`) — cut after review because it would have been the only untyped, lossy hole in an otherwise fully-inferred, fully-typed API. Both are purely additive if added later.

## Related Issue

Closes #350

## Context

Followed the spec in #350 as written, including two decisions that changed after review and are reflected in the current issue body: the call surface is `method(name, options?).invoke(params?)` rather than a single `invoke(method, ...args)` with runtime heuristics to tell params apart from options, and progress reporting was cut entirely rather than shipped in v1.

## Testing

```
pnpm --filter @rozenite/plugin-bridge test        # 25 passed (3 files)
pnpm --filter @rozenite/plugin-bridge typecheck    # clean
pnpm --filter @rozenite/plugin-bridge lint         # clean
pnpm --filter @rozenite/plugin-bridge build        # clean
pnpm release:plan                                  # @rozenite/plugin-bridge picked up for the minor bump
```

Tests use an in-memory pair of fake `RozeniteDevToolsClient`s (with frame drop/delay controls) and `vi.useFakeTimers()`, covering: happy path, zero-arg methods, a reused method handle across multiple calls, `METHOD_NOT_FOUND`, `ACK_TIMEOUT` with/without retry (fresh id per retry), `STALLED` after missed heartbeats, `TIMEOUT` on a never-resolving-but-heartbeating handler, a slow-but-heartbeating handler that does *not* trip `staleTimeoutMs`, caller `AbortSignal` → `cancel` → `ctx.signal` aborted, a late result dropped after cancellation, handler error propagation, `stack` present in dev / absent in production, non-cloneable result → `SERIALIZATION_ERROR`, `close()` → `CLIENT_CLOSED`, and duplicate `handle()` throwing. A separate type-only file (`rpc-types.test.ts`) uses `expectTypeOf` and `@ts-expect-error` (checked by the `typecheck` script) to verify params/result inference through the handle, that `method('zeroArg').invoke()` is valid while passing it params is a type error, that options passed to `invoke()` are a type error, and that unknown method names are a type error.

Also rewrote the docs page (`website/src/docs/plugin-development/rpc.md`, registered in `_meta.json`) for plugin authors — usage, the timer table and defaults, cancellation, the synchronous-blocking limitation, and the error union — and kept the version plan (`.changeset/rpc-abstraction.md`, minor bump for `@rozenite/plugin-bridge`).
