### PR TITLE
feat(runtime): show available Rozenite updates

### DIFF
--- a/.changeset/shell-update-footer.md
+++ b/.changeset/shell-update-footer.md
@@ -1,0 +1,5 @@
+---
+'@rozenite/runtime': minor
+---
+
+Show a link to the latest Rozenite release in the DevTools sidebar when an update is available.

--- a/packages/metro/package.json
+++ b/packages/metro/package.json
@@ -46,6 +46,7 @@
   },
   "dependencies": {
     "@rozenite/middleware": "workspace:*",
+    "@rozenite/runtime": "workspace:*",
     "@rozenite/tools": "workspace:*",
     "tslib": "^2.3.0"
   },

--- a/packages/metro/src/index.ts
+++ b/packages/metro/src/index.ts
@@ -8,6 +8,7 @@ import {
   type RozeniteConfig,
 } from '@rozenite/middleware';
 import { logger } from '@rozenite/tools';
+import runtimePackage from '@rozenite/runtime/package.json' with { type: 'json' };
 import path from 'node:path';
 import { isBundling } from './is-bundling.js';
 
@@ -57,10 +58,13 @@ export const withRozenite = <T extends MetroConfig>(
     }
 
     const { devModePackage, middleware: rozeniteMiddleware } =
-      initializeRozenite({
-        projectRoot,
-        ...options,
-      });
+      initializeRozenite(
+        {
+          projectRoot,
+          ...options,
+        },
+        runtimePackage.version,
+      );
 
     const rozeniteMetroConfig = {
       ...resolvedConfig,

--- a/packages/metro/tsconfig.lib.json
+++ b/packages/metro/tsconfig.lib.json
@@ -8,7 +8,8 @@
     "emitDeclarationOnly": true,
     "forceConsistentCasingInFileNames": true,
     "types": ["node", "vite/client"],
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "resolveJsonModule": true
   },
   "include": ["src/**/*.ts"],
   "references": [

--- a/packages/middleware/src/entry-point.ts
+++ b/packages/middleware/src/entry-point.ts
@@ -32,6 +32,7 @@ const appendScripts = (
   installedPlugins: string[],
   destroyOnDetachPlugins: string[],
   pluginDisplay: 'tabs' | 'sidebar',
+  runtimeVersion?: string,
 ): string => {
   const bodyTagRegex = /<body[^>]*>/;
   const bodyMatch = html.match(bodyTagRegex);
@@ -43,6 +44,7 @@ const appendScripts = (
         installedPlugins: ${JSON.stringify(installedPlugins)},
         destroyOnDetachPlugins: ${JSON.stringify(destroyOnDetachPlugins)},
         pluginDisplay: ${JSON.stringify(pluginDisplay)},
+        runtimeVersion: ${JSON.stringify(runtimeVersion)},
       };
     </script>
   `;
@@ -66,6 +68,7 @@ export const getEntryPointHTML = (
   installedPlugins: string[],
   destroyOnDetachPlugins: string[],
   pluginDisplay: 'tabs' | 'sidebar' = 'sidebar',
+  runtimeVersion?: string,
 ): string => {
   const nonce = crypto.randomUUID();
   const originalEntryPoint = fs.readFileSync(
@@ -79,5 +82,6 @@ export const getEntryPointHTML = (
     installedPlugins,
     destroyOnDetachPlugins,
     pluginDisplay,
+    runtimeVersion,
   );
 };

--- a/packages/middleware/src/index.ts
+++ b/packages/middleware/src/index.ts
@@ -27,6 +27,7 @@ export type {
 
 export const initializeRozenite = (
   options: RozeniteConfig,
+  runtimeVersion?: string,
 ): RozeniteInstance => {
   options.logLevel =
     process.env.ROZENITE_DEBUG === 'true'
@@ -74,6 +75,7 @@ export const initializeRozenite = (
       allInstalledPlugins,
       options.destroyOnDetachPlugins || [],
       agentSessionManager,
+      runtimeVersion,
     ),
     devModePackage,
     dispose: async () => {

--- a/packages/middleware/src/middleware.ts
+++ b/packages/middleware/src/middleware.ts
@@ -38,6 +38,7 @@ export const getMiddleware = (
   installedPlugins: InstalledPlugin[],
   destroyOnDetachPlugins: string[],
   agentSessionManager: AgentSessionManager,
+  runtimeVersion?: string,
 ): Application => {
   const app = express();
   const debuggerFrontend = require(getReactNativeDebuggerFrontendPath(options));
@@ -93,6 +94,7 @@ export const getMiddleware = (
         installedPlugins.map((plugin) => plugin.name),
         destroyOnDetachPlugins,
         options.pluginDisplay ?? 'sidebar',
+        runtimeVersion,
       ),
     );
   });

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -27,6 +27,7 @@
     "access": "public"
   },
   "exports": {
+    "./package.json": "./package.json",
     ".": {
       "types": "./dist/host.d.ts",
       "import": "./dist/host.js",

--- a/packages/runtime/src/global-namespace.ts
+++ b/packages/runtime/src/global-namespace.ts
@@ -4,6 +4,7 @@ declare global {
     developmentServer: boolean;
     destroyOnDetachPlugins: string[];
     pluginDisplay: 'tabs' | 'sidebar';
+    runtimeVersion?: string;
   };
 }
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -61,6 +61,7 @@ const main = async (): Promise<void> => {
       shellUrl.toString(),
       {
         plugins: loadedPlugins,
+        runtimeVersion: getGlobalNamespace().runtimeVersion,
       },
       true,
     );

--- a/packages/shell/package.json
+++ b/packages/shell/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@rozenite/ui": "workspace:*",
+    "lucide-react": "^0.263.1",
     "react": "catalog:",
     "react-dom": "catalog:"
   },

--- a/packages/shell/src/NewVersionFooter.test.ts
+++ b/packages/shell/src/NewVersionFooter.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getAvailableRuntimeVersion } from './new-version';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('getAvailableRuntimeVersion', () => {
+  it('returns the npm version when it differs from the installed runtime', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: '1.14.0' }),
+    });
+
+    await expect(getAvailableRuntimeVersion('1.13.0')).resolves.toBe('1.14.0');
+  });
+
+  it('returns null when the installed runtime is current', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: '1.13.0' }),
+    });
+
+    await expect(getAvailableRuntimeVersion('1.13.0')).resolves.toBeNull();
+  });
+
+  it('rejects failed npm requests', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+    });
+
+    await expect(getAvailableRuntimeVersion('1.13.0')).rejects.toThrow(
+      'Failed to fetch the latest Rozenite version: 503',
+    );
+  });
+});

--- a/packages/shell/src/NewVersionFooter.tsx
+++ b/packages/shell/src/NewVersionFooter.tsx
@@ -1,5 +1,5 @@
 import { ArrowUpRight } from 'lucide-react';
-import { Badge, buttonVariants, cn } from '@rozenite/ui';
+import { Badge } from '@rozenite/ui';
 import { useEffect, useState } from 'react';
 import { getAvailableRuntimeVersion } from './new-version';
 
@@ -40,26 +40,28 @@ export function NewVersionFooter({ currentVersion }: NewVersionFooterProps) {
 
   return (
     <footer className="shrink-0 border-t border-sidebar-border p-2">
-      <div className="rounded-md bg-sidebar-accent p-2">
-        <p className="text-xs font-medium text-sidebar-accent-foreground">
-          New version available
-        </p>
-        <Badge className="mt-1" variant="outline">
-          {latestVersion}
-        </Badge>
-        <a
-          className={cn(
-            buttonVariants({ variant: 'secondary', size: 'compact' }),
-            'mt-2 w-full',
-          )}
-          href={RELEASES_URL}
-          rel="noreferrer"
-          target="_blank"
-        >
-          View release
-          <ArrowUpRight aria-hidden="true" />
-        </a>
-      </div>
+      <a
+        className="group flex items-center gap-2.5 rounded-md border border-sidebar-border bg-sidebar-accent/40 p-2.5 outline-none transition-colors hover:bg-sidebar-accent focus-visible:ring-2 focus-visible:ring-sidebar-ring"
+        href={RELEASES_URL}
+        rel="noreferrer"
+        target="_blank"
+      >
+        <span className="min-w-0 flex-1">
+          <span className="block text-xs font-semibold text-sidebar-accent-foreground">
+            Update available
+          </span>
+          <span className="mt-0.5 flex items-center gap-1.5 text-xs text-sidebar-foreground/65">
+            Rozenite
+            <Badge className="px-1.5 py-0 text-[11px]" variant="outline">
+              v{latestVersion}
+            </Badge>
+          </span>
+        </span>
+        <ArrowUpRight
+          aria-hidden="true"
+          className="size-4 shrink-0 text-sidebar-foreground/50 transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5"
+        />
+      </a>
     </footer>
   );
 }

--- a/packages/shell/src/NewVersionFooter.tsx
+++ b/packages/shell/src/NewVersionFooter.tsx
@@ -1,0 +1,65 @@
+import { ArrowUpRight } from 'lucide-react';
+import { Badge, buttonVariants, cn } from '@rozenite/ui';
+import { useEffect, useState } from 'react';
+import { getAvailableRuntimeVersion } from './new-version';
+
+const RELEASES_URL = 'https://github.com/callstackincubator/rozenite/releases';
+
+type NewVersionFooterProps = {
+  currentVersion?: string;
+};
+
+export function NewVersionFooter({ currentVersion }: NewVersionFooterProps) {
+  const [latestVersion, setLatestVersion] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!currentVersion) {
+      return;
+    }
+
+    let cancelled = false;
+
+    void getAvailableRuntimeVersion(currentVersion)
+      .then((version) => {
+        if (!cancelled) {
+          setLatestVersion(version);
+        }
+      })
+      .catch(() => {
+        // An unavailable registry must not affect the DevTools experience.
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [currentVersion]);
+
+  if (!latestVersion) {
+    return null;
+  }
+
+  return (
+    <footer className="shrink-0 border-t border-sidebar-border p-2">
+      <div className="rounded-md bg-sidebar-accent p-2">
+        <p className="text-xs font-medium text-sidebar-accent-foreground">
+          New version available
+        </p>
+        <Badge className="mt-1" variant="outline">
+          {latestVersion}
+        </Badge>
+        <a
+          className={cn(
+            buttonVariants({ variant: 'secondary', size: 'compact' }),
+            'mt-2 w-full',
+          )}
+          href={RELEASES_URL}
+          rel="noreferrer"
+          target="_blank"
+        >
+          View release
+          <ArrowUpRight aria-hidden="true" />
+        </a>
+      </div>
+    </footer>
+  );
+}

--- a/packages/shell/src/Shell.tsx
+++ b/packages/shell/src/Shell.tsx
@@ -3,11 +3,12 @@ import { EmptyState, PluginShell, Sidebar } from '@rozenite/ui';
 import lightLogo from '../../../website/src/public/logo-light.svg';
 import darkLogo from '../../../website/src/public/logo-dark.svg';
 import { getInitialSelection, type ShellSelection } from './selection';
+import { NewVersionFooter } from './NewVersionFooter';
 import type { ShellConfiguration, ShellPanel, ShellPlugin } from './types';
 
 const SHELL_CONFIGURATION_TYPE = 'rozenite-shell-configuration';
 
-export function Shell({ plugins }: ShellConfiguration) {
+export function Shell({ plugins, runtimeVersion }: ShellConfiguration) {
   const [selection, setSelection] = useState<ShellSelection>(() =>
     getInitialSelection(plugins),
   );
@@ -91,29 +92,17 @@ export function Shell({ plugins }: ShellConfiguration) {
               className="hidden h-6 w-auto dark:block"
             />
           </header>
-          <div className="flex flex-col gap-3 p-2">
-            {plugins.map((plugin) => {
-              if (plugin.panels.length === 0) {
-                return null;
-              }
+          <div className="min-h-0 flex-1 overflow-y-auto p-2">
+            <div className="flex flex-col gap-3">
+              {plugins.map((plugin) => {
+                if (plugin.panels.length === 0) {
+                  return null;
+                }
 
-              if (plugin.panels.length === 1) {
-                const [panel] = plugin.panels;
+                if (plugin.panels.length === 1) {
+                  const [panel] = plugin.panels;
 
-                return (
-                  <Sidebar.Item
-                    key={panel.id}
-                    selected={panel.id === activePanel.id}
-                    onClick={() => selectPanel(plugin, panel)}
-                  >
-                    {panel.name}
-                  </Sidebar.Item>
-                );
-              }
-
-              return (
-                <Sidebar.Group key={plugin.id} label={plugin.name}>
-                  {plugin.panels.map((panel) => (
+                  return (
                     <Sidebar.Item
                       key={panel.id}
                       selected={panel.id === activePanel.id}
@@ -121,11 +110,26 @@ export function Shell({ plugins }: ShellConfiguration) {
                     >
                       {panel.name}
                     </Sidebar.Item>
-                  ))}
-                </Sidebar.Group>
-              );
-            })}
+                  );
+                }
+
+                return (
+                  <Sidebar.Group key={plugin.id} label={plugin.name}>
+                    {plugin.panels.map((panel) => (
+                      <Sidebar.Item
+                        key={panel.id}
+                        selected={panel.id === activePanel.id}
+                        onClick={() => selectPanel(plugin, panel)}
+                      >
+                        {panel.name}
+                      </Sidebar.Item>
+                    ))}
+                  </Sidebar.Group>
+                );
+              })}
+            </div>
           </div>
+          <NewVersionFooter currentVersion={runtimeVersion} />
         </Sidebar>
         <div className="min-w-0 flex-1">
           <iframe

--- a/packages/shell/src/new-version.ts
+++ b/packages/shell/src/new-version.ts
@@ -1,0 +1,32 @@
+const NPM_RUNTIME_URL =
+  'https://registry.npmjs.org/%40rozenite%2Fruntime/latest';
+
+type NpmPackageMetadata = {
+  version?: unknown;
+};
+
+async function fetchLatestRuntimeVersion(): Promise<string> {
+  const response = await fetch(NPM_RUNTIME_URL);
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch the latest Rozenite version: ${response.status}`,
+    );
+  }
+
+  const metadata = (await response.json()) as NpmPackageMetadata;
+
+  if (typeof metadata.version !== 'string') {
+    throw new Error('The npm response did not contain a package version.');
+  }
+
+  return metadata.version;
+}
+
+export async function getAvailableRuntimeVersion(
+  currentVersion: string,
+): Promise<string | null> {
+  const latestVersion = await fetchLatestRuntimeVersion();
+
+  return latestVersion === currentVersion ? null : latestVersion;
+}

