### PR TITLE
feat(ui): add core control and data-display primitives

### DIFF
--- a/.changeset/ui-primitives.md
+++ b/.changeset/ui-primitives.md
@@ -1,0 +1,10 @@
+---
+'@rozenite/ui': minor
+---
+
+Add `@rozenite/ui` core control and data-display primitives: `Select`,
+`Combobox`, `Dialog`, `Tooltip`, `Tabs`, `ScrollArea`, `Field`, `Toolbar`,
+and `Toast` built on Base UI, plus `Button`, `Badge`, `Input`, `SearchField`,
+`DataTable` (sortable, editable, with row actions), `Sidebar`, `EmptyState`,
+`ConfirmDialog`, `JsonInspector`, and a `useCopyToClipboard` hook for
+building DevTools plugin panels.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -47,6 +47,8 @@
     "test": "vitest --run --passWithNoTests"
   },
   "dependencies": {
+    "@base-ui/react": "^1.7.0",
+    "@tanstack/react-table": "^8.21.3",
     "clsx": "^2.1.1",
     "tailwind-merge": "^3.3.1",
     "class-variance-authority": "^0.7.1",

--- a/packages/ui/src/badge/badge.tsx
+++ b/packages/ui/src/badge/badge.tsx
@@ -1,0 +1,32 @@
+import type { ComponentProps } from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '../utils/cn';
+
+export const badgeVariants = cva(
+  'inline-flex w-fit shrink-0 items-center justify-center rounded-full px-2 py-0.5 text-xs font-medium whitespace-nowrap',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground',
+        secondary: 'bg-secondary text-secondary-foreground',
+        outline: 'border border-border text-foreground',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+);
+
+export type BadgeProps = ComponentProps<'span'> &
+  VariantProps<typeof badgeVariants>;
+
+export function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <span
+      data-slot="badge"
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}

--- a/packages/ui/src/button/button.tsx
+++ b/packages/ui/src/button/button.tsx
@@ -1,0 +1,55 @@
+import type { ComponentProps } from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '../utils/cn';
+
+export const buttonVariants = cva(
+  cn(
+    'inline-flex shrink-0 items-center justify-center gap-1.5 whitespace-nowrap rounded-md text-sm font-medium transition-colors',
+    'outline-none focus-visible:ring-2 focus-visible:ring-ring',
+    'disabled:pointer-events-none disabled:opacity-50',
+    '[&_svg]:pointer-events-none [&_svg]:shrink-0',
+  ),
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        secondary:
+          'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        destructive:
+          'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+        outline:
+          'border border-input bg-transparent text-foreground hover:bg-accent hover:text-accent-foreground',
+        ghost: 'text-foreground hover:bg-accent hover:text-accent-foreground',
+      },
+      size: {
+        default: 'h-8 px-3 [&_svg]:size-4',
+        compact: 'h-6 px-2 text-xs [&_svg]:size-3.5',
+        icon: 'h-8 w-8 [&_svg]:size-4',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  },
+);
+
+export type ButtonProps = ComponentProps<'button'> &
+  VariantProps<typeof buttonVariants>;
+
+export function Button({
+  className,
+  variant,
+  size,
+  type = 'button',
+  ...props
+}: ButtonProps) {
+  return (
+    <button
+      type={type}
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size }), className)}
+      {...props}
+    />
+  );
+}

--- a/packages/ui/src/combobox/combobox.tsx
+++ b/packages/ui/src/combobox/combobox.tsx
@@ -1,0 +1,124 @@
+import type { ReactNode } from 'react';
+import { Combobox as ComboboxPrimitive } from '@base-ui/react/combobox';
+import { Check, ChevronsUpDown, X } from 'lucide-react';
+import { cn } from '../utils/cn';
+import { usePluginPortalContainer } from '../theme/theme-context';
+
+export type ComboboxProps<
+  Value,
+  Multiple extends boolean | undefined = false,
+> = ComboboxPrimitive.Root.Props<Value, Multiple>;
+
+function ComboboxRoot<Value, Multiple extends boolean | undefined = false>(
+  props: ComboboxProps<Value, Multiple>,
+) {
+  return <ComboboxPrimitive.Root {...props} />;
+}
+
+export type ComboboxInputProps = ComboboxPrimitive.Input.Props;
+
+function ComboboxInput({ className, ...props }: ComboboxInputProps) {
+  return (
+    <ComboboxPrimitive.InputGroup
+      data-slot="combobox-input-group"
+      className="relative flex items-center"
+    >
+      <ComboboxPrimitive.Input
+        data-slot="combobox-input"
+        className={cn(
+          'h-8 w-full rounded-md border border-input bg-transparent px-3 pr-14 text-sm text-foreground shadow-xs',
+          'outline-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50',
+          'placeholder:text-muted-foreground disabled:pointer-events-none disabled:opacity-50',
+          className,
+        )}
+        {...props}
+      />
+      <div className="absolute right-1.5 flex items-center gap-0.5">
+        <ComboboxPrimitive.Clear
+          data-slot="combobox-clear"
+          className="inline-flex h-5 w-5 items-center justify-center rounded-sm text-muted-foreground hover:text-foreground"
+        >
+          <X className="h-3.5 w-3.5" />
+        </ComboboxPrimitive.Clear>
+        <ComboboxPrimitive.Icon data-slot="combobox-icon">
+          <ChevronsUpDown className="h-3.5 w-3.5 text-muted-foreground" />
+        </ComboboxPrimitive.Icon>
+      </div>
+    </ComboboxPrimitive.InputGroup>
+  );
+}
+
+export type ComboboxContentProps = ComboboxPrimitive.Popup.Props &
+  Pick<ComboboxPrimitive.Positioner.Props, 'side' | 'sideOffset' | 'align'> & {
+    /** Shown when the list has no matching items. */
+    emptyMessage?: ReactNode;
+  };
+
+function ComboboxContent({
+  className,
+  side = 'bottom',
+  sideOffset = 4,
+  align = 'start',
+  emptyMessage = 'No results found.',
+  children,
+  ...props
+}: ComboboxContentProps) {
+  const container = usePluginPortalContainer();
+
+  return (
+    <ComboboxPrimitive.Portal container={container}>
+      <ComboboxPrimitive.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        className="z-50"
+      >
+        <ComboboxPrimitive.Popup
+          data-slot="combobox-content"
+          className={cn(
+            'max-h-64 min-w-[--anchor-width] overflow-y-auto rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md',
+            'origin-(--transform-origin) transition-[transform,scale,opacity] data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0',
+            className,
+          )}
+          {...props}
+        >
+          <ComboboxPrimitive.Empty
+            data-slot="combobox-empty"
+            className="px-2 py-1.5 text-sm text-muted-foreground"
+          >
+            {emptyMessage}
+          </ComboboxPrimitive.Empty>
+          <ComboboxPrimitive.List>{children}</ComboboxPrimitive.List>
+        </ComboboxPrimitive.Popup>
+      </ComboboxPrimitive.Positioner>
+    </ComboboxPrimitive.Portal>
+  );
+}
+
+export type ComboboxItemProps = ComboboxPrimitive.Item.Props;
+
+function ComboboxItem({ className, children, ...props }: ComboboxItemProps) {
+  return (
+    <ComboboxPrimitive.Item
+      data-slot="combobox-item"
+      className={cn(
+        'flex cursor-default items-center justify-between gap-2 rounded-sm px-2 py-1.5 text-sm text-foreground select-none',
+        'data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground',
+        'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <ComboboxPrimitive.ItemIndicator>
+        <Check className="h-3.5 w-3.5" />
+      </ComboboxPrimitive.ItemIndicator>
+    </ComboboxPrimitive.Item>
+  );
+}
+
+export const Combobox = Object.assign(ComboboxRoot, {
+  Input: ComboboxInput,
+  Content: ComboboxContent,
+  Item: ComboboxItem,
+});

--- a/packages/ui/src/confirm-dialog/confirm-dialog.tsx
+++ b/packages/ui/src/confirm-dialog/confirm-dialog.tsx
@@ -1,0 +1,63 @@
+import type { ReactNode } from 'react';
+import { Dialog } from '../dialog/dialog';
+import { Button } from '../button/button';
+
+export type ConfirmDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: ReactNode;
+  description?: ReactNode;
+  /**
+   * `'confirm'` renders Cancel + Confirm buttons; `'alert'` renders a single
+   * acknowledgement button and no cancel affordance.
+   * @default 'confirm'
+   */
+  variant?: 'confirm' | 'alert';
+  /** Styles the confirm/OK button as destructive. */
+  destructive?: boolean;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  onConfirm?: () => void;
+};
+
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  variant = 'confirm',
+  destructive = false,
+  confirmLabel,
+  cancelLabel = 'Cancel',
+  onConfirm,
+}: ConfirmDialogProps) {
+  const isAlert = variant === 'alert';
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <Dialog.Content showCloseButton={false}>
+        <Dialog.Header>
+          <Dialog.Title>{title}</Dialog.Title>
+          {description && (
+            <Dialog.Description>{description}</Dialog.Description>
+          )}
+        </Dialog.Header>
+        <Dialog.Footer>
+          {!isAlert && (
+            <Dialog.Close render={<Button variant="outline" />}>
+              {cancelLabel}
+            </Dialog.Close>
+          )}
+          <Dialog.Close
+            render={
+              <Button variant={destructive ? 'destructive' : 'default'} />
+            }
+            onClick={onConfirm}
+          >
+            {confirmLabel ?? (isAlert ? 'OK' : 'Confirm')}
+          </Dialog.Close>
+        </Dialog.Footer>
+      </Dialog.Content>
+    </Dialog>
+  );
+}

