### PR TITLE
perf(cli): parallelize plugin builds

### DIFF
--- a/.changeset/faster-plugin-builds.md
+++ b/.changeset/faster-plugin-builds.md
@@ -1,0 +1,6 @@
+---
+'@rozenite/vite-plugin': patch
+rozenite: patch
+---
+
+Improve plugin build times by running independent build targets concurrently while preserving all generated outputs.

--- a/packages/cli/src/__tests__/concurrency.test.ts
+++ b/packages/cli/src/__tests__/concurrency.test.ts
@@ -24,4 +24,53 @@ describe('runWithConcurrency', () => {
   it('returns immediately when there are no tasks', async () => {
     await expect(runWithConcurrency([], 2)).resolves.toEqual([]);
   });
+
+  it('stops scheduling tasks after a failure', async () => {
+    const startedTasks: number[] = [];
+
+    await expect(
+      runWithConcurrency(
+        Array.from({ length: 5 }, (_, index) => async () => {
+          startedTasks.push(index);
+
+          if (index === 0) {
+            throw new Error('failed');
+          }
+
+          await new Promise((resolve) => setTimeout(resolve, 10));
+        }),
+        2,
+      ),
+    ).rejects.toThrow('failed');
+
+    expect(startedTasks).toEqual([0, 1]);
+  });
+
+  it('waits for active tasks to settle after cancellation', async () => {
+    const controller = new AbortController();
+    let activeTasks = 0;
+    let maximumActiveTasks = 0;
+
+    const promise = runWithConcurrency(
+      Array.from({ length: 3 }, (_, index) => async () => {
+        activeTasks += 1;
+        maximumActiveTasks = Math.max(maximumActiveTasks, activeTasks);
+
+        try {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          return index;
+        } finally {
+          activeTasks -= 1;
+        }
+      }),
+      2,
+      { signal: controller.signal },
+    );
+
+    controller.abort(new Error('cancelled'));
+
+    await expect(promise).rejects.toThrow('cancelled');
+    expect(activeTasks).toBe(0);
+    expect(maximumActiveTasks).toBe(2);
+  });
 });

--- a/packages/cli/src/__tests__/concurrency.test.ts
+++ b/packages/cli/src/__tests__/concurrency.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { runWithConcurrency } from '../utils/concurrency.js';
+
+describe('runWithConcurrency', () => {
+  it('limits the number of active tasks', async () => {
+    let activeTasks = 0;
+    let maximumActiveTasks = 0;
+
+    const results = await runWithConcurrency(
+      Array.from({ length: 5 }, (_, index) => async () => {
+        activeTasks += 1;
+        maximumActiveTasks = Math.max(maximumActiveTasks, activeTasks);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        activeTasks -= 1;
+        return index;
+      }),
+      2,
+    );
+
+    expect(results).toEqual([0, 1, 2, 3, 4]);
+    expect(maximumActiveTasks).toBe(2);
+  });
+
+  it('returns immediately when there are no tasks', async () => {
+    await expect(runWithConcurrency([], 2)).resolves.toEqual([]);
+  });
+});

--- a/packages/cli/src/commands/build-command.ts
+++ b/packages/cli/src/commands/build-command.ts
@@ -75,18 +75,34 @@ export const buildCommand = async (targetDir: string) => {
       : []),
   ];
 
