### PR TITLE
chore: add agent testing guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,9 @@
   `packages/`; the test app lives in `apps/playground`.
 - Read `CONTRIBUTING.md` and the relevant source, tests, and agent guide before
   making a change.
+- For unit-testing guidance, see @./docs/agents/unit-testing.md.
+- For end-to-end testing guidance, see @./docs/agents/e2e-testing.md.
+- For plugin-development guidance, see @./docs/agents/plugin-development.md.
 - For version plans, see @./docs/agents/version-plans.md.
 - Before preparing or opening a pull request, see @./docs/agents/pull-requests.md.
 - Preserve unrelated work already present in the working tree.

--- a/docs/agents/e2e-testing.md
+++ b/docs/agents/e2e-testing.md
@@ -1,0 +1,34 @@
+# End-to-end testing
+
+- E2E testing is available through `apps/playground`.
+- Use E2E testing for changes likely to break behavior and for visual changes that cannot be adequately tested otherwise.
+- Define the E2E cases before testing.
+- Spawn a `gpt-5.6-luna` or `haiku` sub-agent to run the cases.
+- Pass the sub-agent all instructions in this guide and all change-specific context.
+- Prefer the iPhone simulator; test Android only when crucial.
+- Verify that Rozenite is installed on the running simulator.
+- If Rozenite is installed, assume it is up to date.
+- For unusual issues, assume the app is outdated and rebuild from `apps/playground`:
+
+  ```bash
+  pnpm expo run:ios
+  pnpm expo run:android
+  ```
+
+- After package or dependency changes, rebuild with Turborepo, for example:
+
+  ```bash
+  pnpm turbo run build
+  ```
+
+- Refresh the browser after rebuilding.
+- With the Playground app and Metro running, query Metro's `/json/list` endpoint.
+- Extract the inspector URL from the response.
+- Replace the `ws` query parameter in this URL with the extracted inspector URL:
+
+  ```text
+  http://127.0.0.1:8081/rozenite/rn_fusebox.html?ws=%2Finspector%2Fdebug%3Fdevice%3D2ce2ba5f071e81a9efad6f66a9e029fd6aa11ccd%26page%3D1&sources.hide_add_folder=true&unstable_enableNetworkPanel=true&appId=com.callstackcincubator.rozenite
+  ```
+
+- Open the resulting URL with `agent-browser`.
+- In React Native DevTools, open the Rozenite tab, select the plugin from the sidebar, and run the E2E cases.

--- a/docs/agents/plugin-development.md
+++ b/docs/agents/plugin-development.md
@@ -1,0 +1,8 @@
+# Plugin development
+
+- For new request-response features, prefer the RPC-style protocol over the legacy message-based API.
+- See the [RPC documentation](../../website/src/docs/plugin-development/rpc.md).
+- Prefer reusable UI elements from `@rozenite/ui`.
+- Put reusable new components in the `ui` package.
+- Put one-off new components directly in the plugin.
+- Use the compound components pattern for cooperating component sets.

--- a/docs/agents/unit-testing.md
+++ b/docs/agents/unit-testing.md
@@ -1,0 +1,6 @@
+# Unit testing
+
+- Skip low-ROI tests.
+- Do not add tests solely for code-coverage completeness.
+- If a test mocks roughly 80% of the implementation, reconsider or omit it.
+- For bug fixes, prefer a regression guard reproducing the original failure.


### PR DESCRIPTION
## Description

Adds concise agent guidance for unit testing, E2E testing, and plugin development. Routes the new guides from `AGENTS.md`.

## Related Issue

No issue linked, per request.

## Context

The guides define focused test-selection rules, the Playground-based E2E workflow, RPC preference for new request-response features, shared UI component placement, and compound component usage.

## Testing

- `git diff --cached --check` passed.
- `git diff --check` passed.
- Full Prettier validation was not run because the local dependencies are not installed.
