### PR TITLE
feat(runtime): add unified plugin sidebar

### DIFF
--- a/.changeset/unified-plugin-shell.md
+++ b/.changeset/unified-plugin-shell.md
@@ -1,0 +1,8 @@
+---
+'@rozenite/middleware': minor
+'@rozenite/runtime': minor
+'@rozenite/shell': minor
+---
+
+Show plugin panels in a unified Rozenite sidebar by default, with an option to
+keep the individual DevTools tabs presentation.

--- a/packages/metro/README.md
+++ b/packages/metro/README.md
@@ -54,6 +54,7 @@ export default withRozenite(
     include: ['@my-org/my-plugin', 'another-plugin'],
     exclude: ['unwanted-plugin'],
     destroyOnDetachPlugins: ['@rozenite/network-activity-plugin'],
+    pluginDisplay: 'sidebar',
   }
 );
 ```
@@ -69,6 +70,7 @@ type RozeniteMetroConfig = {
   include?: string[]; // Only load these specific plugins
   exclude?: string[]; // Exclude these plugins from loading
   destroyOnDetachPlugins?: string[]; // Plugins that should be destroyed when switching panels
+  pluginDisplay?: 'sidebar' | 'tabs'; // How plugins are displayed in DevTools
 };
 ```
 
@@ -77,6 +79,7 @@ type RozeniteMetroConfig = {
 - `include` - Array of package names to explicitly include (optional)
 - `exclude` - Array of package names to exclude from loading (optional)
 - `destroyOnDetachPlugins` - Array of package names that should be destroyed when switching panels instead of maintaining their state (optional, by default all plugins persist their state)
+- `pluginDisplay` - Use `'sidebar'` (default) to show all plugin panels in one Rozenite tab, or `'tabs'` to retain a separate DevTools tab for every plugin panel
 
 ## Plugin Discovery
 

--- a/packages/middleware/package.json
+++ b/packages/middleware/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "@rozenite/agent-shared": "workspace:*",
     "@rozenite/runtime": "workspace:*",
+    "@rozenite/shell": "workspace:*",
     "@rozenite/tools": "workspace:*",
     "express": "^5.1.0",
     "semver": "^7.7.2",

--- a/packages/middleware/src/config.ts
+++ b/packages/middleware/src/config.ts
@@ -1,6 +1,9 @@
 import { type ProjectType } from '@rozenite/tools';
 import { RozeniteLogLevel } from './logger.js';
 
+/** Controls whether plugins are shown as individual tabs or in one sidebar. */
+export type RozenitePluginDisplay = 'tabs' | 'sidebar';
+
 export type RozeniteConfig = {
   projectRoot: string;
   include?: string[];
@@ -24,4 +27,11 @@ export type RozeniteConfig = {
    * @default 'info'
    */
   logLevel?: RozeniteLogLevel;
+
+  /**
+   * How Rozenite plugins are shown in React Native DevTools.
+   *
+   * @default 'sidebar'
+   */
+  pluginDisplay?: RozenitePluginDisplay;
 };

--- a/packages/middleware/src/entry-point.ts
+++ b/packages/middleware/src/entry-point.ts
@@ -31,6 +31,7 @@ const appendScripts = (
   nonce: string,
   installedPlugins: string[],
   destroyOnDetachPlugins: string[],
+  pluginDisplay: 'tabs' | 'sidebar',
 ): string => {
   const bodyTagRegex = /<body[^>]*>/;
   const bodyMatch = html.match(bodyTagRegex);
@@ -41,6 +42,7 @@ const appendScripts = (
       var __ROZENITE__ = {
         installedPlugins: ${JSON.stringify(installedPlugins)},
         destroyOnDetachPlugins: ${JSON.stringify(destroyOnDetachPlugins)},
+        pluginDisplay: ${JSON.stringify(pluginDisplay)},
       };
     </script>
   `;
@@ -63,6 +65,7 @@ export const getEntryPointHTML = (
   rnDevToolsFrontendPath: string,
   installedPlugins: string[],
   destroyOnDetachPlugins: string[],
+  pluginDisplay: 'tabs' | 'sidebar' = 'sidebar',
 ): string => {
   const nonce = crypto.randomUUID();
   const originalEntryPoint = fs.readFileSync(
@@ -75,5 +78,6 @@ export const getEntryPointHTML = (
     nonce,
     installedPlugins,
     destroyOnDetachPlugins,
+    pluginDisplay,
   );
 };

--- a/packages/middleware/src/index.ts
+++ b/packages/middleware/src/index.ts
@@ -5,7 +5,7 @@ import { logger } from './logger.js';
 import { getPackageJSON } from './package-json.js';
 import { getInstalledPlugins } from './auto-discovery.js';
 import { createScopedMiddleware } from './scoped-middleware.js';
-import type { RozeniteConfig } from './config.js';
+import type { RozeniteConfig, RozenitePluginDisplay } from './config.js';
 import { getDevModePackage } from './dev-mode.js';
 import { verifyReactNativeVersion } from './verify-react-native-version.js';
 import { getReactNativePackagePath } from './resolve.js';
@@ -82,4 +82,4 @@ export const initializeRozenite = (
   };
 };
 
-export type { RozeniteConfig };
+export type { RozeniteConfig, RozenitePluginDisplay };

--- a/packages/middleware/src/middleware.ts
+++ b/packages/middleware/src/middleware.ts
@@ -46,6 +46,10 @@ export const getMiddleware = (
     require.resolve('@rozenite/runtime'),
     '..',
   );
+  const shellPath = path.join(
+    path.dirname(require.resolve('@rozenite/shell/package.json')),
+    'dist',
+  );
 
   logger.debug(`Debugger frontend path: ${debuggerFrontend}`);
   logger.debug(`Framework path: ${frameworkPath}`);
@@ -88,6 +92,7 @@ export const getMiddleware = (
         debuggerFrontend,
         installedPlugins.map((plugin) => plugin.name),
         destroyOnDetachPlugins,
+        options.pluginDisplay ?? 'sidebar',
       ),
     );
   });
@@ -96,6 +101,8 @@ export const getMiddleware = (
     res.setHeader('Content-Type', 'application/javascript');
     res.end(fs.readFileSync(path.join(frameworkPath, 'host.js'), 'utf8'));
   });
+
+  app.use('/shell', express.static(shellPath));
 
   app.use(createAgentRoutes(agentSessionManager));
 

--- a/packages/runtime/src/create-panel.ts
+++ b/packages/runtime/src/create-panel.ts
@@ -12,7 +12,12 @@ const toExtendedKebabCase = (input: string): string => {
     .replace(/^\.+|\.+$/g, '');
 };
 
-export const createPanel = (pluginId: string, name: string, url: string) => {
+export const createPanel = (
+  pluginId: string,
+  name: string,
+  url: string,
+  shellConfiguration?: unknown,
+) => {
   try {
     const pluginIdKebab = toExtendedKebabCase(pluginId);
     const nameKebab = toExtendedKebabCase(name);
@@ -22,7 +27,13 @@ export const createPanel = (pluginId: string, name: string, url: string) => {
       return;
     }
 
-    const panelView = getPluginView(pluginId, panelId, name, url);
+    const panelView = getPluginView(
+      pluginId,
+      panelId,
+      name,
+      url,
+      shellConfiguration,
+    );
 
     UI.InspectorView.InspectorView.instance().addPanel(panelView);
   } catch (err) {

--- a/packages/runtime/src/create-panel.ts
+++ b/packages/runtime/src/create-panel.ts
@@ -17,6 +17,7 @@ export const createPanel = (
   name: string,
   url: string,
   shellConfiguration?: unknown,
+  insertAtStart = false,
 ) => {
   try {
     const pluginIdKebab = toExtendedKebabCase(pluginId);
@@ -36,6 +37,18 @@ export const createPanel = (
     );
 
     UI.InspectorView.InspectorView.instance().addPanel(panelView);
+
+    if (insertAtStart) {
+      const tabbedPane = UI.InspectorView.InspectorView.instance().tabbedPane;
+      const panelViewTab = tabbedPane.tabsById.get(panelId);
+
+      if (!panelViewTab) {
+        throw new Error(`Panel view tab not found: ${panelId}`);
+      }
+
+      tabbedPane.insertBefore(panelViewTab, 0);
+      tabbedPane.selectTab(panelViewTab.id);
+    }
   } catch (err) {
     console.error(err);
     throw err;

--- a/packages/runtime/src/dev-mode.ts
+++ b/packages/runtime/src/dev-mode.ts
@@ -1,29 +1,19 @@
-import { getManifest } from './manifest';
-import { loadPluginFromUrl } from './plugin-loader';
+import { loadPluginFromUrl, type LoadedPlugin } from './plugin-loader';
 
 /** Must match `config.server.port` in `packages/vite-plugin` (`rozeniteClientPlugin`). */
 const DEV_SERVER_URL = 'http://localhost:8888';
 
-const isDevServerAvailable = async (): Promise<boolean> => {
+export const setupDevMode = async (): Promise<LoadedPlugin | null> => {
   try {
-    await getManifest(DEV_SERVER_URL);
-    return true;
+    const plugin = await loadPluginFromUrl(DEV_SERVER_URL);
+
+    console.group('🔧 Rozenite Dev Mode');
+    console.log('We detected that you are developing a plugin.');
+    console.log('This plugin will be automatically loaded with hot reload.');
+    console.groupEnd();
+
+    return plugin;
   } catch {
-    return false;
+    return null;
   }
-};
-
-export const setupDevMode = async (): Promise<void> => {
-  const isAvailable = await isDevServerAvailable();
-
-  if (!isAvailable) {
-    return;
-  }
-
-  console.group('🔧 Rozenite Dev Mode');
-  console.log('We detected that you are developing a plugin.');
-  console.log('This plugin will be automatically loaded with hot reload.');
-  console.groupEnd();
-
-  await loadPluginFromUrl(DEV_SERVER_URL);
 };

--- a/packages/runtime/src/global-namespace.ts
+++ b/packages/runtime/src/global-namespace.ts
@@ -3,6 +3,7 @@ declare global {
     installedPlugins: string[];
     developmentServer: boolean;
     destroyOnDetachPlugins: string[];
+    pluginDisplay: 'tabs' | 'sidebar';
   };
 }
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,5 +1,6 @@
 import { setupDevMode } from './dev-mode.js';
 import { getGlobalNamespace } from './global-namespace.js';
+import { createPanel } from './create-panel.js';
 import { loadPlugin } from './plugin-loader.js';
 import { addWelcomeView } from './rn-devtools/rozenite-welcome-view.js';
 import {
@@ -33,18 +34,34 @@ const main = async (): Promise<void> => {
   console.log('Found plugins: ' + plugins.join(', '));
   console.groupEnd();
 
-  addWelcomeView();
+  const { pluginDisplay = 'sidebar' } = getGlobalNamespace();
 
-  await Promise.all(
-    plugins.map(async (plugin) => {
-      await loadPlugin(plugin);
-    }),
-  );
+  if (pluginDisplay === 'tabs') {
+    addWelcomeView();
+    await Promise.all(plugins.map((plugin) => loadPlugin(plugin)));
+    await setupDevMode();
+  } else {
+    const loadedPlugins = await Promise.all(
+      plugins.map(async (plugin) => {
+        return loadPlugin(plugin);
+      }),
+    );
+
+    const developmentPlugin = await setupDevMode();
+    if (developmentPlugin) {
+      loadedPlugins.push(developmentPlugin);
+    }
+
+    const shellUrl = new URL(location.href);
+    shellUrl.search = '';
+    shellUrl.pathname = '/rozenite/shell/index.html';
+    createPanel('@rozenite/shell', 'Rozenite', shellUrl.toString(), {
+      plugins: loadedPlugins,
+    });
+  }
 
   trackPanelSelection();
   switchToSelectedPanel();
-
-  await setupDevMode();
 };
 
 void main().catch((error) => {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -35,9 +35,9 @@ const main = async (): Promise<void> => {
   console.groupEnd();
 
   const { pluginDisplay = 'sidebar' } = getGlobalNamespace();
+  addWelcomeView();
 
   if (pluginDisplay === 'tabs') {
-    addWelcomeView();
     await Promise.all(plugins.map((plugin) => loadPlugin(plugin)));
     await setupDevMode();
   } else {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -35,9 +35,9 @@ const main = async (): Promise<void> => {
   console.groupEnd();
 
   const { pluginDisplay = 'sidebar' } = getGlobalNamespace();
-  addWelcomeView();
 
   if (pluginDisplay === 'tabs') {
+    addWelcomeView();
     await Promise.all(plugins.map((plugin) => loadPlugin(plugin)));
     await setupDevMode();
   } else {
@@ -55,9 +55,15 @@ const main = async (): Promise<void> => {
     const shellUrl = new URL(location.href);
     shellUrl.search = '';
     shellUrl.pathname = '/rozenite/shell/index.html';
-    createPanel('@rozenite/shell', 'Rozenite', shellUrl.toString(), {
-      plugins: loadedPlugins,
-    });
+    createPanel(
+      '@rozenite/shell',
+      'Rozenite',
+      shellUrl.toString(),
+      {
+        plugins: loadedPlugins,
+      },
+      true,
+    );
   }
 
   trackPanelSelection();

--- a/packages/runtime/src/plugin-loader.ts
+++ b/packages/runtime/src/plugin-loader.ts
@@ -1,27 +1,48 @@
-import { createPanel } from './create-panel';
 import { getManifest } from './manifest';
 
-const getPluginUrl = (pluginId: string) => {
+export type LoadedPlugin = {
+  id: string;
+  name: string;
+  description: string;
+  panels: {
+    id: string;
+    name: string;
+    source: string;
+  }[];
+};
+
+export const getPluginUrl = (pluginId: string) => {
   const url = new URL(location.href);
   url.search = '';
   url.pathname = '/rozenite/plugins/' + pluginId.replace('/', '_');
   return url.toString();
 };
 
-export const loadPluginFromUrl = async (url: string): Promise<void> => {
+export const loadPluginFromUrl = async (
+  url: string,
+  pluginId?: string,
+): Promise<LoadedPlugin> => {
   const manifest = await getManifest(url);
-  manifest.panels.forEach((panel) => {
-    const panelUrl = url + panel.source;
-    createPanel(manifest.name, panel.name, panelUrl);
-  });
+  const id = pluginId ?? manifest.name;
 
   console.groupCollapsed(`📦 Plugin: ${manifest.name}`);
   console.log('Version:', manifest.version);
   console.log('Description:', manifest.description);
   console.log('Panels:', manifest.panels.map((panel) => panel.name).join(', '));
   console.groupEnd();
+
+  return {
+    id,
+    name: manifest.name,
+    description: manifest.description,
+    panels: manifest.panels.map((panel) => ({
+      id: `${id}:${panel.name}`,
+      name: panel.name,
+      source: url + panel.source,
+    })),
+  };
 };
 
-export const loadPlugin = async (pluginId: string): Promise<void> => {
-  await loadPluginFromUrl(getPluginUrl(pluginId));
+export const loadPlugin = async (pluginId: string): Promise<LoadedPlugin> => {
+  return loadPluginFromUrl(getPluginUrl(pluginId), pluginId);
 };

--- a/packages/runtime/src/rn-devtools/plugin-view.ts
+++ b/packages/runtime/src/rn-devtools/plugin-view.ts
@@ -9,11 +9,19 @@ export class PluginView
 {
   #model: RozenitePluginModel | null = null;
   #src: string;
+  #shellConfiguration: unknown;
 
-  constructor(pluginId: string, panelId: string, name: string, url: string) {
+  constructor(
+    pluginId: string,
+    panelId: string,
+    name: string,
+    url: string,
+    shellConfiguration?: unknown,
+  ) {
     super(name + ' 💎', true, panelId);
 
     this.#src = url;
+    this.#shellConfiguration = shellConfiguration;
 
     const globalNamespace = getGlobalNamespace();
     const destroyOnDetachPlugins = globalNamespace.destroyOnDetachPlugins;
@@ -104,6 +112,17 @@ export class PluginView
         return;
       }
 
+      if (event.data?.type === 'rozenite-shell-ready') {
+        iframe.contentWindow?.postMessage(
+          {
+            type: 'rozenite-shell-configuration',
+            payload: this.#shellConfiguration,
+          },
+          '*',
+        );
+        return;
+      }
+
       model.sendMessage(event.data.payload);
     });
 
@@ -166,6 +185,7 @@ export const getPluginView = (
   panelId: string,
   name: string,
   url: string,
+  shellConfiguration?: unknown,
 ) => {
-  return new PluginView(pluginId, panelId, name, url);
+  return new PluginView(pluginId, panelId, name, url, shellConfiguration);
 };

--- a/packages/shell/index.html
+++ b/packages/shell/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Rozenite</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/packages/shell/package.json
+++ b/packages/shell/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@rozenite/shell",
+  "version": "1.13.0",
+  "description": "Unified Rozenite panel shell for React Native DevTools.",
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "eslint .",
+    "test": "vitest --run --passWithNoTests"
+  },
+  "dependencies": {
+    "@rozenite/ui": "workspace:*",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.2.2",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "typescript": "~5.9.3",
+    "vite": "catalog:",
+    "vitest": "^4.0.18"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/shell/src/Shell.tsx
+++ b/packages/shell/src/Shell.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { EmptyState, PluginShell, Sidebar } from '@rozenite/ui';
+import { getInitialSelection, type ShellSelection } from './selection';
+import type { ShellConfiguration, ShellPanel, ShellPlugin } from './types';
+
+const SHELL_CONFIGURATION_TYPE = 'rozenite-shell-configuration';
+
+export function Shell({ plugins }: ShellConfiguration) {
+  const [selection, setSelection] = useState<ShellSelection>(() =>
+    getInitialSelection(plugins),
+  );
+  const contentFrame = useRef<HTMLIFrameElement>(null);
+
+  useEffect(() => {
+    setSelection((current) => {
+      if (
+        current &&
+        plugins.some(
+          (plugin) =>
+            plugin.id === current.pluginId &&
+            plugin.panels.some((panel) => panel.id === current.panelId),
+        )
+      ) {
+        return current;
+      }
+
+      return getInitialSelection(plugins);
+    });
+  }, [plugins]);
+
+  useEffect(() => {
+    const forwardToActivePanel = (event: MessageEvent) => {
+      const activeFrame = contentFrame.current;
+
+      if (event.source === window.parent) {
+        activeFrame?.contentWindow?.postMessage(event.data, '*');
+        return;
+      }
+
+      if (event.source === activeFrame?.contentWindow) {
+        window.parent.postMessage(event.data, '*');
+      }
+    };
+
+    window.addEventListener('message', forwardToActivePanel);
+    return () => window.removeEventListener('message', forwardToActivePanel);
+  }, []);
+
+  const activePlugin = useMemo(
+    () => plugins.find((plugin) => plugin.id === selection?.pluginId) ?? null,
+    [plugins, selection?.pluginId],
+  );
+  const activePanel = activePlugin?.panels.find(
+    (panel) => panel.id === selection?.panelId,
+  );
+  const selectPanel = (plugin: ShellPlugin, panel: ShellPanel) => {
+    setSelection({ pluginId: plugin.id, panelId: panel.id });
+  };
+
+  if (!activePlugin || !activePanel) {
+    return (
+      <PluginShell>
+        <PluginShell.Body className="items-center justify-center">
+          <EmptyState
+            title="No Rozenite plugins available"
+            description="Install a Rozenite plugin and reconnect DevTools to inspect it here."
+          />
+        </PluginShell.Body>
+      </PluginShell>
+    );
+  }
+
+  return (
+    <PluginShell>
+      <PluginShell.Body className="flex-row overflow-hidden">
+        <Sidebar aria-label="Rozenite panels" className="w-56 shrink-0 gap-3">
+          {plugins.map((plugin) => {
+            if (plugin.panels.length === 0) {
+              return null;
+            }
+
+            if (plugin.panels.length === 1) {
+              const [panel] = plugin.panels;
+
+              return (
+                <Sidebar.Item
+                  key={panel.id}
+                  selected={panel.id === activePanel.id}
+                  onClick={() => selectPanel(plugin, panel)}
+                >
+                  {panel.name}
+                </Sidebar.Item>
+              );
+            }
+
+            return (
+              <Sidebar.Group key={plugin.id} label={plugin.name}>
+                {plugin.panels.map((panel) => (
+                  <Sidebar.Item
+                    key={panel.id}
+                    selected={panel.id === activePanel.id}
+                    onClick={() => selectPanel(plugin, panel)}
+                  >
+                    {panel.name}
+                  </Sidebar.Item>
+                ))}
+              </Sidebar.Group>
+            );
+          })}
+        </Sidebar>
+        <div className="min-w-0 flex-1">
+          <iframe
+            key={`${activePlugin.id}:${activePanel.id}`}
+            ref={contentFrame}
+            title={`${activePlugin.name}: ${activePanel.name}`}
+            src={activePanel.source}
+          />
+        </div>
+      </PluginShell.Body>
+    </PluginShell>
+  );
+}
+
+export { SHELL_CONFIGURATION_TYPE };

--- a/packages/shell/src/Shell.tsx
+++ b/packages/shell/src/Shell.tsx
@@ -79,7 +79,7 @@ export function Shell({ plugins }: ShellConfiguration) {
           aria-label="Rozenite panels"
           className="w-56 shrink-0 gap-0 p-0"
         >
-          <header className="shrink-0 border-b border-sidebar-border px-3 py-3">
+          <header className="sticky top-0 z-10 shrink-0 border-b border-sidebar-border bg-sidebar px-3 py-3">
             <img
               src={lightLogo}
               alt="Rozenite"

--- a/packages/shell/src/Shell.tsx
+++ b/packages/shell/src/Shell.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { EmptyState, PluginShell, Sidebar } from '@rozenite/ui';
+import lightLogo from '../../../website/src/public/logo-light.svg';
+import darkLogo from '../../../website/src/public/logo-dark.svg';
 import { getInitialSelection, type ShellSelection } from './selection';
 import type { ShellConfiguration, ShellPanel, ShellPlugin } from './types';
 
@@ -73,29 +75,32 @@ export function Shell({ plugins }: ShellConfiguration) {
   return (
     <PluginShell>
       <PluginShell.Body className="flex-row overflow-hidden">
-        <Sidebar aria-label="Rozenite panels" className="w-56 shrink-0 gap-3">
-          {plugins.map((plugin) => {
-            if (plugin.panels.length === 0) {
-              return null;
-            }
+        <Sidebar
+          aria-label="Rozenite panels"
+          className="w-56 shrink-0 gap-0 p-0"
+        >
+          <header className="shrink-0 border-b border-sidebar-border px-3 py-3">
+            <img
+              src={lightLogo}
+              alt="Rozenite"
+              className="h-6 w-auto dark:hidden"
+            />
+            <img
+              src={darkLogo}
+              alt="Rozenite"
+              className="hidden h-6 w-auto dark:block"
+            />
+          </header>
+          <div className="flex flex-col gap-3 p-2">
+            {plugins.map((plugin) => {
+              if (plugin.panels.length === 0) {
+                return null;
+              }
 
-            if (plugin.panels.length === 1) {
-              const [panel] = plugin.panels;
+              if (plugin.panels.length === 1) {
+                const [panel] = plugin.panels;
 
-              return (
-                <Sidebar.Item
-                  key={panel.id}
-                  selected={panel.id === activePanel.id}
-                  onClick={() => selectPanel(plugin, panel)}
-                >
-                  {panel.name}
-                </Sidebar.Item>
-              );
-            }
-
-            return (
-              <Sidebar.Group key={plugin.id} label={plugin.name}>
-                {plugin.panels.map((panel) => (
+                return (
                   <Sidebar.Item
                     key={panel.id}
                     selected={panel.id === activePanel.id}
@@ -103,10 +108,24 @@ export function Shell({ plugins }: ShellConfiguration) {
                   >
                     {panel.name}
                   </Sidebar.Item>
-                ))}
-              </Sidebar.Group>
-            );
-          })}
+                );
+              }
+
+              return (
+                <Sidebar.Group key={plugin.id} label={plugin.name}>
+                  {plugin.panels.map((panel) => (
+                    <Sidebar.Item
+                      key={panel.id}
+                      selected={panel.id === activePanel.id}
+                      onClick={() => selectPanel(plugin, panel)}
+                    >
+                      {panel.name}
+                    </Sidebar.Item>
+                  ))}
+                </Sidebar.Group>
+              );
+            })}
+          </div>
         </Sidebar>
         <div className="min-w-0 flex-1">
           <iframe

--- a/packages/shell/src/main.tsx
+++ b/packages/shell/src/main.tsx
@@ -1,0 +1,31 @@
+import { createRoot } from 'react-dom/client';
+import { useEffect, useState } from 'react';
+import { Shell, SHELL_CONFIGURATION_TYPE } from './Shell';
+import type { ShellConfiguration } from './types';
+import './styles.css';
+
+function App() {
+  const [configuration, setConfiguration] = useState<ShellConfiguration>({
+    plugins: [],
+  });
+
+  useEffect(() => {
+    const receiveConfiguration = (event: MessageEvent) => {
+      if (
+        event.source === window.parent &&
+        event.data?.type === SHELL_CONFIGURATION_TYPE
+      ) {
+        setConfiguration(event.data.payload as ShellConfiguration);
+      }
+    };
+
+    window.addEventListener('message', receiveConfiguration);
+    window.parent.postMessage({ type: 'rozenite-shell-ready' }, '*');
+
+    return () => window.removeEventListener('message', receiveConfiguration);
+  }, []);
+
+  return <Shell plugins={configuration.plugins} />;
+}
+
+createRoot(document.getElementById('root')!).render(<App />);

--- a/packages/shell/src/selection.test.ts
+++ b/packages/shell/src/selection.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { getInitialSelection } from './selection';
+
+describe('getInitialSelection', () => {
+  it('selects the first plugin that exposes a panel', () => {
+    expect(
+      getInitialSelection([
+        { id: 'empty', name: 'Empty', description: '', panels: [] },
+        {
+          id: 'storage',
+          name: 'Storage',
+          description: '',
+          panels: [{ id: 'storage:table', name: 'Table', source: '/table' }],
+        },
+      ]),
+    ).toEqual({ pluginId: 'storage', panelId: 'storage:table' });
+  });
+
+  it('returns null when no plugin has a panel', () => {
+    expect(getInitialSelection([])).toBeNull();
+  });
+});

--- a/packages/shell/src/selection.ts
+++ b/packages/shell/src/selection.ts
@@ -1,0 +1,13 @@
+import type { ShellPlugin } from './types';
+
+export type ShellSelection = {
+  pluginId: string;
+  panelId: string;
+} | null;
+
+export function getInitialSelection(plugins: ShellPlugin[]): ShellSelection {
+  const plugin = plugins.find((candidate) => candidate.panels.length > 0);
+  const panel = plugin?.panels[0];
+
+  return plugin && panel ? { pluginId: plugin.id, panelId: panel.id } : null;
+}

--- a/packages/shell/src/styles.css
+++ b/packages/shell/src/styles.css
@@ -1,0 +1,22 @@
+@import '@rozenite/ui/styles.css';
+
+@source "./**/*.{ts,tsx}";
+
+html,
+body,
+#root {
+  height: 100%;
+  margin: 0;
+}
+
+body {
+  overflow: hidden;
+}
+
+iframe {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  background: var(--background);
+}

--- a/packages/shell/src/types.ts
+++ b/packages/shell/src/types.ts
@@ -1,0 +1,16 @@
+export type ShellPanel = {
+  id: string;
+  name: string;
+  source: string;
+};
+
+export type ShellPlugin = {
+  id: string;
+  name: string;
+  description: string;
+  panels: ShellPanel[];
+};
+
+export type ShellConfiguration = {
+  plugins: ShellPlugin[];
+};

--- a/packages/shell/tsconfig.json
+++ b/packages/shell/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "noEmit": true,
+    "types": ["vite/client"],
+    "lib": ["dom", "es2022"],
+    "jsx": "react-jsx",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "paths": {
+      "@rozenite/ui": ["../ui/src/index.ts"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "vite.config.ts"],
+  "references": [
+    {
+      "path": "../ui/tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/shell/vite.config.ts
+++ b/packages/shell/vite.config.ts
@@ -1,0 +1,16 @@
+import tailwindcss from '@tailwindcss/vite';
+import react from '@vitejs/plugin-react';
+import { defineConfig, type PluginOption } from 'vite';
+
+export default defineConfig({
+  // The Tailwind Vite plugin currently resolves its own Vite type instance.
+  // Both plugins are Vite-compatible at runtime; this cast avoids treating
+  // their private Rollup types as incompatible.
+  plugins: [tailwindcss(), react()] as unknown as PluginOption[],
+  base: './',
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    reportCompressedSize: false,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -651,6 +651,9 @@ importers:
       '@rozenite/runtime':
         specifier: workspace:*
         version: link:../runtime
+      '@rozenite/shell':
+        specifier: workspace:*
+        version: link:../shell
       '@rozenite/tools':
         specifier: workspace:*
         version: link:../tools
@@ -1231,6 +1234,37 @@ importers:
       tslib:
         specifier: ^2.3.0
         version: 2.8.1
+
+  packages/shell:
+    dependencies:
+      '@rozenite/ui':
+        specifier: workspace:*
+        version: link:../ui
+      react:
+        specifier: 'catalog:'
+        version: 19.2.3
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.3(react@19.2.3)
+    devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.2.2
+        version: 4.2.2(vite@7.3.5(@types/node@22.17.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.8.1))
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.4(@types/react@19.2.14)
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^7.3.1
+        version: 7.3.5(@types/node@22.17.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.8.1)
+      vitest:
+        specifier: ^4.0.18
+        version: 4.1.0(@types/node@22.17.0)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@22.1.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.8.1)
 
   packages/sqlite-plugin:
     dependencies:

--- a/website/src/docs/getting-started.mdx
+++ b/website/src/docs/getting-started.mdx
@@ -302,6 +302,22 @@ export default withRozenite(
 
 **Note**: When using the `include` option, auto-discovery is completely disabled. Only the explicitly listed plugins will be loaded, and any plugins not in the list will be ignored, even if they are installed in your `node_modules`.
 
+## Plugin display
+
+By default, Rozenite puts all available plugin panels in one DevTools tab. Use
+the sidebar to move between panels. Plugins with one panel appear directly in
+the list, while plugins with several panels are grouped together.
+
+If you prefer each panel to have its own DevTools tab, set `pluginDisplay` to
+`'tabs'` in your Rozenite configuration:
+
+```javascript title="metro.config.js"
+module.exports = withRozenite(mergeConfig(defaultConfig, customConfig), {
+  enabled: process.env.WITH_ROZENITE === 'true',
+  pluginDisplay: 'tabs',
+});
+```
+
 ## Plugin State Management
 
 By default, Rozenite preserves plugin UI state when switching between DevTools panels. This provides a smooth user experience where data doesn't get lost when navigating between different plugins. However, for plugins that consume significant memory or resources, you may want to destroy them when they're not active.


### PR DESCRIPTION
## Description

Introduce a unified Rozenite DevTools tab that lists plugin panels in one sidebar. Single-panel plugins are direct entries; multi-panel plugins are grouped by plugin. The existing per-panel DevTools tabs remain available through configuration.

## Related Issue

Closes #354

## Context

Loading every plugin panel as a top-level DevTools tab becomes cluttered and makes related Rozenite tooling feel disconnected. The shell retains each plugin panel as an iframe and proxies the existing bridge messages, so plugin implementations do not need a new integration contract. `pluginDisplay: 'sidebar'` is the default; `pluginDisplay: 'tabs'` restores the legacy presentation.

## Testing

- `pnpm lint:all`
- `pnpm format:all`
- `pnpm typecheck:all`
- `pnpm release:plan`
- `pnpm --filter @rozenite/file-system-plugin build`
- `pnpm --filter @rozenite/shell test`