-  await runWithConcurrency(
-    buildJobs.map(
-      (job) => () =>
-        step(job, async () => {
-          await spawn('vite', ['build'], {
-            cwd: targetDir,
-            env: job.env,
+  const buildController = new AbortController();
+
+  try {
+    await runWithConcurrency(
+      buildJobs.map((job) => async () => {
+        try {
+          await step(job, async () => {
+            await spawn('vite', ['build'], {
+              cwd: targetDir,
+              env: {
+                ...job.env,
+                ROZENITE_BUILD: '1',
+              },
+              signal: buildController.signal,
+            });
           });
-        }),
-    ),
-    os.availableParallelism(),
-  );
+        } catch (error) {
+          buildController.abort(error);
+          throw error;
+        }
+      }),
+      os.availableParallelism(),
+      { signal: buildController.signal },
+    );
+  } catch (error) {
+    buildController.abort(error);
+    throw error;
+  }
 
   outro('Plugin built successfully');
 };

--- a/packages/cli/src/commands/build-command.ts
+++ b/packages/cli/src/commands/build-command.ts
@@ -1,10 +1,12 @@
 import fs from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
 import { step } from '../utils/steps.js';
 import { spawn } from '../utils/spawn.js';
 import { intro, outro } from '../utils/prompts.js';
 import { logger } from '../utils/logger.js';
 import { syncPluginPackageJSON } from '../utils/plugin-package-json.js';
+import { runWithConcurrency } from '../utils/concurrency.js';
 
 export const buildCommand = async (targetDir: string) => {
   intro('Rozenite');
@@ -34,72 +36,57 @@ export const buildCommand = async (targetDir: string) => {
     },
   );
 
-  await step(
+  const buildJobs = [
     {
       start: 'Building panels',
       stop: 'Panels built',
       error: 'Failed to build panels',
+      env: undefined,
     },
-    async () => {
-      await spawn('vite', ['build'], {
-        cwd: targetDir,
-      });
-    },
+    ...(hasMetroEntryPoint
+      ? [
+          {
+            start: 'Building Metro entry point',
+            stop: 'Metro entry point built',
+            error: 'Failed to build Metro entry point',
+            env: { VITE_ROZENITE_TARGET: 'server' },
+          },
+        ]
+      : []),
+    ...(hasReactNativeEntryPoint
+      ? [
+          {
+            start: 'Building React Native entry point',
+            stop: 'React Native entry point built',
+            error: 'Failed to build React Native entry point',
+            env: { VITE_ROZENITE_TARGET: 'react-native' },
+          },
+        ]
+      : []),
+    ...(hasSdkEntryPoint
+      ? [
+          {
+            start: 'Building SDK entry point',
+            stop: 'SDK entry point built',
+            error: 'Failed to build SDK entry point',
+            env: { VITE_ROZENITE_TARGET: 'sdk' },
+          },
+        ]
+      : []),
+  ];
+
+  await runWithConcurrency(
+    buildJobs.map(
+      (job) => () =>
+        step(job, async () => {
+          await spawn('vite', ['build'], {
+            cwd: targetDir,
+            env: job.env,
+          });
+        }),
+    ),
+    os.availableParallelism(),
   );
-
-  if (hasMetroEntryPoint) {
-    await step(
-      {
-        start: 'Building Metro entry point',
-        stop: 'Metro entry point built',
-        error: 'Failed to build Metro entry point',
-      },
-      async () => {
-        await spawn('vite', ['build'], {
-          cwd: targetDir,
-          env: {
-            VITE_ROZENITE_TARGET: 'server',
-          },
-        });
-      },
-    );
-  }
-
-  if (hasReactNativeEntryPoint) {
-    await step(
-      {
-        start: 'Building React Native entry point',
-        stop: 'React Native entry point built',
-        error: 'Failed to build React Native entry point',
-      },
-      async () => {
-        await spawn('vite', ['build'], {
-          cwd: targetDir,
-          env: {
-            VITE_ROZENITE_TARGET: 'react-native',
-          },
-        });
-      },
-    );
-  }
-
-  if (hasSdkEntryPoint) {
-    await step(
-      {
-        start: 'Building SDK entry point',
-        stop: 'SDK entry point built',
-        error: 'Failed to build SDK entry point',
-      },
-      async () => {
-        await spawn('vite', ['build'], {
-          cwd: targetDir,
-          env: {
-            VITE_ROZENITE_TARGET: 'sdk',
-          },
-        });
-      },
-    );
-  }
 
   outro('Plugin built successfully');
 };

--- a/packages/cli/src/utils/concurrency.ts
+++ b/packages/cli/src/utils/concurrency.ts
@@ -1,6 +1,11 @@
+export type RunWithConcurrencyOptions = {
+  signal?: AbortSignal;
+};
+
 export const runWithConcurrency = async <T>(
   tasks: Array<() => Promise<T>>,
   concurrency: number,
+  { signal }: RunWithConcurrencyOptions = {},
 ): Promise<T[]> => {
   if (tasks.length === 0) {
     return [];
@@ -9,20 +14,35 @@ export const runWithConcurrency = async <T>(
   const workerCount = Math.max(1, Math.min(concurrency, tasks.length));
   const results = new Array<T>(tasks.length);
   let nextTaskIndex = 0;
+  let firstError: unknown;
 
   const worker = async () => {
-    while (true) {
+    while (!signal?.aborted && firstError === undefined) {
       const taskIndex = nextTaskIndex++;
 
       if (taskIndex >= tasks.length) {
         return;
       }
 
-      results[taskIndex] = await tasks[taskIndex]();
+      try {
+        results[taskIndex] = await tasks[taskIndex]();
+      } catch (error) {
+        firstError ??= error;
+        return;
+      }
     }
   };
 
   await Promise.all(Array.from({ length: workerCount }, worker));
+
+  if (firstError !== undefined) {
+    throw firstError;
+  }
+
+  if (signal?.aborted) {
+    const reason = (signal as AbortSignal & { reason?: unknown }).reason;
+    throw reason ?? new Error('Operation was aborted');
+  }
 
   return results;
 };

--- a/packages/cli/src/utils/concurrency.ts
+++ b/packages/cli/src/utils/concurrency.ts
@@ -1,0 +1,28 @@
+export const runWithConcurrency = async <T>(
+  tasks: Array<() => Promise<T>>,
+  concurrency: number,
+): Promise<T[]> => {
+  if (tasks.length === 0) {
+    return [];
+  }
+
+  const workerCount = Math.max(1, Math.min(concurrency, tasks.length));
+  const results = new Array<T>(tasks.length);
+  let nextTaskIndex = 0;
+
+  const worker = async () => {
+    while (true) {
+      const taskIndex = nextTaskIndex++;
+
+      if (taskIndex >= tasks.length) {
+        return;
+      }
+
+      results[taskIndex] = await tasks[taskIndex]();
+    }
+  };
+
+  await Promise.all(Array.from({ length: workerCount }, worker));
+
+  return results;
+};

--- a/packages/vite-plugin/src/client-plugin.ts
+++ b/packages/vite-plugin/src/client-plugin.ts
@@ -185,7 +185,9 @@ export const rozeniteClientPlugin = (): Plugin => {
       config.server.port = 8888;
 
       config.build ??= {};
-      config.build.emptyOutDir = false;
+      if (process.env.ROZENITE_BUILD === '1') {
+        config.build.emptyOutDir = false;
+      }
       config.build.rollupOptions ??= {};
       config.build.rollupOptions.input = {
         ...(config.build.rollupOptions.input as Record<string, string>),

--- a/packages/vite-plugin/src/client-plugin.ts
+++ b/packages/vite-plugin/src/client-plugin.ts
@@ -185,6 +185,7 @@ export const rozeniteClientPlugin = (): Plugin => {
       config.server.port = 8888;
 
       config.build ??= {};
+      config.build.emptyOutDir = false;
       config.build.rollupOptions ??= {};
       config.build.rollupOptions.input = {
         ...(config.build.rollupOptions.input as Record<string, string>),

--- a/packages/vite-plugin/src/react-native-plugin.ts
+++ b/packages/vite-plugin/src/react-native-plugin.ts
@@ -8,6 +8,7 @@ export const rozeniteReactNativePlugin = (): Plugin => {
       const projectRoot = config.root ?? process.cwd();
 
       config.build ??= {};
+      config.build.emptyOutDir = false;
       config.build.rollupOptions ??= {};
 
       config.build.lib = {

--- a/packages/vite-plugin/src/react-native-plugin.ts
+++ b/packages/vite-plugin/src/react-native-plugin.ts
@@ -8,7 +8,9 @@ export const rozeniteReactNativePlugin = (): Plugin => {
       const projectRoot = config.root ?? process.cwd();
 
       config.build ??= {};
-      config.build.emptyOutDir = false;
+      if (process.env.ROZENITE_BUILD === '1') {
+        config.build.emptyOutDir = false;
+      }
       config.build.rollupOptions ??= {};
 
       config.build.lib = {

--- a/packages/vite-plugin/src/sdk-plugin.ts
+++ b/packages/vite-plugin/src/sdk-plugin.ts
@@ -8,6 +8,7 @@ export const rozeniteSdkPlugin = (): Plugin => {
       const projectRoot = config.root ?? process.cwd();
 
       config.build ??= {};
+      config.build.emptyOutDir = false;
       config.build.lib = {
         entry: path.resolve(projectRoot, 'sdk.ts'),
         formats: ['es' as const, 'cjs' as const],

--- a/packages/vite-plugin/src/sdk-plugin.ts
+++ b/packages/vite-plugin/src/sdk-plugin.ts
@@ -8,7 +8,9 @@ export const rozeniteSdkPlugin = (): Plugin => {
       const projectRoot = config.root ?? process.cwd();
 
       config.build ??= {};
-      config.build.emptyOutDir = false;
+      if (process.env.ROZENITE_BUILD === '1') {
+        config.build.emptyOutDir = false;
+      }
       config.build.lib = {
         entry: path.resolve(projectRoot, 'sdk.ts'),
         formats: ['es' as const, 'cjs' as const],

--- a/packages/vite-plugin/src/server-plugin.ts
+++ b/packages/vite-plugin/src/server-plugin.ts
@@ -10,7 +10,9 @@ export const rozeniteServerPlugin = (): Plugin => {
       const projectRoot = config.root ?? process.cwd();
 
       config.build ??= {};
-      config.build.emptyOutDir = false;
+      if (process.env.ROZENITE_BUILD === '1') {
+        config.build.emptyOutDir = false;
+      }
       config.build.lib = {
         entry: path.resolve(projectRoot, 'metro.ts'),
         formats: ['es' as const, 'cjs' as const],

--- a/packages/vite-plugin/src/server-plugin.ts
+++ b/packages/vite-plugin/src/server-plugin.ts
@@ -10,6 +10,7 @@ export const rozeniteServerPlugin = (): Plugin => {
       const projectRoot = config.root ?? process.cwd();
 
       config.build ??= {};
+      config.build.emptyOutDir = false;
       config.build.lib = {
         entry: path.resolve(projectRoot, 'metro.ts'),
         formats: ['es' as const, 'cjs' as const],


### PR DESCRIPTION
## Description

Improves Rozenite plugin build times by cleaning the output directory once and running the panel, React Native, Metro, and SDK Vite targets concurrently with CPU-bounded concurrency. Target builds are forced to preserve the shared `dist` directory, and panel builds continue to omit declaration generation.

## Related Issue

Closes https://github.com/callstackincubator/rozenite/issues/358

## Context

The CLI previously spawned each target build serially. A warm `@rozenite/storage-plugin` build took about 16.3 seconds; after this change it takes about 8.0 seconds. The independent target outputs live under separate directories, while a single pre-build cleanup prevents stale artifacts. Node `os.availableParallelism()` provides the concurrency bound without adding a runtime dependency.

## Testing

- `pnpm --filter rozenite test` — 77 tests passed
- `pnpm --filter rozenite typecheck`
- `pnpm --filter @rozenite/vite-plugin typecheck`
- `pnpm --filter rozenite lint`
- `pnpm --filter @rozenite/vite-plugin lint`
- Prettier check and `git diff --check`
- `pnpm --filter @rozenite/storage-plugin build` — completed successfully and produced panel, manifest, React Native, and SDK outputs