### PR TITLE
feat(sqlite-plugin): add table and database drop actions

### DIFF
--- a/.changeset/sqlite-drop-tables-and-views.md
+++ b/.changeset/sqlite-drop-tables-and-views.md
@@ -1,0 +1,8 @@
+---
+'@rozenite/sqlite-plugin': minor
+---
+
+Add controls to drop a single table or view from the Structure tab and to
+drop all tables and views in a database from the sidebar. Both are gated by
+a shared confirmation dialog that requires typing the object or database
+name and previews the SQL that will run.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,19 +1,35 @@
 ## Description
 
-<!-- Provide a general summary of your changes -->
+Adds schema-level destructive actions to the SQLite DevTools panel:
+
+- Drop the selected table or view from the Structure tab.
+- Drop all user tables and views from the selected database.
+- Protect both operations with a shared type-to-confirm dialog, SQL preview, counts, and inline errors.
 
 ## Related Issue
 
 <!--- This project only accepts pull requests related to open issues -->
 <!--- If suggesting a new feature or change, please discuss it in an issue first -->
 <!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
-<!--- Please link to the issue here: -->
+Closes https://github.com/callstackincubator/rozenite/issues/346
 
 ## Context
 
-<!-- Why this feature was implemented in this particular way? -->
-<!-- Is there anything reviewer needs to know before conducting code review? -->
+The adapter exposes execution of SQL statements, but not database-file deletion, so “drop database” is implemented honestly as dropping every user table and view while keeping the open database file intact. Single-object drops use the existing query path; the database sweep uses script execution and drops views before tables.
+
+When foreign-key enforcement is enabled, the sweep temporarily disables it and restores the original value on both success and failure paths. Identifiers are quoted with the existing SQLite identifier helper, and the explorer refreshes after a successful mutation.
 
 ## Testing
 
-<!-- Please describe how you tested your changes -->
+Automated:
+
+- `pnpm --filter @rozenite/sqlite-plugin build`
+- `pnpm --filter @rozenite/sqlite-plugin test` — 49 tests passed
+- `pnpm --filter @rozenite/sqlite-plugin typecheck`
+- `pnpm --filter @rozenite/sqlite-plugin lint`
+
+Manual verification (confirmed in the requested environment):
+
+- Started Metro from `apps/playground` in this worktree.
+- Opened the already-installed Rozenite playground on the running iPhone 17 Pro simulator with `agent-device`.
+- Opened React Native DevTools at the provided URL with `agent-browser` and exercised the SQLite panel’s table/view and database-level drop flows, including confirmation gating and post-drop explorer state.

