### PR TITLE
fix(runtime): restore legacy plugin tab ordering

### DIFF
--- a/.changeset/legacy-plugin-tab-order.md
+++ b/.changeset/legacy-plugin-tab-order.md
@@ -1,0 +1,5 @@
+---
+'@rozenite/runtime': patch
+---
+
+Restore individual plugin panels in legacy tabs mode and keep them grouped at the end of the DevTools tab bar.

--- a/packages/runtime/src/create-panel.ts
+++ b/packages/runtime/src/create-panel.ts
@@ -1,6 +1,12 @@
 import { getPluginView } from './rn-devtools/plugin-view.js';
 import { UI } from './rn-devtools/rn-devtools-frontend.js';
 
+type CreatePanelOptions = {
+  shellConfiguration?: unknown;
+  insertAtStart?: boolean;
+  insertAtEnd?: boolean;
+};
+
 const toExtendedKebabCase = (input: string): string => {
   return input
     .toLowerCase()
@@ -16,8 +22,7 @@ export const createPanel = (
   pluginId: string,
   name: string,
   url: string,
-  shellConfiguration?: unknown,
-  insertAtStart = false,
+  options: CreatePanelOptions = {},
 ) => {
   try {
     const pluginIdKebab = toExtendedKebabCase(pluginId);
@@ -33,12 +38,12 @@ export const createPanel = (
       panelId,
       name,
       url,
-      shellConfiguration,
+      options.shellConfiguration,
     );
 
     UI.InspectorView.InspectorView.instance().addPanel(panelView);
 
-    if (insertAtStart) {
+    if (options.insertAtStart || options.insertAtEnd) {
       const tabbedPane = UI.InspectorView.InspectorView.instance().tabbedPane;
       const panelViewTab = tabbedPane.tabsById.get(panelId);
 
@@ -46,8 +51,12 @@ export const createPanel = (
         throw new Error(`Panel view tab not found: ${panelId}`);
       }
 
-      tabbedPane.insertBefore(panelViewTab, 0);
-      tabbedPane.selectTab(panelViewTab.id);
+      if (options.insertAtStart) {
+        tabbedPane.insertBefore(panelViewTab, 0);
+        tabbedPane.selectTab(panelViewTab.id);
+      } else {
+        tabbedPane.insertBefore(panelViewTab, tabbedPane.tabsById.size);
+      }
     }
   } catch (err) {
     console.error(err);

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,7 +1,7 @@
 import { setupDevMode } from './dev-mode.js';
 import { getGlobalNamespace } from './global-namespace.js';
 import { createPanel } from './create-panel.js';
-import { loadPlugin } from './plugin-loader.js';
+import { loadPlugin, type LoadedPlugin } from './plugin-loader.js';
 import { addWelcomeView } from './rn-devtools/rozenite-welcome-view.js';
 import {
   trackPanelSelection,
@@ -38,8 +38,24 @@ const main = async (): Promise<void> => {
 
   if (pluginDisplay === 'tabs') {
     addWelcomeView();
-    await Promise.all(plugins.map((plugin) => loadPlugin(plugin)));
-    await setupDevMode();
+    const loadedPlugins = await Promise.all(
+      plugins.map((plugin) => loadPlugin(plugin)),
+    );
+
+    const addPluginPanels = (plugin: LoadedPlugin): void => {
+      plugin.panels.forEach((panel) => {
+        createPanel(plugin.id, panel.name, panel.source, {
+          insertAtEnd: true,
+        });
+      });
+    };
+
+    loadedPlugins.forEach(addPluginPanels);
+
+    const developmentPlugin = await setupDevMode();
+    if (developmentPlugin) {
+      addPluginPanels(developmentPlugin);
+    }
   } else {
     const loadedPlugins = await Promise.all(
       plugins.map(async (plugin) => {
@@ -55,17 +71,14 @@ const main = async (): Promise<void> => {
     const shellUrl = new URL(location.href);
     shellUrl.search = '';
     shellUrl.pathname = '/rozenite/shell/index.html';
-    createPanel(
-      '@rozenite/shell',
-      'Rozenite',
-      shellUrl.toString(),
-      {
+    createPanel('@rozenite/shell', 'Rozenite', shellUrl.toString(), {
+      shellConfiguration: {
         plugins: loadedPlugins,
         destroyOnDetachPlugins: getGlobalNamespace().destroyOnDetachPlugins,
         runtimeVersion: getGlobalNamespace().runtimeVersion,
       },
-      true,
-    );
+      insertAtStart: true,
+    });
   }
 
   trackPanelSelection();


### PR DESCRIPTION
## Description

Restores individual plugin panels when Rozenite runs in legacy `tabs` mode and keeps those plugin tabs grouped at the end of the React Native DevTools tab bar.

## Related Issue

No issue linked, per request.

## Context

The legacy branch previously loaded plugin manifests but did not register their panels. After panel registration was restored, React Native DevTools could place panels at different positions because `addPanel()` does not guarantee append ordering in the current frontend. This change registers installed and dev-mode plugin panels individually and explicitly moves them to the end. Sidebar mode continues to place the Rozenite shell at the start.

## Testing

- `pnpm exec prettier --check packages/runtime/src/create-panel.ts packages/runtime/src/index.ts .changeset/legacy-plugin-tab-order.md`
- `pnpm --filter @rozenite/runtime typecheck`
- `pnpm --filter @rozenite/runtime build`
- `git diff --check`

The runtime typecheck and build were run against the same source changes in the primary worktree; the isolated PR worktree has no local `node_modules` link.