--- a/packages/ui/src/data-table/data-table-editable-cell.tsx
+++ b/packages/ui/src/data-table/data-table-editable-cell.tsx
@@ -1,0 +1,72 @@
+import { useState, type ComponentProps } from 'react';
+import { cn } from '../utils/cn';
+
+export type DataTableEditableCellProps = Omit<
+  ComponentProps<'input'>,
+  'value' | 'onChange' | 'onCommit'
+> & {
+  value: string;
+  /** Called with the new value when the edit is confirmed (Enter or blur). */
+  onCommit: (value: string) => void;
+};
+
+/**
+ * Click-to-edit text cell for `DataTable`. Renders the value as plain text
+ * until clicked, then swaps to an input; commits on Enter or blur, discards
+ * on Escape.
+ */
+export function DataTableEditableCell({
+  value,
+  onCommit,
+  className,
+  ...props
+}: DataTableEditableCellProps) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(value);
+
+  if (!editing) {
+    return (
+      <button
+        type="button"
+        onClick={() => {
+          setDraft(value);
+          setEditing(true);
+        }}
+        className={cn(
+          'w-full rounded-sm px-1 py-0.5 text-left hover:bg-accent/50',
+          className,
+        )}
+      >
+        {value}
+      </button>
+    );
+  }
+
+  const commit = () => {
+    setEditing(false);
+    if (draft !== value) {
+      onCommit(draft);
+    }
+  };
+
+  return (
+    <input
+      autoFocus
+      value={draft}
+      onChange={(event) => setDraft(event.target.value)}
+      onBlur={commit}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter') {
+          commit();
+        } else if (event.key === 'Escape') {
+          setEditing(false);
+        }
+      }}
+      className={cn(
+        'w-full rounded-sm border border-ring bg-transparent px-1 py-0.5 outline-none',
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/packages/ui/src/data-table/data-table-utils.test.ts
+++ b/packages/ui/src/data-table/data-table-utils.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { updateCellValue } from './data-table-utils';
+
+describe('updateCellValue', () => {
+  const data = [
+    { key: 'a', value: '1' },
+    { key: 'b', value: '2' },
+  ];
+
+  it('replaces the field on the targeted row', () => {
+    const result = updateCellValue(data, 1, 'value', '99');
+    expect(result[1]).toEqual({ key: 'b', value: '99' });
+  });
+
+  it('leaves other rows untouched', () => {
+    const result = updateCellValue(data, 1, 'value', '99');
+    expect(result[0]).toBe(data[0]);
+  });
+
+  it('does not mutate the original array or row', () => {
+    const result = updateCellValue(data, 0, 'key', 'z');
+    expect(data[0].key).toBe('a');
+    expect(result).not.toBe(data);
+    expect(result[0]).not.toBe(data[0]);
+  });
+
+  it('is a no-op replacement when the row index is out of range', () => {
+    const result = updateCellValue(data, 5, 'value', 'x');
+    expect(result).toEqual(data);
+  });
+});

--- a/packages/ui/src/data-table/data-table-utils.ts
+++ b/packages/ui/src/data-table/data-table-utils.ts
@@ -1,0 +1,14 @@
+/**
+ * Returns a new array with a single row's field replaced, for committing an
+ * inline cell edit without mutating the original data.
+ */
+export function updateCellValue<TRow extends Record<string, unknown>>(
+  data: TRow[],
+  rowIndex: number,
+  columnId: string,
+  value: unknown,
+): TRow[] {
+  return data.map((row, index) =>
+    index === rowIndex ? { ...row, [columnId]: value } : row,
+  );
+}

--- a/packages/ui/src/data-table/data-table.tsx
+++ b/packages/ui/src/data-table/data-table.tsx
@@ -1,0 +1,164 @@
+import { useState, type ReactNode } from 'react';
+import {
+  flexRender,
+  getCoreRowModel,
+  getSortedRowModel,
+  useReactTable,
+  type ColumnDef,
+  type SortingState,
+} from '@tanstack/react-table';
+import { ChevronDown, ChevronUp, ChevronsUpDown } from 'lucide-react';
+import { cn } from '../utils/cn';
+
+declare module '@tanstack/react-table' {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- required by the RowData constraint of TableMeta
+  interface TableMeta<TData> {
+    /** Commits an inline edit made in a cell back to the caller's data. */
+    updateData: (rowIndex: number, columnId: string, value: unknown) => void;
+  }
+}
+
+export type DataTableColumn<TRow> = ColumnDef<TRow, any>;
+
+export type DataTableProps<TRow> = {
+  columns: DataTableColumn<TRow>[];
+  data: TRow[];
+  className?: string;
+  /** Shows a loading row in place of the table body. */
+  loading?: boolean;
+  /** Shown instead of rows when `data` is empty and not loading. */
+  emptyMessage?: ReactNode;
+  onRowClick?: (row: TRow) => void;
+  /**
+   * Called when a cell editor commits a new value. Wire this up to your own
+   * state update (e.g. `updateCellValue` from this package) and pass the
+   * updated array back in as `data`.
+   */
+  onCellEdit?: (rowIndex: number, columnId: string, value: unknown) => void;
+  getRowId?: (row: TRow, index: number) => string;
+};
+
+export function DataTable<TRow>({
+  columns,
+  data,
+  className,
+  loading = false,
+  emptyMessage = 'No data.',
+  onRowClick,
+  onCellEdit,
+  getRowId,
+}: DataTableProps<TRow>) {
+  const [sorting, setSorting] = useState<SortingState>([]);
+
+  const table = useReactTable({
+    data,
+    columns,
+    state: { sorting },
+    onSortingChange: setSorting,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getRowId,
+    meta: {
+      updateData: (rowIndex, columnId, value) => {
+        onCellEdit?.(rowIndex, columnId, value);
+      },
+    },
+  });
+
+  const columnCount = columns.length;
+
+  return (
+    <table
+      data-slot="data-table"
+      className={cn('w-full border-collapse text-sm', className)}
+    >
+      <thead data-slot="data-table-head">
+        {table.getHeaderGroups().map((headerGroup) => (
+          <tr key={headerGroup.id} className="border-b border-border">
+            {headerGroup.headers.map((header) => {
+              const canSort = header.column.getCanSort();
+              const sortDirection = header.column.getIsSorted();
+
+              return (
+                <th
+                  key={header.id}
+                  colSpan={header.colSpan}
+                  className="h-8 px-3 text-left text-xs font-medium text-muted-foreground"
+                >
+                  {header.isPlaceholder ? null : canSort ? (
+                    <button
+                      type="button"
+                      onClick={header.column.getToggleSortingHandler()}
+                      className="inline-flex items-center gap-1 hover:text-foreground"
+                    >
+                      {flexRender(
+                        header.column.columnDef.header,
+                        header.getContext(),
+                      )}
+                      <SortIcon direction={sortDirection} />
+                    </button>
+                  ) : (
+                    flexRender(
+                      header.column.columnDef.header,
+                      header.getContext(),
+                    )
+                  )}
+                </th>
+              );
+            })}
+          </tr>
+        ))}
+      </thead>
+      <tbody data-slot="data-table-body">
+        {loading ? (
+          <tr>
+            <td
+              colSpan={columnCount}
+              className="h-16 text-center text-xs text-muted-foreground"
+            >
+              Loading…
+            </td>
+          </tr>
+        ) : data.length === 0 ? (
+          <tr>
+            <td
+              colSpan={columnCount}
+              className="h-16 text-center text-xs text-muted-foreground"
+            >
+              {emptyMessage}
+            </td>
+          </tr>
+        ) : (
+          table.getRowModel().rows.map((row) => (
+            <tr
+              key={row.id}
+              onClick={onRowClick ? () => onRowClick(row.original) : undefined}
+              className={cn(
+                'border-b border-border last:border-0',
+                onRowClick && 'cursor-pointer hover:bg-accent/50',
+              )}
+            >
+              {row.getVisibleCells().map((cell) => (
+                <td key={cell.id} className="px-3 py-1.5 text-foreground">
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </td>
+              ))}
+            </tr>
+          ))
+        )}
+      </tbody>
+    </table>
+  );
+}
+
+function SortIcon({ direction }: { direction: false | 'asc' | 'desc' }) {
+  if (direction === 'asc') {
+    return <ChevronUp className="h-3 w-3" />;
+  }
+
+  if (direction === 'desc') {
+    return <ChevronDown className="h-3 w-3" />;
+  }
+
+  return <ChevronsUpDown className="h-3 w-3 text-muted-foreground/60" />;
+}

--- a/packages/ui/src/dialog/dialog.tsx
+++ b/packages/ui/src/dialog/dialog.tsx
@@ -1,0 +1,136 @@
+import type { ComponentProps } from 'react';
+import { Dialog as DialogPrimitive } from '@base-ui/react/dialog';
+import { X } from 'lucide-react';
+import { cn } from '../utils/cn';
+import { usePluginPortalContainer } from '../theme/theme-context';
+
+export type DialogProps = DialogPrimitive.Root.Props;
+
+function DialogRoot(props: DialogProps) {
+  return <DialogPrimitive.Root {...props} />;
+}
+
+export type DialogTriggerProps = DialogPrimitive.Trigger.Props;
+
+function DialogTrigger(props: DialogTriggerProps) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+}
+
+export type DialogCloseProps = DialogPrimitive.Close.Props;
+
+function DialogClose(props: DialogCloseProps) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
+}
+
+export type DialogContentProps = DialogPrimitive.Popup.Props & {
+  /** Hides the built-in close button in the top-right corner. */
+  showCloseButton?: boolean;
+};
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: DialogContentProps) {
+  const container = usePluginPortalContainer();
+
+  return (
+    <DialogPrimitive.Portal container={container}>
+      <DialogPrimitive.Backdrop
+        data-slot="dialog-backdrop"
+        className={cn(
+          'fixed inset-0 z-50 bg-background/70',
+          'transition-opacity data-[ending-style]:opacity-0 data-[starting-style]:opacity-0',
+        )}
+      />
+      <DialogPrimitive.Viewport className="fixed inset-0 z-50 flex items-center justify-center p-4">
+        <DialogPrimitive.Popup
+          data-slot="dialog-content"
+          className={cn(
+            'relative flex w-full max-w-md flex-col gap-4 rounded-lg border border-border bg-card p-6 text-card-foreground shadow-lg',
+            'transition-[transform,scale,opacity] data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0',
+            className,
+          )}
+          {...props}
+        >
+          {children}
+          {showCloseButton && (
+            <DialogPrimitive.Close
+              data-slot="dialog-close"
+              aria-label="Close"
+              className={cn(
+                'absolute top-4 right-4 inline-flex h-6 w-6 items-center justify-center rounded-sm text-muted-foreground',
+                'hover:bg-accent hover:text-accent-foreground',
+                'outline-none focus-visible:ring-2 focus-visible:ring-ring',
+              )}
+            >
+              <X className="h-4 w-4" />
+            </DialogPrimitive.Close>
+          )}
+        </DialogPrimitive.Popup>
+      </DialogPrimitive.Viewport>
+    </DialogPrimitive.Portal>
+  );
+}
+
+export type DialogHeaderProps = ComponentProps<'div'>;
+
+function DialogHeader({ className, ...props }: DialogHeaderProps) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn('flex flex-col gap-1.5', className)}
+      {...props}
+    />
+  );
+}
+
+export type DialogFooterProps = ComponentProps<'div'>;
+
+function DialogFooter({ className, ...props }: DialogFooterProps) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export type DialogTitleProps = DialogPrimitive.Title.Props;
+
+function DialogTitle({ className, ...props }: DialogTitleProps) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn('text-sm font-semibold text-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+export type DialogDescriptionProps = DialogPrimitive.Description.Props;
+
+function DialogDescription({ className, ...props }: DialogDescriptionProps) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn('text-sm text-muted-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+export const Dialog = Object.assign(DialogRoot, {
+  Trigger: DialogTrigger,
+  Close: DialogClose,
+  Content: DialogContent,
+  Header: DialogHeader,
+  Footer: DialogFooter,
+  Title: DialogTitle,
+  Description: DialogDescription,
+});