--- a/packages/sqlite-plugin/src/ui/__tests__/sqlite-drop-mutations.test.ts
+++ b/packages/sqlite-plugin/src/ui/__tests__/sqlite-drop-mutations.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildDropAllEntitiesSql,
+  buildDropEntitySql,
+  buildSetForeignKeysSql,
+  isForeignKeysEnabled,
+  orderEntitiesForDrop,
+  SQLITE_READ_FOREIGN_KEYS_SQL,
+  type SqliteDropTarget,
+} from '../sqlite-drop-mutations';
+
+describe('buildDropEntitySql', () => {
+  it('builds a DROP TABLE statement for a table entity', () => {
+    expect(
+      buildDropEntitySql({
+        schemaName: 'main',
+        name: 'projects',
+        type: 'table',
+      }),
+    ).toBe('DROP TABLE "main"."projects"');
+  });
+
+  it('builds a DROP VIEW statement for a view entity', () => {
+    expect(
+      buildDropEntitySql({
+        schemaName: 'main',
+        name: 'active_projects',
+        type: 'view',
+      }),
+    ).toBe('DROP VIEW "main"."active_projects"');
+  });
+
+  it('quotes identifiers containing double quotes by doubling them', () => {
+    expect(
+      buildDropEntitySql({
+        schemaName: 'main',
+        name: 'weird"table',
+        type: 'table',
+      }),
+    ).toBe('DROP TABLE "main"."weird""table"');
+  });
+
+  it('quotes identifiers containing dots so they are not read as separators', () => {
+    expect(
+      buildDropEntitySql({
+        schemaName: 'main',
+        name: 'schema.like.name',
+        type: 'table',
+      }),
+    ).toBe('DROP TABLE "main"."schema.like.name"');
+  });
+
+  it('quotes schema names containing double quotes and dots as well', () => {
+    expect(
+      buildDropEntitySql({
+        schemaName: 'weird"schema.name',
+        name: 'projects',
+        type: 'view',
+      }),
+    ).toBe('DROP VIEW "weird""schema.name"."projects"');
+  });
+});
+
+describe('orderEntitiesForDrop', () => {
+  it('moves all views before all tables while preserving relative order', () => {
+    const entities: SqliteDropTarget[] = [
+      { schemaName: 'main', name: 'a_table', type: 'table' },
+      { schemaName: 'main', name: 'b_view', type: 'view' },
+      { schemaName: 'main', name: 'c_table', type: 'table' },
+      { schemaName: 'main', name: 'd_view', type: 'view' },
+    ];
+
+    expect(orderEntitiesForDrop(entities).map((entity) => entity.name)).toEqual(
+      ['b_view', 'd_view', 'a_table', 'c_table'],
+    );
+  });
+
+  it('returns an empty array for an empty database', () => {
+    expect(orderEntitiesForDrop([])).toEqual([]);
+  });
+});
+
+describe('buildDropAllEntitiesSql', () => {
+  it('emits DROP VIEW statements before DROP TABLE statements', () => {
+    const entities: SqliteDropTarget[] = [
+      { schemaName: 'main', name: 'projects', type: 'table' },
+      { schemaName: 'main', name: 'active_projects', type: 'view' },
+    ];
+
+    expect(buildDropAllEntitiesSql(entities)).toBe(
+      'DROP VIEW "main"."active_projects";\nDROP TABLE "main"."projects";',
+    );
+  });
+
+  it('quotes every identifier in the generated script', () => {
+    const entities: SqliteDropTarget[] = [
+      { schemaName: 'main', name: 'weird"table', type: 'table' },
+      { schemaName: 'main', name: 'schema.view', type: 'view' },
+    ];
+
+    expect(buildDropAllEntitiesSql(entities)).toBe(
+      'DROP VIEW "main"."schema.view";\nDROP TABLE "main"."weird""table";',
+    );
+  });
+
+  it('returns an empty string for an empty database', () => {
+    expect(buildDropAllEntitiesSql([])).toBe('');
+  });
+});
+
+describe('foreign key pragma helpers', () => {
+  it('exposes the read-only pragma statement', () => {
+    expect(SQLITE_READ_FOREIGN_KEYS_SQL).toBe('PRAGMA foreign_keys');
+  });
+
+  it('builds a statement enabling foreign keys', () => {
+    expect(buildSetForeignKeysSql(true)).toBe('PRAGMA foreign_keys = ON');
+  });
+
+  it('builds a statement disabling foreign keys', () => {
+    expect(buildSetForeignKeysSql(false)).toBe('PRAGMA foreign_keys = OFF');
+  });
+
+  it('treats a foreign_keys value of 1 as enabled', () => {
+    expect(isForeignKeysEnabled([{ foreign_keys: 1 }])).toBe(true);
+  });
+
+  it('treats a foreign_keys value of 0 as disabled', () => {
+    expect(isForeignKeysEnabled([{ foreign_keys: 0 }])).toBe(false);
+  });
+
+  it('treats an empty result set as disabled', () => {
+    expect(isForeignKeysEnabled([])).toBe(false);
+  });
+});

--- a/packages/sqlite-plugin/src/ui/globals.css
+++ b/packages/sqlite-plugin/src/ui/globals.css
@@ -399,6 +399,18 @@
     flex-shrink: 0;
   }
 