--- a/packages/shell/src/types.ts
+++ b/packages/shell/src/types.ts
@@ -13,4 +13,5 @@ export type ShellPlugin = {
 
 export type ShellConfiguration = {
   plugins: ShellPlugin[];
+  runtimeVersion?: string;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -632,6 +632,9 @@ importers:
       '@rozenite/middleware':
         specifier: workspace:*
         version: link:../middleware
+      '@rozenite/runtime':
+        specifier: workspace:*
+        version: link:../runtime
       '@rozenite/tools':
         specifier: workspace:*
         version: link:../tools
@@ -1240,6 +1243,9 @@ importers:
       '@rozenite/ui':
         specifier: workspace:*
         version: link:../ui
+      lucide-react:
+        specifier: ^0.263.1
+        version: 0.263.1(react@19.2.3)
       react:
         specifier: 'catalog:'
         version: 19.2.3


### PR DESCRIPTION
## Description

Adds a lazy DevTools sidebar footer that appears when a newer `@rozenite/runtime` version is available on npm and links to the GitHub releases page.

## Related Issue

Not applicable — this is the requested feature work; no matching open issue was found.

## Context

`withRozenite` resolves the installed `@rozenite/runtime` version and passes it through the existing middleware bootstrap and runtime shell configuration. The shell runs in an iframe, so the configuration explicitly forwards the version rather than reading the parent global. The footer fetches npm once, remains absent while loading or on failure, and renders only when the versions differ.

## Testing

Automated:

- `pnpm --filter @rozenite/shell test` — 5 tests passed
- `pnpm build:all`
- `pnpm typecheck:all`
- `pnpm lint:all`
- `pnpm format:all`
- `pnpm release:plan`

Manual verification was not run.