--- a/packages/ui/src/empty-state/empty-state.tsx
+++ b/packages/ui/src/empty-state/empty-state.tsx
@@ -1,0 +1,38 @@
+import type { ComponentProps, ComponentType, ReactNode } from 'react';
+import { cn } from '../utils/cn';
+
+export type EmptyStateProps = ComponentProps<'div'> & {
+  /** A `lucide-react` icon component, rendered above the title. */
+  icon?: ComponentType<{ className?: string }>;
+  title: ReactNode;
+  description?: ReactNode;
+  /** e.g. a `Button` to retry or take a corrective action. */
+  action?: ReactNode;
+};
+
+export function EmptyState({
+  className,
+  icon: Icon,
+  title,
+  description,
+  action,
+  ...props
+}: EmptyStateProps) {
+  return (
+    <div
+      data-slot="empty-state"
+      className={cn(
+        'flex flex-1 flex-col items-center justify-center gap-1.5 p-8 text-center',
+        className,
+      )}
+      {...props}
+    >
+      {Icon && <Icon className="mb-2 h-8 w-8 text-muted-foreground" />}
+      <p className="text-sm font-medium text-foreground">{title}</p>
+      {description && (
+        <p className="max-w-sm text-sm text-muted-foreground">{description}</p>
+      )}
+      {action && <div className="mt-3">{action}</div>}
+    </div>
+  );
+}