+  .sqlite-button-danger {
+    border-color: rgba(255, 100, 100, 0.35);
+    background: rgba(255, 90, 90, 0.14);
+    color: rgba(255, 214, 214, 0.95);
+  }
+
+  .sqlite-button-danger:hover:not(:disabled) {
+    border-color: rgba(255, 120, 120, 0.55);
+    background: rgba(255, 90, 90, 0.22);
+    color: white;
+  }
+
   .sqlite-badge,
   .sqlite-chip,
   .sqlite-count-pill {

--- a/packages/sqlite-plugin/src/ui/panel.tsx
+++ b/packages/sqlite-plugin/src/ui/panel.tsx
@@ -65,6 +65,17 @@ import {
 } from './sqlite-introspection';
 import { QueryResultTable } from './query-result-table';
 import { SqliteRowDeleteModal } from './sqlite-row-delete-modal';
+import {
+  SqliteDropModal,
+  type SqliteDropModalTarget,
+} from './sqlite-drop-modal';
+import {
+  buildDropAllEntitiesSql,
+  buildDropEntitySql,
+  buildSetForeignKeysSql,
+  isForeignKeysEnabled,
+  SQLITE_READ_FOREIGN_KEYS_SQL,
+} from './sqlite-drop-mutations';
 import { SqliteDataTable } from './sqlite-data-table';
 import { SqliteRowEditModal } from './sqlite-row-edit-modal';
 import { SqlEditor, type SqlEditorHandle } from './sql-editor';
@@ -148,6 +159,15 @@ type ActiveRowMutationState = {
   rowIndex: number;
 } | null;
 
+/**
+ * The drop dialog operates on the target captured when it opened, so that a
+ * mid-dialog explorer reload cannot repoint it at a different object.
+ */
+type ActiveDropState = {
+  databaseId: string;
+  target: SqliteDropModalTarget;
+} | null;
+
 const DEFAULT_QUERY =
   'SELECT name, type FROM sqlite_schema ORDER BY type, name';
 const DEFAULT_QUERY_LIMIT = 100;
@@ -162,6 +182,14 @@ const DEFAULT_EXPLORER_STATE: ExplorerState = {
   loading: false,
   error: null,
   loaded: false,
+};
+
+const DEFAULT_DROP_TARGET: SqliteDropModalTarget = {
+  kind: 'entity',
+  entityType: 'table',
+  qualifiedName: '',
+  confirmationValue: '',
+  sql: '',
 };
 
 const joinClassNames = (
@@ -315,6 +343,7 @@ const iconButtonClassName =
   'sqlite-icon-button inline-flex h-10 w-10 items-center justify-center rounded-xl';
 const primaryIconButtonClassName = `${iconButtonClassName} sqlite-button-primary`;
 const secondaryIconButtonClassName = `${iconButtonClassName} sqlite-button-secondary`;
+const dangerIconButtonClassName = `${iconButtonClassName} sqlite-button-danger`;
 const ghostIconButtonClassName = `${iconButtonClassName} sqlite-button-ghost`;
 
 const renderEmptyState = (
@@ -418,6 +447,7 @@ export default function SqlitePanel() {
   >({});
   const [editingRow, setEditingRow] = useState<ActiveRowMutationState>(null);
   const [deletingRow, setDeletingRow] = useState<ActiveRowMutationState>(null);
+  const [activeDrop, setActiveDrop] = useState<ActiveDropState>(null);
 
   const [objectSearch, setObjectSearch] = useState('');
   const [dataSearch, setDataSearch] = useState('');
@@ -1201,6 +1231,149 @@ export default function SqlitePanel() {
     selectedDatabaseId,
     selectedEntity,
   ]);
+
+  const handleOpenDropEntity = useCallback(() => {
+    if (!selectedDatabaseId || !selectedEntity) {
+      return;
+    }
+
+    setActiveDrop({
+      databaseId: selectedDatabaseId,
+      target: {
+        kind: 'entity',
+        entityType: selectedEntity.type,
+        qualifiedName: `${selectedEntity.schemaName}.${selectedEntity.name}`,
+        confirmationValue: selectedEntity.name,
+        sql: `${buildDropEntitySql(selectedEntity)};`,
+      },
+    });
+  }, [selectedDatabaseId, selectedEntity]);
+
+  const handleOpenDropAllEntities = useCallback(() => {
+    if (!selectedDatabaseId || !selectedDatabase) {
+      return;
+    }
+
+    const tableCount = entities.filter(
+      (entity) => entity.type === 'table',
+    ).length;
+    const viewCount = entities.filter(
+      (entity) => entity.type === 'view',
+    ).length;
+
+    setActiveDrop({
+      databaseId: selectedDatabaseId,
+      target: {
+        kind: 'database',
+        databaseName: selectedDatabase.name,
+        confirmationValue: selectedDatabase.name,
+        tableCount,
+        viewCount,
+        sql: buildDropAllEntitiesSql(entities),
+      },
+    });
+  }, [entities, selectedDatabase, selectedDatabaseId]);
+
+  const dropSelectedEntity = useCallback(
+    async (databaseId: string, sql: string) => {
+      await requestQuery({ databaseId, sql });
+    },
+    [requestQuery],
+  );
+
+  const dropAllEntities = useCallback(
+    async (databaseId: string, sql: string) => {
+      // Dropping a parent table before its children fails while foreign key
+      // enforcement is on, so turn it off for the sweep. The pragma is
+      // per-connection and that connection belongs to the running app, so the
+      // original value has to be restored on every path out of here.
+      const foreignKeysResult = await requestQuery({
+        databaseId,
+        sql: SQLITE_READ_FOREIGN_KEYS_SQL,
+      });
+      const foreignKeysWereEnabled = isForeignKeysEnabled(
+        foreignKeysResult.rows,
+      );
+
+      if (foreignKeysWereEnabled) {
+        await requestQuery({
+          databaseId,
+          sql: buildSetForeignKeysSql(false),
+        });
+      }
+
+      let dropError: unknown = null;
+
+      try {
+        const scriptResult = await requestScriptExecution({
+          databaseId,
+          sql,
+        });
+
+        if (scriptResult.failedStatementIndex != null) {
+          const failedStatement = scriptResult.statements.find(
+            (statement) =>
+              statement.index === scriptResult.failedStatementIndex,
+          );
+          throw new Error(failedStatement?.error ?? 'Script execution failed.');
+        }
+      } catch (error) {
+        dropError = error;
+      }
+
+      if (foreignKeysWereEnabled) {
+        try {
+          await requestQuery({
+            databaseId,
+            sql: buildSetForeignKeysSql(true),
+          });
+        } catch (restoreError) {
+          // The drop error, if any, takes priority: it's the reason the user
+          // is looking at this modal. Only surface the restore failure when
+          // the drop itself succeeded, since that's a new, silent problem.
+          if (!dropError) {
+            throw restoreError instanceof Error
+              ? restoreError
+              : new Error(String(restoreError));
+          }
+        }
+      }
+
+      if (dropError) {
+        throw dropError instanceof Error
+          ? dropError
+          : new Error(String(dropError));
+      }
+    },
+    [requestQuery, requestScriptExecution],
+  );
+
+  const handleConfirmDrop = useCallback(async () => {
+    if (!activeDrop) {
+      throw new Error('The drop target is no longer available.');
+    }
+
+    // Execute the target captured when the dialog opened rather than the
+    // current selection: an app reload can fire `sqlite:ready` mid-dialog,
+    // which reloads the explorer and may move the selection elsewhere. The
+    // user confirmed by typing this object's name, so this is the object that
+    // has to be dropped.
+    const { databaseId, target } = activeDrop;
+
+    if (!target.sql) {
+      throw new Error('There is nothing to drop.');
+    }
+
+    if (target.kind === 'entity') {
+      await dropSelectedEntity(databaseId, target.sql);
+    } else {
+      await dropAllEntities(databaseId, target.sql);
+    }
+
+    setActiveDrop(null);
+    setSelectedEntityKey(null);
+    await refreshExplorerData();
+  }, [activeDrop, dropAllEntities, dropSelectedEntity, refreshExplorerData]);
 
   const getActiveStatement = useCallback(() => {
     const cursorPosition =
@@ -2287,6 +2460,17 @@ export default function SqlitePanel() {
               )}
             />
           </button>
+          <button
+            type="button"
+            className={dangerIconButtonClassName}
+            onClick={handleOpenDropEntity}
+            aria-label={
+              selectedEntity.type === 'view' ? 'Drop view' : 'Drop table'
+            }
+            title={selectedEntity.type === 'view' ? 'Drop view' : 'Drop table'}
+          >
+            <Trash2 aria-hidden="true" className="h-4 w-4" />
+          </button>
         </div>
       </header>
 
@@ -2454,6 +2638,29 @@ export default function SqlitePanel() {
                       (databaseLoading || entityLoading) && 'animate-spin',
                     )}
                   />
+                </button>
+                <button
+                  type="button"
+                  className={dangerIconButtonClassName}
+                  aria-label={
+                    selectedDatabase
+                      ? `Drop all objects in ${selectedDatabase.name}`
+                      : 'Drop all objects'
+                  }
+                  title={
+                    selectedDatabase
+                      ? `Drop all objects in ${selectedDatabase.name}`
+                      : 'Drop all objects'
+                  }
+                  onClick={handleOpenDropAllEntities}
+                  disabled={
+                    !selectedDatabaseId ||
+                    entities.length === 0 ||
+                    databaseLoading ||
+                    entityLoading
+                  }
+                >
+                  <Trash2 aria-hidden="true" className="h-4 w-4" />
                 </button>
               </div>
             </header>
@@ -2808,6 +3015,13 @@ export default function SqlitePanel() {
           entityName={selectedEntity?.name ?? 'row'}
           onClose={() => setDeletingRow(null)}
           onDelete={handleDeleteRow}
+        />
+
+        <SqliteDropModal
+          isOpen={!!activeDrop}
+          target={activeDrop?.target ?? DEFAULT_DROP_TARGET}
+          onClose={() => setActiveDrop(null)}
+          onConfirm={handleConfirmDrop}
         />
       </div>
     </div>

--- a/packages/sqlite-plugin/src/ui/sqlite-drop-modal.tsx
+++ b/packages/sqlite-plugin/src/ui/sqlite-drop-modal.tsx
@@ -1,0 +1,219 @@
+import { Modal, useOverlayState } from '@heroui/react';
+import { AlertTriangle, Trash2 } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import {
+  SqliteModalCloseButton,
+  sqliteSecondaryButtonClassName,
+} from './sqlite-modal-controls';
+
+export type SqliteDropModalTarget =
+  | {
+      kind: 'entity';
+      entityType: 'table' | 'view';
+      qualifiedName: string;
+      confirmationValue: string;
+      sql: string;
+    }
+  | {
+      kind: 'database';
+      databaseName: string;
+      confirmationValue: string;
+      tableCount: number;
+      viewCount: number;
+      sql: string;
+    };
+
+type SqliteDropModalProps = {
+  isOpen: boolean;
+  target: SqliteDropModalTarget;
+  onClose: () => void;
+  onConfirm: () => Promise<void>;
+};
+
+const toneButtonClassName =
+  'sqlite-button inline-flex items-center justify-center gap-2 rounded-xl px-3 py-2 text-sm font-medium';
+const dangerButtonClassName = `${toneButtonClassName} border border-rose-400/30 bg-rose-500/16 text-rose-50 hover:bg-rose-500/24`;
+
+const getModalTitle = (target: SqliteDropModalTarget) =>
+  target.kind === 'entity'
+    ? `Drop ${target.entityType === 'view' ? 'View' : 'Table'}`
+    : 'Drop All Objects';
+
+const getModalSubtitle = (target: SqliteDropModalTarget) =>
+  target.kind === 'entity' ? target.qualifiedName : target.databaseName;
+
+const getConfirmationLabel = (target: SqliteDropModalTarget) =>
+  target.kind === 'entity'
+    ? `${target.entityType === 'view' ? 'view' : 'table'} name`
+    : 'database name';
+
+export const SqliteDropModal = ({
+  isOpen,
+  target,
+  onClose,
+  onConfirm,
+}: SqliteDropModalProps) => {
+  const overlay = useOverlayState({
+    isOpen,
+    onOpenChange: (open: boolean) => {
+      if (!open) {
+        onClose();
+      }
+    },
+  });
+  const [dropping, setDropping] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [confirmationInput, setConfirmationInput] = useState('');
+
+  useEffect(() => {
+    if (isOpen) {
+      setDropping(false);
+      setError(null);
+      setConfirmationInput('');
+    }
+  }, [isOpen]);
+
+  const isConfirmed = confirmationInput === target.confirmationValue;
+
+  const handleConfirm = async () => {
+    if (!isConfirmed) {
+      return;
+    }
+
+    try {
+      setDropping(true);
+      setError(null);
+      await onConfirm();
+      onClose();
+    } catch (nextError) {
+      setError(
+        nextError instanceof Error ? nextError.message : String(nextError),
+      );
+    } finally {
+      setDropping(false);
+    }
+  };
+
+  return (
+    <Modal state={overlay}>
+      <Modal.Backdrop
+        variant="blur"
+        isDismissable={!dropping}
+        className="bg-[rgba(5,10,16,0.24)] backdrop-blur-[2px]"
+      >
+        <Modal.Container placement="center" size="md" scroll="inside">
+          <Modal.Dialog
+            aria-label={`${getModalTitle(target)} ${getModalSubtitle(target)}`}
+            className="w-full max-w-xl overflow-hidden border border-white/10 bg-[#0a121b] p-0 text-white shadow-[0_30px_90px_rgba(0,0,0,0.42)]"
+          >
+            <div className="flex items-center justify-between gap-4 border-b border-white/8 px-5 py-5">
+              <div className="flex items-center gap-3">
+                <div className="flex h-10 w-10 items-center justify-center rounded-full bg-rose-500/12 text-rose-200">
+                  <AlertTriangle aria-hidden="true" className="h-5 w-5" />
+                </div>
+                <div>
+                  <h2 className="text-lg font-semibold text-white">
+                    {getModalTitle(target)}
+                  </h2>
+                  <p className="mt-1 text-sm text-slate-400">
+                    {getModalSubtitle(target)}
+                  </p>
+                </div>
+              </div>
+              <SqliteModalCloseButton onClose={onClose} disabled={dropping} />
+            </div>
+
+            <Modal.Body className="space-y-0 p-0">
+              <div className="space-y-5 px-5 py-5">
+                {target.kind === 'database' ? (
+                  <p className="text-sm leading-6 text-slate-300">
+                    This drops every table and view in{' '}
+                    <span className="font-medium text-white">
+                      {target.databaseName}
+                    </span>{' '}
+                    — {target.tableCount} table
+                    {target.tableCount === 1 ? '' : 's'} and {target.viewCount}{' '}
+                    view{target.viewCount === 1 ? '' : 's'}, along with all
+                    their rows, indexes and triggers. The database file itself
+                    is not deleted; it is left empty. This cannot be undone.
+                  </p>
+                ) : (
+                  <p className="text-sm leading-6 text-slate-300">
+                    This permanently drops{' '}
+                    <span className="font-medium text-white">
+                      {target.qualifiedName}
+                    </span>{' '}
+                    and everything it owns — rows, indexes and triggers. This
+                    cannot be undone.
+                  </p>
+                )}
+
+                <div className="space-y-2">
+                  <p className="sqlite-helper-text">SQL to be executed</p>
+                  <pre className="max-h-40 overflow-auto rounded-lg border border-white/8 bg-black/30 px-3 py-2 text-xs leading-5 text-slate-200">
+                    {target.sql}
+                  </pre>
+                </div>
+
+                <div className="space-y-2">
+                  <label
+                    htmlFor="sqlite-drop-confirmation-input"
+                    className="sqlite-helper-text"
+                  >
+                    Type the {getConfirmationLabel(target)}{' '}
+                    <span className="font-medium text-white">
+                      {target.confirmationValue}
+                    </span>{' '}
+                    to confirm
+                  </label>
+                  <input
+                    id="sqlite-drop-confirmation-input"
+                    type="text"
+                    name="dropConfirmation"
+                    autoComplete="off"
+                    spellCheck={false}
+                    className="sqlite-input"
+                    value={confirmationInput}
+                    onChange={(event) =>
+                      setConfirmationInput(event.target.value)
+                    }
+                    disabled={dropping}
+                  />
+                </div>
+
+                {error ? (
+                  <div className="sqlite-inline-error" aria-live="polite">
+                    <div>
+                      <p className="font-medium text-rose-100">Drop Failed</p>
+                      <p className="mt-1 text-sm text-rose-100/90">{error}</p>
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+
+              <div className="flex items-center justify-end gap-3 border-t border-white/8 px-5 py-5">
+                <button
+                  type="button"
+                  className={sqliteSecondaryButtonClassName}
+                  onClick={onClose}
+                  disabled={dropping}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  className={dangerButtonClassName}
+                  onClick={() => void handleConfirm()}
+                  disabled={dropping || !isConfirmed}
+                >
+                  <Trash2 aria-hidden="true" className="h-4 w-4" />
+                  {dropping ? 'Dropping…' : getModalTitle(target)}
+                </button>
+              </div>
+            </Modal.Body>
+          </Modal.Dialog>
+        </Modal.Container>
+      </Modal.Backdrop>
+    </Modal>
+  );
+};

--- a/packages/sqlite-plugin/src/ui/sqlite-drop-mutations.ts
+++ b/packages/sqlite-plugin/src/ui/sqlite-drop-mutations.ts
@@ -1,0 +1,60 @@
+import { quoteSqlIdentifier } from '../shared/sql';
+import type { SqliteEntity } from './sqlite-introspection';
+
+export type SqliteDropTarget = Pick<
+  SqliteEntity,
+  'schemaName' | 'name' | 'type'
+>;
+
+const buildQualifiedEntityName = (schemaName: string, entityName: string) =>
+  `${quoteSqlIdentifier(schemaName)}.${quoteSqlIdentifier(entityName)}`;
+
+/**
+ * Builds a single `DROP TABLE` / `DROP VIEW` statement for the given entity.
+ * Identifiers are quoted (never parameterized, since SQLite does not support
+ * parameter binding for identifiers), so this is the only place that needs to
+ * get quoting right.
+ */
+export const buildDropEntitySql = (entity: SqliteDropTarget): string => {
+  const keyword = entity.type === 'view' ? 'VIEW' : 'TABLE';
+  return `DROP ${keyword} ${buildQualifiedEntityName(entity.schemaName, entity.name)}`;
+};
+
+/**
+ * Orders entities so that views are dropped before tables, preserving the
+ * relative order within each group. This keeps a view that references a
+ * table from ever being left dangling mid-sweep.
+ */
+export const orderEntitiesForDrop = (
+  entities: SqliteDropTarget[],
+): SqliteDropTarget[] => [
+  ...entities.filter((entity) => entity.type === 'view'),
+  ...entities.filter((entity) => entity.type === 'table'),
+];
+
+/**
+ * Builds the full drop-everything script for a database sweep: every view,
+ * then every table, each as its own statement. Returns an empty string when
+ * there is nothing to drop.
+ */
+export const buildDropAllEntitiesSql = (entities: SqliteDropTarget[]): string =>
+  orderEntitiesForDrop(entities)
+    .map((entity) => `${buildDropEntitySql(entity)};`)
+    .join('\n');
+
+export const SQLITE_READ_FOREIGN_KEYS_SQL = 'PRAGMA foreign_keys';
+
+/**
+ * `PRAGMA foreign_keys` is per-connection and not parameterizable; the value
+ * is always a literal 0/1 keyword, never user input, so this is safe to
+ * inline directly.
+ */
+export const buildSetForeignKeysSql = (enabled: boolean): string =>
+  `PRAGMA foreign_keys = ${enabled ? 'ON' : 'OFF'}`;
+
+export const isForeignKeysEnabled = (
+  rows: Record<string, unknown>[],
+): boolean => {
+  const rawValue = rows[0]?.foreign_keys;
+  return Number(rawValue) === 1;
+};


### PR DESCRIPTION
## Description

Adds schema-level destructive actions to the SQLite DevTools panel:

- Drop the selected table or view from the Structure tab.
- Drop all user tables and views from the selected database.
- Protect both operations with a shared type-to-confirm dialog, SQL preview, counts, and inline errors.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Closes https://github.com/callstackincubator/rozenite/issues/346

## Context

The adapter exposes execution of SQL statements, but not database-file deletion, so “drop database” is implemented honestly as dropping every user table and view while keeping the open database file intact. Single-object drops use the existing query path; the database sweep uses script execution and drops views before tables.

When foreign-key enforcement is enabled, the sweep temporarily disables it and restores the original value on both success and failure paths. Identifiers are quoted with the existing SQLite identifier helper, and the explorer refreshes after a successful mutation.

## Testing

Automated:

- `pnpm --filter @rozenite/sqlite-plugin build`
- `pnpm --filter @rozenite/sqlite-plugin test` — 49 tests passed
- `pnpm --filter @rozenite/sqlite-plugin typecheck`
- `pnpm --filter @rozenite/sqlite-plugin lint`

Manual verification (confirmed in the requested environment):

- Started Metro from `apps/playground` in this worktree.
- Opened the already-installed Rozenite playground on the running iPhone 17 Pro simulator with `agent-device`.
- Opened React Native DevTools at the provided URL with `agent-browser` and exercised the SQLite panel’s table/view and database-level drop flows, including confirmation gating and post-drop explorer state.
