### PR TITLE
fix(runtime): preserve panel state in sidebar

### DIFF
--- a/.changeset/persistent-sidebar-panels.md
+++ b/.changeset/persistent-sidebar-panels.md
@@ -1,0 +1,7 @@
+---
+'@rozenite/runtime': patch
+'@rozenite/shell': patch
+---
+
+Preserve sidebar panel state by default and respect `destroyOnDetachPlugins`
+when switching panels.

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -61,6 +61,7 @@ const main = async (): Promise<void> => {
       shellUrl.toString(),
       {
         plugins: loadedPlugins,
+        destroyOnDetachPlugins: getGlobalNamespace().destroyOnDetachPlugins,
         runtimeVersion: getGlobalNamespace().runtimeVersion,
       },
       true,

--- a/packages/shell/src/Shell.tsx
+++ b/packages/shell/src/Shell.tsx
@@ -8,11 +8,15 @@ import type { ShellConfiguration, ShellPanel, ShellPlugin } from './types';
 
 const SHELL_CONFIGURATION_TYPE = 'rozenite-shell-configuration';
 
-export function Shell({ plugins, runtimeVersion }: ShellConfiguration) {
+export function Shell({
+  plugins,
+  destroyOnDetachPlugins,
+  runtimeVersion,
+}: ShellConfiguration) {
   const [selection, setSelection] = useState<ShellSelection>(() =>
     getInitialSelection(plugins),
   );
-  const contentFrame = useRef<HTMLIFrameElement>(null);
+  const contentFrames = useRef(new Map<string, HTMLIFrameElement>());
 
   useEffect(() => {
     setSelection((current) => {
@@ -32,21 +36,25 @@ export function Shell({ plugins, runtimeVersion }: ShellConfiguration) {
   }, [plugins]);
 
   useEffect(() => {
-    const forwardToActivePanel = (event: MessageEvent) => {
-      const activeFrame = contentFrame.current;
-
+    const forwardToPanels = (event: MessageEvent) => {
       if (event.source === window.parent) {
-        activeFrame?.contentWindow?.postMessage(event.data, '*');
+        for (const frame of contentFrames.current.values()) {
+          frame.contentWindow?.postMessage(event.data, '*');
+        }
         return;
       }
 
-      if (event.source === activeFrame?.contentWindow) {
+      if (
+        [...contentFrames.current.values()].some(
+          (frame) => event.source === frame.contentWindow,
+        )
+      ) {
         window.parent.postMessage(event.data, '*');
       }
     };
 
-    window.addEventListener('message', forwardToActivePanel);
-    return () => window.removeEventListener('message', forwardToActivePanel);
+    window.addEventListener('message', forwardToPanels);
+    return () => window.removeEventListener('message', forwardToPanels);
   }, []);
 
   const activePlugin = useMemo(
@@ -55,6 +63,10 @@ export function Shell({ plugins, runtimeVersion }: ShellConfiguration) {
   );
   const activePanel = activePlugin?.panels.find(
     (panel) => panel.id === selection?.panelId,
+  );
+  const destroyedPluginIds = new Set(destroyOnDetachPlugins);
+  const panels = plugins.flatMap((plugin) =>
+    plugin.panels.map((panel) => ({ plugin, panel })),
   );
   const selectPanel = (plugin: ShellPlugin, panel: ShellPanel) => {
     setSelection({ pluginId: plugin.id, panelId: panel.id });
@@ -132,12 +144,30 @@ export function Shell({ plugins, runtimeVersion }: ShellConfiguration) {
           <NewVersionFooter currentVersion={runtimeVersion} />
         </Sidebar>
         <div className="min-w-0 flex-1">
-          <iframe
-            key={`${activePlugin.id}:${activePanel.id}`}
-            ref={contentFrame}
-            title={`${activePlugin.name}: ${activePanel.name}`}
-            src={activePanel.source}
-          />
+          {panels.map(({ plugin, panel }) => {
+            const isActive = panel.id === activePanel.id;
+            const shouldDestroy = destroyedPluginIds.has(plugin.id);
+
+            if (shouldDestroy && !isActive) {
+              return null;
+            }
+
+            return (
+              <iframe
+                key={panel.id}
+                ref={(frame) => {
+                  if (frame) {
+                    contentFrames.current.set(panel.id, frame);
+                  } else {
+                    contentFrames.current.delete(panel.id);
+                  }
+                }}
+                hidden={!isActive}
+                title={`${plugin.name}: ${panel.name}`}
+                src={panel.source}
+              />
+            );
+          })}
         </div>
       </PluginShell.Body>
     </PluginShell>

--- a/packages/shell/src/main.tsx
+++ b/packages/shell/src/main.tsx
@@ -7,6 +7,7 @@ import './styles.css';
 function App() {
   const [configuration, setConfiguration] = useState<ShellConfiguration>({
     plugins: [],
+    destroyOnDetachPlugins: [],
   });
 
   useEffect(() => {
@@ -25,7 +26,7 @@ function App() {
     return () => window.removeEventListener('message', receiveConfiguration);
   }, []);
 
-  return <Shell plugins={configuration.plugins} />;
+  return <Shell {...configuration} />;
 }
 
 createRoot(document.getElementById('root')!).render(<App />);

--- a/packages/shell/src/types.ts
+++ b/packages/shell/src/types.ts
@@ -13,5 +13,6 @@ export type ShellPlugin = {
 
 export type ShellConfiguration = {
   plugins: ShellPlugin[];
+  destroyOnDetachPlugins: string[];
   runtimeVersion?: string;
 };


### PR DESCRIPTION
## Description

Preserves plugin panel state when navigating within the unified Rozenite sidebar, while continuing to reset plugins configured with `destroyOnDetachPlugins`.

## Related Issue

None — no issue required for this focused fix.

## Context

The sidebar previously replaced its single iframe whenever the active menu item changed, so every plugin lost its UI state. The shell now keeps default plugin frames mounted and hides inactive ones; configured plugins still unmount on navigation. Runtime messages are relayed to every mounted frame, matching the legacy hidden-tab behavior.

## Testing

- `pnpm --filter @rozenite/runtime build`
- `pnpm --filter @rozenite/shell build`
- `pnpm --filter @rozenite/runtime typecheck`
- `pnpm --filter @rozenite/shell typecheck`
- `pnpm --filter @rozenite/shell lint`
- `pnpm exec prettier --check .changeset/persistent-sidebar-panels.md packages/runtime/src/index.ts packages/shell/src/Shell.tsx packages/shell/src/main.tsx packages/shell/src/types.ts`
- `pnpm release:plan`

`pnpm format:all` is blocked by existing unformatted files under tracked `.claude/worktrees` directories. The aggregate typecheck encountered a transient runtime declaration-build race; the focused runtime and shell checks above pass serially.