--- a/packages/ui/src/field/field.tsx
+++ b/packages/ui/src/field/field.tsx
@@ -1,0 +1,74 @@
+import { Field as FieldPrimitive } from '@base-ui/react/field';
+import { cn } from '../utils/cn';
+
+export type FieldProps = FieldPrimitive.Root.Props;
+
+function FieldRoot({ className, ...props }: FieldProps) {
+  return (
+    <FieldPrimitive.Root
+      data-slot="field"
+      className={cn('flex flex-col gap-1.5', className)}
+      {...props}
+    />
+  );
+}
+
+export type FieldLabelProps = FieldPrimitive.Label.Props;
+
+function FieldLabel({ className, ...props }: FieldLabelProps) {
+  return (
+    <FieldPrimitive.Label
+      data-slot="field-label"
+      className={cn('text-sm font-medium text-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+export type FieldControlProps = FieldPrimitive.Control.Props;
+
+function FieldControl({ className, ...props }: FieldControlProps) {
+  return (
+    <FieldPrimitive.Control
+      data-slot="field-control"
+      className={cn(
+        'h-8 w-full rounded-md border border-input bg-transparent px-3 text-sm text-foreground shadow-xs',
+        'outline-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50',
+        'placeholder:text-muted-foreground disabled:pointer-events-none disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export type FieldDescriptionProps = FieldPrimitive.Description.Props;
+
+function FieldDescription({ className, ...props }: FieldDescriptionProps) {
+  return (
+    <FieldPrimitive.Description
+      data-slot="field-description"
+      className={cn('text-xs text-muted-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+export type FieldErrorProps = FieldPrimitive.Error.Props;
+
+function FieldError({ className, ...props }: FieldErrorProps) {
+  return (
+    <FieldPrimitive.Error
+      data-slot="field-error"
+      className={cn('text-xs text-destructive', className)}
+      {...props}
+    />
+  );
+}
+
+export const Field = Object.assign(FieldRoot, {
+  Label: FieldLabel,
+  Control: FieldControl,
+  Description: FieldDescription,
+  Error: FieldError,
+});

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -25,3 +25,111 @@ export type {
 
 export { usePluginTheme } from './theme/theme-context';
 export type { PluginTheme } from './theme/resolve-theme';
+
+export { Select } from './select/select';
+export type {
+  SelectProps,
+  SelectTriggerProps,
+  SelectValueProps,
+  SelectContentProps,
+  SelectItemProps,
+} from './select/select';
+
+export { Combobox } from './combobox/combobox';
+export type {
+  ComboboxProps,
+  ComboboxInputProps,
+  ComboboxContentProps,
+  ComboboxItemProps,
+} from './combobox/combobox';
+
+export { Dialog } from './dialog/dialog';
+export type {
+  DialogProps,
+  DialogTriggerProps,
+  DialogCloseProps,
+  DialogContentProps,
+  DialogHeaderProps,
+  DialogFooterProps,
+  DialogTitleProps,
+  DialogDescriptionProps,
+} from './dialog/dialog';
+
+export { Tooltip } from './tooltip/tooltip';
+export type {
+  TooltipProviderProps,
+  TooltipProps,
+  TooltipTriggerProps,
+  TooltipContentProps,
+} from './tooltip/tooltip';
+
+export { Tabs } from './tabs/tabs';
+export type {
+  TabsProps,
+  TabsListProps,
+  TabsTabProps,
+  TabsPanelProps,
+} from './tabs/tabs';
+
+export { ScrollArea } from './scroll-area/scroll-area';
+export type { ScrollAreaProps } from './scroll-area/scroll-area';
+
+export { Field } from './field/field';
+export type {
+  FieldProps,
+  FieldLabelProps,
+  FieldControlProps,
+  FieldDescriptionProps,
+  FieldErrorProps,
+} from './field/field';
+
+export { Toolbar } from './toolbar/toolbar';
+export type {
+  ToolbarProps,
+  ToolbarButtonProps,
+  ToolbarSeparatorProps,
+  ToolbarGroupProps,
+} from './toolbar/toolbar';
+
+export { Toast, useToast } from './toast/toast';
+export type { ToastProviderProps } from './toast/toast';
+
+export { Button, buttonVariants } from './button/button';
+export type { ButtonProps } from './button/button';
+
+export { Badge, badgeVariants } from './badge/badge';
+export type { BadgeProps } from './badge/badge';
+
+export { Input } from './input/input';
+export type { InputProps } from './input/input';
+
+export { SearchField } from './search-field/search-field';
+export type { SearchFieldProps } from './search-field/search-field';
+
+export { DataTable } from './data-table/data-table';
+export type { DataTableProps, DataTableColumn } from './data-table/data-table';
+export { DataTableEditableCell } from './data-table/data-table-editable-cell';
+export type { DataTableEditableCellProps } from './data-table/data-table-editable-cell';
+export { updateCellValue } from './data-table/data-table-utils';
+
+export { Sidebar } from './sidebar/sidebar';
+export type {
+  SidebarProps,
+  SidebarGroupProps,
+  SidebarItemProps,
+} from './sidebar/sidebar';
+
+export { EmptyState } from './empty-state/empty-state';
+export type { EmptyStateProps } from './empty-state/empty-state';
+
+export { ConfirmDialog } from './confirm-dialog/confirm-dialog';
+export type { ConfirmDialogProps } from './confirm-dialog/confirm-dialog';
+
+export { JsonInspector } from './json-inspector/json-inspector';
+export type { JsonInspectorProps } from './json-inspector/json-inspector';
+
+export { useCopyToClipboard } from './use-copy-to-clipboard/use-copy-to-clipboard';
+export type {
+  UseCopyToClipboardOptions,
+  UseCopyToClipboardResult,
+} from './use-copy-to-clipboard/use-copy-to-clipboard';

--- a/packages/ui/src/input/input.tsx
+++ b/packages/ui/src/input/input.tsx
@@ -1,0 +1,20 @@
+import type { ComponentProps } from 'react';
+import { cn } from '../utils/cn';
+
+export type InputProps = ComponentProps<'input'>;
+
+export function Input({ className, type = 'text', ...props }: InputProps) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        'h-8 w-full min-w-0 rounded-md border border-input bg-transparent px-3 text-sm text-foreground shadow-xs transition-colors',
+        'outline-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50',
+        'placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/packages/ui/src/json-inspector/json-inspector.tsx
+++ b/packages/ui/src/json-inspector/json-inspector.tsx
@@ -1,0 +1,122 @@
+import { useState } from 'react';
+import { ChevronRight } from 'lucide-react';
+import { cn } from '../utils/cn';
+import {
+  classifyValue,
+  getChildKeys,
+  getContainerSummary,
+  isExpandable,
+  type JsonNodeType,
+} from './json-node';
+
+export type JsonInspectorProps = {
+  data: unknown;
+  className?: string;
+  /** Root nesting depths expanded by default. @default 1 */
+  defaultExpandedDepth?: number;
+};
+
+export function JsonInspector({
+  data,
+  className,
+  defaultExpandedDepth = 1,
+}: JsonInspectorProps) {
+  return (
+    <div
+      data-slot="json-inspector"
+      className={cn('font-mono text-xs', className)}
+    >
+      <JsonNodeView
+        label={null}
+        value={data}
+        depth={0}
+        defaultExpandedDepth={defaultExpandedDepth}
+      />
+    </div>
+  );
+}
+
+type JsonNodeViewProps = {
+  label: string | null;
+  value: unknown;
+  depth: number;
+  defaultExpandedDepth: number;
+};
+
+function JsonNodeView({
+  label,
+  value,
+  depth,
+  defaultExpandedDepth,
+}: JsonNodeViewProps) {
+  const [expanded, setExpanded] = useState(depth < defaultExpandedDepth);
+  const expandable = isExpandable(value);
+
+  if (!expandable) {
+    return (
+      <div data-slot="json-inspector-leaf" className="flex gap-1">
+        {label !== null && (
+          <span className="text-muted-foreground">{label}:</span>
+        )}
+        <LeafValue value={value} />
+      </div>
+    );
+  }
+
+  const childKeys = getChildKeys(value) ?? [];
+
+  return (
+    <div data-slot="json-inspector-node">
+      <button
+        type="button"
+        onClick={() => setExpanded((prev) => !prev)}
+        className="inline-flex items-center gap-1 text-foreground hover:text-primary"
+      >
+        <ChevronRight
+          className={cn(
+            'h-3 w-3 shrink-0 text-muted-foreground transition-transform',
+            expanded && 'rotate-90',
+          )}
+        />
+        {label !== null && (
+          <span className="text-muted-foreground">{label}:</span>
+        )}
+        <span className="text-muted-foreground">
+          {getContainerSummary(value)}
+        </span>
+      </button>
+      {expanded && (
+        <div className="ml-3.5 border-l border-border pl-2">
+          {childKeys.map((key) => (
+            <JsonNodeView
+              key={key}
+              label={key}
+              value={(value as Record<string, unknown>)[key]}
+              depth={depth + 1}
+              defaultExpandedDepth={defaultExpandedDepth}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const LEAF_COLOR_BY_TYPE: Partial<Record<JsonNodeType, string>> = {
+  string: 'text-primary',
+  number: 'text-accent-foreground',
+  boolean: 'text-secondary-foreground',
+  null: 'text-destructive',
+  undefined: 'text-destructive',
+};
+
+function LeafValue({ value }: { value: unknown }) {
+  const type = classifyValue(value);
+  const text = type === 'string' ? `"${value as string}"` : String(value);
+
+  return (
+    <span className={LEAF_COLOR_BY_TYPE[type] ?? 'text-foreground'}>
+      {text}
+    </span>
+  );
+}

--- a/packages/ui/src/json-inspector/json-node.test.ts
+++ b/packages/ui/src/json-inspector/json-node.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import {
+  classifyValue,
+  getChildKeys,
+  getContainerSummary,
+  isExpandable,
+} from './json-node';
+
+describe('classifyValue', () => {
+  it('classifies primitives', () => {
+    expect(classifyValue('a')).toBe('string');
+    expect(classifyValue(1)).toBe('number');
+    expect(classifyValue(true)).toBe('boolean');
+    expect(classifyValue(undefined)).toBe('undefined');
+    expect(classifyValue(10n)).toBe('bigint');
+  });
+
+  it('classifies null distinctly from object', () => {
+    expect(classifyValue(null)).toBe('null');
+    expect(classifyValue({})).toBe('object');
+  });
+
+  it('classifies arrays distinctly from objects', () => {
+    expect(classifyValue([])).toBe('array');
+    expect(classifyValue([1, 2])).toBe('array');
+  });
+});
+
+describe('isExpandable', () => {
+  it('is true only for objects and arrays', () => {
+    expect(isExpandable({})).toBe(true);
+    expect(isExpandable([])).toBe(true);
+    expect(isExpandable(null)).toBe(false);
+    expect(isExpandable('string')).toBe(false);
+    expect(isExpandable(42)).toBe(false);
+  });
+});
+
+describe('getChildKeys', () => {
+  it('returns stringified indices for arrays', () => {
+    expect(getChildKeys(['a', 'b', 'c'])).toEqual(['0', '1', '2']);
+  });
+
+  it('returns own enumerable keys for objects', () => {
+    expect(getChildKeys({ b: 1, a: 2 })).toEqual(['b', 'a']);
+  });
+
+  it('returns undefined for leaf values', () => {
+    expect(getChildKeys('a')).toBeUndefined();
+    expect(getChildKeys(1)).toBeUndefined();
+    expect(getChildKeys(null)).toBeUndefined();
+  });
+});
+
+describe('getContainerSummary', () => {
+  it('summarises arrays with bracket count', () => {
+    expect(getContainerSummary([1, 2, 3])).toBe('[3]');
+    expect(getContainerSummary([])).toBe('[0]');
+  });
+
+  it('summarises objects with brace count', () => {
+    expect(getContainerSummary({ a: 1, b: 2 })).toBe('{2}');
+    expect(getContainerSummary({})).toBe('{0}');
+  });
+});

--- a/packages/ui/src/json-inspector/json-node.ts
+++ b/packages/ui/src/json-inspector/json-node.ts
@@ -1,0 +1,62 @@
+export type JsonNodeType =
+  | 'object'
+  | 'array'
+  | 'string'
+  | 'number'
+  | 'boolean'
+  | 'null'
+  | 'undefined'
+  | 'function'
+  | 'symbol'
+  | 'bigint';
+
+const EXPANDABLE_TYPES: ReadonlySet<JsonNodeType> = new Set([
+  'object',
+  'array',
+]);
+
+/** Classifies a value into the leaf/container type used to render it. */
+export function classifyValue(value: unknown): JsonNodeType {
+  if (value === null) {
+    return 'null';
+  }
+
+  if (Array.isArray(value)) {
+    return 'array';
+  }
+
+  const type = typeof value;
+
+  if (type === 'object') {
+    return 'object';
+  }
+
+  return type as JsonNodeType;
+}
+
+/** Whether a value renders as an expandable tree node rather than a leaf. */
+export function isExpandable(value: unknown): boolean {
+  return EXPANDABLE_TYPES.has(classifyValue(value));
+}
+
+/**
+ * Ordered child keys for an expandable value (array indices as strings for
+ * arrays, own enumerable keys for objects). `undefined` for leaf values.
+ */
+export function getChildKeys(value: unknown): string[] | undefined {
+  if (Array.isArray(value)) {
+    return value.map((_, index) => String(index));
+  }
+
+  if (classifyValue(value) === 'object') {
+    return Object.keys(value as object);
+  }
+
+  return undefined;
+}
+
+/** Human-readable summary shown next to a collapsed container, e.g. "{3}" or "[0]". */
+export function getContainerSummary(value: unknown): string {
+  const keys = getChildKeys(value) ?? [];
+  return Array.isArray(value) ? `[${keys.length}]` : `{${keys.length}}`;
+}

--- a/packages/ui/src/plugin-shell/plugin-shell.tsx
+++ b/packages/ui/src/plugin-shell/plugin-shell.tsx
@@ -1,6 +1,10 @@
-import type { ComponentProps } from 'react';
+import { useState, type ComponentProps } from 'react';
 import { cn } from '../utils/cn';
-import { PluginThemeProvider, usePluginTheme } from '../theme/theme-context';
+import {
+  PluginPortalContainerContext,
+  PluginThemeProvider,
+  usePluginTheme,
+} from '../theme/theme-context';
 
 export type PluginShellProps = ComponentProps<'div'> & {
   /**
@@ -44,9 +48,11 @@ function ThemedShell({
   ...props
 }: Omit<PluginShellProps, 'unstyled'>) {
   const { theme } = usePluginTheme();
+  const [rootElement, setRootElement] = useState<HTMLDivElement | null>(null);
 
   return (
     <div
+      ref={setRootElement}
       data-slot="plugin-shell"
       className={cn(
         theme === 'dark' && 'dark',
@@ -55,7 +61,9 @@ function ThemedShell({
       )}
       {...props}
     >
-      {children}
+      <PluginPortalContainerContext.Provider value={rootElement}>
+        {children}
+      </PluginPortalContainerContext.Provider>
     </div>
   );
 }

--- a/packages/ui/src/scroll-area/scroll-area.tsx
+++ b/packages/ui/src/scroll-area/scroll-area.tsx
@@ -1,0 +1,58 @@
+import type { ReactNode } from 'react';
+import { ScrollArea as ScrollAreaPrimitive } from '@base-ui/react/scroll-area';
+import { cn } from '../utils/cn';
+
+export type ScrollAreaProps = ScrollAreaPrimitive.Root.Props & {
+  children?: ReactNode;
+  viewportClassName?: string;
+};
+
+function ScrollAreaRoot({
+  className,
+  viewportClassName,
+  children,
+  ...props
+}: ScrollAreaProps) {
+  return (
+    <ScrollAreaPrimitive.Root
+      data-slot="scroll-area"
+      className={cn('relative overflow-hidden', className)}
+      {...props}
+    >
+      <ScrollAreaPrimitive.Viewport
+        data-slot="scroll-area-viewport"
+        className={cn('h-full w-full', viewportClassName)}
+      >
+        <ScrollAreaPrimitive.Content>{children}</ScrollAreaPrimitive.Content>
+      </ScrollAreaPrimitive.Viewport>
+      <ScrollAreaBar orientation="vertical" />
+      <ScrollAreaBar orientation="horizontal" />
+      <ScrollAreaPrimitive.Corner data-slot="scroll-area-corner" />
+    </ScrollAreaPrimitive.Root>
+  );
+}
+
+function ScrollAreaBar({
+  orientation,
+}: {
+  orientation: 'vertical' | 'horizontal';
+}) {
+  return (
+    <ScrollAreaPrimitive.Scrollbar
+      data-slot="scroll-area-scrollbar"
+      orientation={orientation}
+      className={cn(
+        'flex touch-none p-0.5 transition-colors select-none',
+        orientation === 'vertical' && 'h-full w-2.5',
+        orientation === 'horizontal' && 'h-2.5 w-full flex-col',
+      )}
+    >
+      <ScrollAreaPrimitive.Thumb
+        data-slot="scroll-area-thumb"
+        className="relative flex-1 rounded-full bg-border hover:bg-muted-foreground"
+      />
+    </ScrollAreaPrimitive.Scrollbar>
+  );
+}
+
+export const ScrollArea = ScrollAreaRoot;

--- a/packages/ui/src/search-field/search-field.tsx
+++ b/packages/ui/src/search-field/search-field.tsx
@@ -1,0 +1,46 @@
+import type { ComponentProps } from 'react';
+import { Search, X } from 'lucide-react';
+import { cn } from '../utils/cn';
+
+export type SearchFieldProps = Omit<ComponentProps<'input'>, 'type'> & {
+  /** Called when the clear button is pressed. Omit to hide the clear affordance. */
+  onClear?: () => void;
+};
+
+export function SearchField({
+  className,
+  value,
+  onClear,
+  ...props
+}: SearchFieldProps) {
+  const showClear = Boolean(onClear) && Boolean(value);
+
+  return (
+    <div data-slot="search-field" className="relative flex items-center">
+      <Search className="pointer-events-none absolute left-2.5 h-3.5 w-3.5 text-muted-foreground" />
+      <input
+        type="search"
+        value={value}
+        className={cn(
+          'h-8 w-full min-w-0 rounded-md border border-input bg-transparent pl-8 text-sm text-foreground shadow-xs transition-colors',
+          showClear ? 'pr-8' : 'pr-3',
+          'outline-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50',
+          'placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
+          '[&::-webkit-search-cancel-button]:appearance-none',
+          className,
+        )}
+        {...props}
+      />
+      {showClear && (
+        <button
+          type="button"
+          onClick={onClear}
+          aria-label="Clear search"
+          className="absolute right-2 inline-flex h-4 w-4 items-center justify-center rounded-sm text-muted-foreground hover:text-foreground"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/select/select.tsx
+++ b/packages/ui/src/select/select.tsx
@@ -1,0 +1,115 @@
+import { Select as SelectPrimitive } from '@base-ui/react/select';
+import { Check, ChevronsUpDown } from 'lucide-react';
+import { cn } from '../utils/cn';
+import { usePluginPortalContainer } from '../theme/theme-context';
+
+export type SelectProps<
+  Value,
+  Multiple extends boolean | undefined = false,
+> = SelectPrimitive.Root.Props<Value, Multiple>;
+
+function SelectRoot<Value, Multiple extends boolean | undefined = false>(
+  props: SelectProps<Value, Multiple>,
+) {
+  return <SelectPrimitive.Root {...props} />;
+}
+
+export type SelectTriggerProps = SelectPrimitive.Trigger.Props;
+
+function SelectTrigger({ className, children, ...props }: SelectTriggerProps) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      className={cn(
+        'flex h-8 w-full items-center justify-between gap-2 rounded-md border border-input bg-transparent px-3 text-sm text-foreground shadow-xs',
+        'outline-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50',
+        'disabled:pointer-events-none disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon>
+        <ChevronsUpDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  );
+}
+
+export type SelectValueProps = SelectPrimitive.Value.Props;
+
+function SelectValue({ className, ...props }: SelectValueProps) {
+  return (
+    <SelectPrimitive.Value
+      data-slot="select-value"
+      className={cn('truncate', className)}
+      {...props}
+    />
+  );
+}
+
+export type SelectContentProps = SelectPrimitive.Popup.Props &
+  Pick<SelectPrimitive.Positioner.Props, 'side' | 'sideOffset' | 'align'>;
+
+function SelectContent({
+  className,
+  side = 'bottom',
+  sideOffset = 4,
+  align = 'start',
+  children,
+  ...props
+}: SelectContentProps) {
+  const container = usePluginPortalContainer();
+
+  return (
+    <SelectPrimitive.Portal container={container}>
+      <SelectPrimitive.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        className="z-50"
+      >
+        <SelectPrimitive.Popup
+          data-slot="select-content"
+          className={cn(
+            'max-h-64 min-w-[--anchor-width] overflow-y-auto rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md',
+            'origin-(--transform-origin) transition-[transform,scale,opacity] data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0',
+            className,
+          )}
+          {...props}
+        >
+          <SelectPrimitive.List>{children}</SelectPrimitive.List>
+        </SelectPrimitive.Popup>
+      </SelectPrimitive.Positioner>
+    </SelectPrimitive.Portal>
+  );
+}
+
+export type SelectItemProps = SelectPrimitive.Item.Props;
+
+function SelectItem({ className, children, ...props }: SelectItemProps) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        'flex cursor-default items-center justify-between gap-2 rounded-sm px-2 py-1.5 text-sm text-foreground select-none',
+        'data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground',
+        'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+        className,
+      )}
+      {...props}
+    >
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-3.5 w-3.5" />
+      </SelectPrimitive.ItemIndicator>
+    </SelectPrimitive.Item>
+  );
+}
+
+export const Select = Object.assign(SelectRoot, {
+  Trigger: SelectTrigger,
+  Value: SelectValue,
+  Content: SelectContent,
+  Item: SelectItem,
+});

--- a/packages/ui/src/sidebar/sidebar.tsx
+++ b/packages/ui/src/sidebar/sidebar.tsx
@@ -1,0 +1,86 @@
+import type { ComponentProps, ReactNode } from 'react';
+import { cn } from '../utils/cn';
+
+export type SidebarProps = ComponentProps<'nav'>;
+
+function SidebarRoot({ className, ...props }: SidebarProps) {
+  return (
+    <nav
+      data-slot="sidebar"
+      className={cn(
+        'flex h-full w-56 shrink-0 flex-col gap-4 overflow-y-auto border-r border-sidebar-border bg-sidebar p-2 text-sidebar-foreground',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export type SidebarGroupProps = ComponentProps<'div'> & {
+  label?: ReactNode;
+};
+
+function SidebarGroup({
+  className,
+  label,
+  children,
+  ...props
+}: SidebarGroupProps) {
+  return (
+    <div
+      data-slot="sidebar-group"
+      className={cn('flex flex-col gap-0.5', className)}
+      {...props}
+    >
+      {label && (
+        <div
+          data-slot="sidebar-group-label"
+          className="px-2 py-1 text-xs font-medium text-sidebar-foreground/60"
+        >
+          {label}
+        </div>
+      )}
+      {children}
+    </div>
+  );
+}
+
+export type SidebarItemProps = ComponentProps<'button'> & {
+  selected?: boolean;
+  /** Rendered at the end of the row, e.g. a `Badge` with an entry count. */
+  trailing?: ReactNode;
+};
+
+function SidebarItem({
+  className,
+  selected = false,
+  trailing,
+  children,
+  type = 'button',
+  ...props
+}: SidebarItemProps) {
+  return (
+    <button
+      type={type}
+      data-slot="sidebar-item"
+      data-selected={selected || undefined}
+      aria-current={selected || undefined}
+      className={cn(
+        'flex h-7 w-full items-center gap-2 rounded-md px-2 text-left text-sm text-sidebar-foreground',
+        'hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
+        'outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring',
+        'data-[selected]:bg-sidebar-accent data-[selected]:text-sidebar-accent-foreground data-[selected]:font-medium',
+        className,
+      )}
+      {...props}
+    >
+      <span className="min-w-0 flex-1 truncate">{children}</span>
+      {trailing}
+    </button>
+  );
+}
+
+export const Sidebar = Object.assign(SidebarRoot, {
+  Group: SidebarGroup,
+  Item: SidebarItem,
+});

--- a/packages/ui/src/tabs/tabs.tsx
+++ b/packages/ui/src/tabs/tabs.tsx
@@ -1,0 +1,59 @@
+import { Tabs as TabsPrimitive } from '@base-ui/react/tabs';
+import { cn } from '../utils/cn';
+
+export type TabsProps = TabsPrimitive.Root.Props;
+
+function TabsRoot(props: TabsProps) {
+  return <TabsPrimitive.Root data-slot="tabs" {...props} />;
+}
+
+export type TabsListProps = TabsPrimitive.List.Props;
+
+function TabsList({ className, ...props }: TabsListProps) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      className={cn(
+        'inline-flex h-8 items-center gap-1 rounded-md bg-muted p-1 text-muted-foreground',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export type TabsTabProps = TabsPrimitive.Tab.Props;
+
+function TabsTab({ className, ...props }: TabsTabProps) {
+  return (
+    <TabsPrimitive.Tab
+      data-slot="tabs-tab"
+      className={cn(
+        'inline-flex h-6 items-center justify-center rounded-sm px-2.5 text-sm font-medium whitespace-nowrap text-muted-foreground',
+        'outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        'data-[selected]:bg-background data-[selected]:text-foreground data-[selected]:shadow-xs',
+        'disabled:pointer-events-none disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export type TabsPanelProps = TabsPrimitive.Panel.Props;
+
+function TabsPanel({ className, ...props }: TabsPanelProps) {
+  return (
+    <TabsPrimitive.Panel
+      data-slot="tabs-panel"
+      className={cn('flex-1 outline-none', className)}
+      {...props}
+    />
+  );
+}
+
+export const Tabs = Object.assign(TabsRoot, {
+  List: TabsList,
+  Tab: TabsTab,
+  Panel: TabsPanel,
+});

--- a/packages/ui/src/theme/theme-context.tsx
+++ b/packages/ui/src/theme/theme-context.tsx
@@ -82,3 +82,21 @@ export function usePluginTheme(): PluginThemeContextValue {
 
   return context;
 }
+
+/**
+ * Holds the `PluginShell` root element so that portal-rendered surfaces
+ * (Select, Combobox, Dialog, Tooltip, Toast) can mount inside it instead of
+ * `document.body`. The shell's `dark` class lives on that root element, so
+ * anything portalled to `document.body` would otherwise escape it and
+ * render with light tokens.
+ *
+ * `null` outside a `PluginShell` (or before it has mounted), in which case
+ * consumers should fall back to the Base UI default of `document.body`.
+ */
+export const PluginPortalContainerContext = createContext<HTMLElement | null>(
+  null,
+);
+
+export function usePluginPortalContainer(): HTMLElement | null {
+  return useContext(PluginPortalContainerContext);
+}

--- a/packages/ui/src/toast/toast.tsx
+++ b/packages/ui/src/toast/toast.tsx
@@ -1,0 +1,75 @@
+import type { ReactNode } from 'react';
+import { Toast as ToastPrimitive } from '@base-ui/react/toast';
+import { X } from 'lucide-react';
+import { cn } from '../utils/cn';
+import { usePluginPortalContainer } from '../theme/theme-context';
+
+export const useToast = ToastPrimitive.useToastManager;
+
+export type ToastProviderProps = ToastPrimitive.Provider.Props & {
+  children?: ReactNode;
+};
+
+function ToastProviderRoot({ children, ...props }: ToastProviderProps) {
+  return (
+    <ToastPrimitive.Provider data-slot="toast-provider" {...props}>
+      {children}
+      <Toaster />
+    </ToastPrimitive.Provider>
+  );
+}
+
+function Toaster() {
+  const { toasts } = ToastPrimitive.useToastManager();
+  const container = usePluginPortalContainer();
+
+  return (
+    <ToastPrimitive.Portal container={container}>
+      <ToastPrimitive.Viewport
+        data-slot="toast-viewport"
+        className="fixed right-4 bottom-4 z-50 flex w-80 flex-col gap-2"
+      >
+        {toasts.map((toast) => (
+          <ToastPrimitive.Root
+            key={toast.id}
+            toast={toast}
+            data-slot="toast"
+            className={cn(
+              'relative flex items-start gap-2 rounded-md border border-border bg-card p-3 text-card-foreground shadow-md',
+              'transition-[transform,opacity] data-[ending-style]:opacity-0 data-[starting-style]:opacity-0',
+              toast.type === 'error' &&
+                'border-destructive/50 text-destructive',
+            )}
+          >
+            <ToastPrimitive.Content
+              data-slot="toast-content"
+              className="flex min-w-0 flex-1 flex-col gap-0.5"
+            >
+              {toast.title && (
+                <ToastPrimitive.Title
+                  data-slot="toast-title"
+                  className="text-sm font-medium"
+                />
+              )}
+              {toast.description && (
+                <ToastPrimitive.Description
+                  data-slot="toast-description"
+                  className="text-xs text-muted-foreground"
+                />
+              )}
+            </ToastPrimitive.Content>
+            <ToastPrimitive.Close
+              data-slot="toast-close"
+              aria-label="Dismiss"
+              className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-sm text-muted-foreground hover:text-foreground"
+            >
+              <X className="h-3.5 w-3.5" />
+            </ToastPrimitive.Close>
+          </ToastPrimitive.Root>
+        ))}
+      </ToastPrimitive.Viewport>
+    </ToastPrimitive.Portal>
+  );
+}
+
+export const Toast = { Provider: ToastProviderRoot };

--- a/packages/ui/src/toolbar/toolbar.tsx
+++ b/packages/ui/src/toolbar/toolbar.tsx
@@ -1,0 +1,65 @@
+import { Toolbar as ToolbarPrimitive } from '@base-ui/react/toolbar';
+import { cn } from '../utils/cn';
+
+export type ToolbarProps = ToolbarPrimitive.Root.Props;
+
+function ToolbarRoot({ className, ...props }: ToolbarProps) {
+  return (
+    <ToolbarPrimitive.Root
+      data-slot="toolbar"
+      className={cn(
+        'flex items-center gap-1 border-b border-border bg-card px-2 py-1.5',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export type ToolbarButtonProps = ToolbarPrimitive.Button.Props;
+
+function ToolbarButton({ className, ...props }: ToolbarButtonProps) {
+  return (
+    <ToolbarPrimitive.Button
+      data-slot="toolbar-button"
+      className={cn(
+        'inline-flex h-7 items-center justify-center gap-1.5 rounded-md px-2 text-sm font-medium text-foreground',
+        'hover:bg-accent hover:text-accent-foreground',
+        'outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        'disabled:pointer-events-none disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export type ToolbarSeparatorProps = ToolbarPrimitive.Separator.Props;
+
+function ToolbarSeparator({ className, ...props }: ToolbarSeparatorProps) {
+  return (
+    <ToolbarPrimitive.Separator
+      data-slot="toolbar-separator"
+      className={cn('mx-1 h-4 w-px bg-border', className)}
+      {...props}
+    />
+  );
+}
+
+export type ToolbarGroupProps = ToolbarPrimitive.Group.Props;
+
+function ToolbarGroup({ className, ...props }: ToolbarGroupProps) {
+  return (
+    <ToolbarPrimitive.Group
+      data-slot="toolbar-group"
+      className={cn('flex items-center gap-1', className)}
+      {...props}
+    />
+  );
+}
+
+export const Toolbar = Object.assign(ToolbarRoot, {
+  Button: ToolbarButton,
+  Separator: ToolbarSeparator,
+  Group: ToolbarGroup,
+});

--- a/packages/ui/src/tooltip/tooltip.tsx
+++ b/packages/ui/src/tooltip/tooltip.tsx
@@ -1,0 +1,69 @@
+import { Tooltip as TooltipPrimitive } from '@base-ui/react/tooltip';
+import { cn } from '../utils/cn';
+import { usePluginPortalContainer } from '../theme/theme-context';
+
+export type TooltipProviderProps = TooltipPrimitive.Provider.Props;
+
+function TooltipProvider(props: TooltipProviderProps) {
+  return <TooltipPrimitive.Provider data-slot="tooltip-provider" {...props} />;
+}
+
+export type TooltipProps = TooltipPrimitive.Root.Props;
+
+function TooltipRoot(props: TooltipProps) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
+}
+
+export type TooltipTriggerProps = TooltipPrimitive.Trigger.Props;
+
+function TooltipTrigger(props: TooltipTriggerProps) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
+}
+
+export type TooltipContentProps = TooltipPrimitive.Popup.Props &
+  Pick<
+    TooltipPrimitive.Positioner.Props,
+    'side' | 'sideOffset' | 'align' | 'alignOffset'
+  >;
+
+function TooltipContent({
+  className,
+  side = 'top',
+  sideOffset = 6,
+  align = 'center',
+  alignOffset = 0,
+  children,
+  ...props
+}: TooltipContentProps) {
+  const container = usePluginPortalContainer();
+
+  return (
+    <TooltipPrimitive.Portal container={container}>
+      <TooltipPrimitive.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        alignOffset={alignOffset}
+        className="z-50"
+      >
+        <TooltipPrimitive.Popup
+          data-slot="tooltip-content"
+          className={cn(
+            'z-50 w-fit max-w-xs rounded-md bg-foreground px-2.5 py-1.5 text-xs text-background',
+            'origin-(--transform-origin) transition-[transform,scale,opacity] data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[starting-style]:scale-90 data-[starting-style]:opacity-0',
+            className,
+          )}
+          {...props}
+        >
+          {children}
+        </TooltipPrimitive.Popup>
+      </TooltipPrimitive.Positioner>
+    </TooltipPrimitive.Portal>
+  );
+}
+
+export const Tooltip = Object.assign(TooltipRoot, {
+  Provider: TooltipProvider,
+  Trigger: TooltipTrigger,
+  Content: TooltipContent,
+});

--- a/packages/ui/src/use-copy-to-clipboard/use-copy-to-clipboard.ts
+++ b/packages/ui/src/use-copy-to-clipboard/use-copy-to-clipboard.ts
@@ -1,0 +1,39 @@
+import { useCallback, useRef, useState } from 'react';
+
+export type UseCopyToClipboardOptions = {
+  /** How long `copied` stays `true` after a successful copy, in ms. */
+  resetDelay?: number;
+};
+
+export type UseCopyToClipboardResult = {
+  copy: (text: string) => Promise<boolean>;
+  copied: boolean;
+};
+
+export function useCopyToClipboard({
+  resetDelay = 2000,
+}: UseCopyToClipboardOptions = {}): UseCopyToClipboardResult {
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const copy = useCallback(
+    async (text: string) => {
+      if (typeof navigator === 'undefined' || !navigator.clipboard) {
+        return false;
+      }
+
+      try {
+        await navigator.clipboard.writeText(text);
+        setCopied(true);
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = setTimeout(() => setCopied(false), resetDelay);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    [resetDelay],
+  );
+
+  return { copy, copied };
+}

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -29,6 +29,8 @@ export default defineConfig({
         'clsx',
         'tailwind-merge',
         'class-variance-authority',
+        /^@base-ui\/react/,
+        '@tanstack/react-table',
       ],
     },
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1459,6 +1459,12 @@ importers:
 
   packages/ui:
     dependencies:
+      '@base-ui/react':
+        specifier: ^1.7.0
+        version: 1.7.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@tanstack/react-table':
+        specifier: ^8.21.3
+        version: 8.21.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -2341,6 +2347,10 @@ packages:
     resolution: {integrity: sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
@@ -2364,6 +2374,33 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@base-ui/react@1.7.0':
+    resolution: {integrity: sha512-j+8QjX44C32jrXD/qyEAGpFr70FRpGL2CY61mQd9nBPWN737CK0xxD1ceJ055rW4RtdvFDT1e7otzdlfxvsYug==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@date-fns/tz': ^1.2.0
+      '@types/react': ^17 || ^18 || ^19
+      date-fns: ^4.0.0
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@date-fns/tz':
+        optional: true
+      '@types/react':
+        optional: true
+      date-fns:
+        optional: true
+
+  '@base-ui/utils@0.3.2':
+    resolution: {integrity: sha512-oWy1aq/I2GmYjpl4PhEAhzflF8VPGKgZeq0xAWTbfD5KBWyxcN0ZP2+WHSUm/5Z6lVMBDLReLcoXwSYoRc/zNQ==}
+    peerDependencies:
+      '@types/react': ^17 || ^18 || ^19
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
@@ -3084,11 +3121,23 @@ packages:
   '@floating-ui/core@1.7.2':
     resolution: {integrity: sha512-wNB5ooIKHQc+Kui96jE/n69rHFWAVoxn5CAzL1Xdd8FG03cgY3MLO+GF9U3W737fYDSgPWA6MReKhBQBop6Pcw==}
 
+  '@floating-ui/core@1.8.0':
+    resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
+
   '@floating-ui/dom@1.7.2':
     resolution: {integrity: sha512-7cfaOQuCS27HD7DX+6ib2OrnW+b4ZBwDNnCcT0uTyidcmyWb03FnQqJybDBoCnpdxwBSfA94UAYlRCt7mV+TbA==}
 
+  '@floating-ui/dom@1.8.0':
+    resolution: {integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==}
+
   '@floating-ui/react-dom@2.1.4':
     resolution: {integrity: sha512-JbbpPhp38UmXDDAu60RJmbeme37Jbgsm7NrHGgzYYFKmblzRUh6Pa641dII6LsjwF4XlScDrde2UAzDo/b9KPw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/react-dom@2.1.9':
+    resolution: {integrity: sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
@@ -3101,6 +3150,9 @@ packages:
 
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+
+  '@floating-ui/utils@0.2.12':
+    resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
 
   '@formatjs/ecma402-abstract@2.3.6':
     resolution: {integrity: sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==}
@@ -12565,6 +12617,9 @@ packages:
   reselect@5.1.1:
     resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
+  reselect@5.2.0:
+    resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
+
   resize-observer-polyfill@1.5.1:
     resolution: {integrity: sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==}
 
@@ -15163,6 +15218,8 @@ snapshots:
     dependencies:
       regenerator-runtime: 0.14.1
 
+  '@babel/runtime@7.29.7': {}
+
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -15208,6 +15265,29 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@base-ui/react@1.7.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@base-ui/utils': 0.3.2(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@floating-ui/react-dom': 2.1.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@floating-ui/utils': 0.2.12
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      use-sync-external-store: 1.6.0(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@base-ui/utils@0.3.2(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@floating-ui/utils': 0.2.12
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      reselect: 5.2.0
+      use-sync-external-store: 1.6.0(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   '@bcoe/v8-coverage@1.0.2': {}
 
@@ -16798,14 +16878,29 @@ snapshots:
     dependencies:
       '@floating-ui/utils': 0.2.10
 
+  '@floating-ui/core@1.8.0':
+    dependencies:
+      '@floating-ui/utils': 0.2.12
+
   '@floating-ui/dom@1.7.2':
     dependencies:
       '@floating-ui/core': 1.7.2
       '@floating-ui/utils': 0.2.10
 
+  '@floating-ui/dom@1.8.0':
+    dependencies:
+      '@floating-ui/core': 1.8.0
+      '@floating-ui/utils': 0.2.12
+
   '@floating-ui/react-dom@2.1.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@floating-ui/dom': 1.7.2
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+
+  '@floating-ui/react-dom@2.1.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@floating-ui/dom': 1.8.0
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
@@ -16818,6 +16913,8 @@ snapshots:
       tabbable: 6.2.0
 
   '@floating-ui/utils@0.2.10': {}
+
+  '@floating-ui/utils@0.2.12': {}
 
   '@formatjs/ecma402-abstract@2.3.6':
     dependencies:
@@ -29752,6 +29849,8 @@ snapshots:
   requires-port@1.0.0: {}
 
   reselect@5.1.1: {}
+
+  reselect@5.2.0: {}
 
   resize-observer-polyfill@1.5.1: {}
 


### PR DESCRIPTION
## Description

Adds the core control and data-display primitives to `@rozenite/ui`: Base UI-backed `Select`, `Combobox`, `Dialog`, `Tooltip`, `Tabs`, `ScrollArea`, `Field`, `Toolbar`, and `Toast`, plus `cva`-styled `Button`, `Badge`, `Input`, `SearchField`, `DataTable`, `Sidebar`, `EmptyState`, `ConfirmDialog`, `JsonInspector`, and a `useCopyToClipboard` hook. This stacks on #347 (now merged) and still has zero consumers — PR 3 migrates `storage-plugin` onto these.

## Related Issue

https://github.com/callstackincubator/rozenite/issues/343

## Context

**Portal theming**: `PluginShell` puts the `dark` class on its own root `div`, so any Base UI portal rendered to `document.body` (Select, Combobox, Dialog, Tooltip, Toast) would escape it and render with light tokens. Solved once at the root: `PluginShell` now tracks its root element in state and provides it via a new `PluginPortalContainerContext` (in `theme-context.tsx`). Each portal-based primitive reads it with `usePluginPortalContainer()` and passes it as Base UI's `container` prop, so the portal mounts inside the themed subtree instead of `document.body`. Outside a `PluginShell` (or in `unstyled` mode) the context is `null` and Base UI falls back to its default of `document.body`.

**`DataTable` inline editing**: built on `@tanstack/react-table`'s own `meta` mechanism rather than a custom prop — `DataTable` sets `table.options.meta.updateData` and forwards it to `onCellEdit(rowIndex, columnId, value)`. Column definitions decide per-cell whether to render an editor (e.g. with the exported `DataTableEditableCell` click-to-edit helper) and call that callback to commit. This keeps `DataTable` fully generic: no storage-specific types leak in, and PR 3's key/type/value editable table is just column definitions using this mechanism. The immutable update itself is the pure, tested `updateCellValue(data, rowIndex, columnId, value)` helper.

`ConfirmDialog` covers both shapes from the brief (destructive confirm with Cancel + Confirm, and a single-button alert) via a `variant: 'confirm' | 'alert'` prop, composing `Dialog.Close` with `Button` through Base UI's `render` prop rather than a custom `asChild` shim.

## Testing

- `pnpm install`
- `pnpm build:all` — 29/29 tasks succeeded; `@rozenite/ui` emits a single `dist/index.d.ts`
- `pnpm typecheck:all` — 58/58 tasks succeeded
- `pnpm lint:all` — 56/56 tasks succeeded
- `pnpm format:all` — all files pass Prettier
- `pnpm --filter @rozenite/ui test` — 20/20 tests passed (pure-logic tests for `JsonInspector`'s value classification and `DataTable`'s cell-update helper; no rendering/snapshot tests)
- `pnpm release:plan` — exits 0; the `ui-primitives` changeset (`@rozenite/ui`: minor) is picked up


---

Replaces #348, which GitHub auto-closed when its base branch `claude/ui-foundation-343` was deleted on merging #347. Same branch, same commit, rebased onto `main`.
