### PR TITLE
feat(runtime): add versioned welcome dialog

### DIFF
--- a/.changeset/shell-welcome-dialog.md
+++ b/.changeset/shell-welcome-dialog.md
@@ -1,0 +1,5 @@
+---
+'@rozenite/shell': minor
+---
+
+Show release-specific welcome messaging the first time a new Rozenite version runs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@
 - For end-to-end testing guidance, see @./docs/agents/e2e-testing.md.
 - For plugin-development guidance, see @./docs/agents/plugin-development.md.
 - For version plans, see @./docs/agents/version-plans.md.
+- For welcome dialog release content, see @./agents/release-content.md.
 - Before preparing or opening a pull request, see @./docs/agents/pull-requests.md.
 - Preserve unrelated work already present in the working tree.
 - Keep changes focused; do not make opportunistic refactors.

--- a/agents/release-content.md
+++ b/agents/release-content.md
@@ -1,0 +1,6 @@
+# Release content
+
+`packages/shell/src/ReleaseContent.tsx` contains the welcome dialog content.
+
+Update it only when the user asks to change release or welcome messaging.
+Update `WELCOME_RELEASE_ID` with the release content.

--- a/agents/release-content.md
+++ b/agents/release-content.md
@@ -3,4 +3,4 @@
 `packages/shell/src/ReleaseContent.tsx` contains the welcome dialog content.
 
 Update it only when the user asks to change release or welcome messaging.
-Update `WELCOME_RELEASE_ID` with the release content.
+The runtime version controls when it appears.

--- a/packages/shell/src/ReleaseContent.tsx
+++ b/packages/shell/src/ReleaseContent.tsx
@@ -1,0 +1,19 @@
+export const WELCOME_RELEASE_ID = '1.13.0';
+
+/**
+ * Release-specific welcome content. Replace this component and update
+ * WELCOME_RELEASE_ID when preparing a release that needs a welcome dialog.
+ */
+export function ReleaseContent() {
+  return (
+    <div className="space-y-4 text-sm text-muted-foreground">
+      <p>
+        Rozenite now brings your DevTools plugin panels together in one shared
+        shell.
+      </p>
+      <p>
+        Select a panel from the sidebar to start inspecting your application.
+      </p>
+    </div>
+  );
+}

--- a/packages/shell/src/ReleaseContent.tsx
+++ b/packages/shell/src/ReleaseContent.tsx
@@ -1,4 +1,10 @@
+import { Dialog } from '@rozenite/ui';
+
 export const WELCOME_RELEASE_ID = '1.13.0';
+
+const METRO_CONFIGURATION_URL =
+  'https://github.com/callstackincubator/rozenite/tree/main/packages/metro#configuration';
+const ISSUES_URL = 'https://github.com/callstackincubator/rozenite/issues';
 
 /**
  * Release-specific welcome content. Replace this component and update
@@ -6,14 +12,53 @@ export const WELCOME_RELEASE_ID = '1.13.0';
  */
 export function ReleaseContent() {
   return (
-    <div className="space-y-4 text-sm text-muted-foreground">
-      <p>
-        Rozenite now brings your DevTools plugin panels together in one shared
-        shell.
-      </p>
-      <p>
-        Select a panel from the sidebar to start inspecting your application.
-      </p>
+    <div className="space-y-4">
+      <Dialog.Header>
+        <Dialog.Title>Rozenite is changing</Dialog.Title>
+        <Dialog.Description>
+          The DevTools experience now uses a unified UI.
+        </Dialog.Description>
+      </Dialog.Header>
+      <div className="space-y-4 text-sm text-muted-foreground">
+        <p>
+          Plugin panels now live together in one place, with a consistent
+          layout and appearance. The goal is to make Rozenite easier to move
+          through and more comfortable to use day to day.
+        </p>
+        <p>
+          Prefer the previous layout? Set{' '}
+          <code className="rounded bg-muted px-1 py-0.5 font-mono text-foreground">
+            pluginDisplay: 'tabs'
+          </code>{' '}
+          in the options passed to{' '}
+          <code className="rounded bg-muted px-1 py-0.5 font-mono text-foreground">
+            withRozenite
+          </code>{' '}
+          in your Metro config. See the{' '}
+          <a
+            className="text-primary underline underline-offset-4 hover:text-primary/80"
+            href={METRO_CONFIGURATION_URL}
+            rel="noreferrer"
+            target="_blank"
+          >
+            Metro configuration reference
+          </a>
+          .
+        </p>
+        <p>
+          Please report UI issues, plugin improvements, and requests for new
+          plugins in the{' '}
+          <a
+            className="text-primary underline underline-offset-4 hover:text-primary/80"
+            href={ISSUES_URL}
+            rel="noreferrer"
+            target="_blank"
+          >
+            Rozenite repository
+          </a>
+          .
+        </p>
+      </div>
     </div>
   );
 }

--- a/packages/shell/src/ReleaseContent.tsx
+++ b/packages/shell/src/ReleaseContent.tsx
@@ -1,20 +1,32 @@
 import { Dialog } from '@rozenite/ui';
-
-export const WELCOME_RELEASE_ID = '1.13.0';
+import lightLogo from '../../../website/src/public/logo-light.svg';
+import darkLogo from '../../../website/src/public/logo-dark.svg';
 
 const METRO_CONFIGURATION_URL =
   'https://github.com/callstackincubator/rozenite/tree/main/packages/metro#configuration';
 const ISSUES_URL = 'https://github.com/callstackincubator/rozenite/issues';
 
 /**
- * Release-specific welcome content. Replace this component and update
- * WELCOME_RELEASE_ID when preparing a release that needs a welcome dialog.
+ * Release-specific welcome content. Replace this component when preparing a
+ * release that needs a welcome dialog.
  */
 export function ReleaseContent() {
   return (
     <div className="space-y-4">
+      <div className="h-8">
+        <img
+          src={lightLogo}
+          alt="Rozenite"
+          className="h-8 w-auto dark:hidden"
+        />
+        <img
+          src={darkLogo}
+          alt="Rozenite"
+          className="hidden h-8 w-auto dark:block"
+        />
+      </div>
       <Dialog.Header>
-        <Dialog.Title>Rozenite is changing</Dialog.Title>
+        <Dialog.Title>We are changing</Dialog.Title>
         <Dialog.Description>
           The DevTools experience now uses a unified UI.
         </Dialog.Description>

--- a/packages/shell/src/Shell.tsx
+++ b/packages/shell/src/Shell.tsx
@@ -13,6 +13,7 @@ import lightLogo from '../../../website/src/public/logo-light.svg';
 import darkLogo from '../../../website/src/public/logo-dark.svg';
 import { getInitialSelection, type ShellSelection } from './selection';
 import { NewVersionFooter } from './NewVersionFooter';
+import { WelcomeDialog } from './WelcomeDialog';
 import type { ShellConfiguration, ShellPanel, ShellPlugin } from './types';
 
 const SHELL_CONFIGURATION_TYPE = 'rozenite-shell-configuration';
@@ -104,6 +105,7 @@ export function Shell({
   if (!activePlugin || !activePanel) {
     return (
       <PluginShell>
+        <WelcomeDialog runtimeVersion={runtimeVersion} />
         <PluginShell.Body className="items-center justify-center">
           <EmptyState
             title="No Rozenite plugins available"
@@ -116,6 +118,7 @@ export function Shell({
 
   return (
     <PluginShell>
+      <WelcomeDialog runtimeVersion={runtimeVersion} />
       <PluginShell.Body className="flex-row overflow-hidden">
         <Split
           direction="horizontal"

--- a/packages/shell/src/WelcomeDialog.tsx
+++ b/packages/shell/src/WelcomeDialog.tsx
@@ -45,12 +45,6 @@ export function WelcomeDialog({ runtimeVersion }: WelcomeDialogProps) {
       }}
     >
       <Dialog.Content className="max-w-xl" showCloseButton={false}>
-        <Dialog.Header>
-          <Dialog.Title>Welcome to Rozenite {WELCOME_RELEASE_ID}</Dialog.Title>
-          <Dialog.Description>
-            Here is what is new in this release.
-          </Dialog.Description>
-        </Dialog.Header>
         <ScrollArea className="max-h-80 pr-4">
           <ReleaseContent />
         </ScrollArea>

--- a/packages/shell/src/WelcomeDialog.tsx
+++ b/packages/shell/src/WelcomeDialog.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useRef, useState } from 'react';
+import { Button, Dialog, ScrollArea } from '@rozenite/ui';
+import { ReleaseContent, WELCOME_RELEASE_ID } from './ReleaseContent';
+import {
+  readWelcomeDismissal,
+  shouldShowWelcomeDialog,
+  writeWelcomeDismissal,
+} from './welcome-dialog-state';
+
+type WelcomeDialogProps = {
+  runtimeVersion?: string;
+};
+
+export function WelcomeDialog({ runtimeVersion }: WelcomeDialogProps) {
+  const [open, setOpen] = useState(false);
+  const dismissedReleaseId = useRef<string | null>(null);
+
+  useEffect(() => {
+    const isDismissed =
+      dismissedReleaseId.current === WELCOME_RELEASE_ID ||
+      readWelcomeDismissal(WELCOME_RELEASE_ID);
+
+    setOpen(
+      shouldShowWelcomeDialog(
+        runtimeVersion,
+        WELCOME_RELEASE_ID,
+        isDismissed,
+      ),
+    );
+  }, [runtimeVersion]);
+
+  const dismiss = () => {
+    dismissedReleaseId.current = WELCOME_RELEASE_ID;
+    writeWelcomeDismissal(WELCOME_RELEASE_ID);
+    setOpen(false);
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) {
+          dismiss();
+        }
+      }}
+    >
+      <Dialog.Content className="max-w-xl" showCloseButton={false}>
+        <Dialog.Header>
+          <Dialog.Title>Welcome to Rozenite {WELCOME_RELEASE_ID}</Dialog.Title>
+          <Dialog.Description>
+            Here is what is new in this release.
+          </Dialog.Description>
+        </Dialog.Header>
+        <ScrollArea className="max-h-80 pr-4">
+          <ReleaseContent />
+        </ScrollArea>
+        <Dialog.Footer>
+          <Button onClick={dismiss}>Got it</Button>
+        </Dialog.Footer>
+      </Dialog.Content>
+    </Dialog>
+  );
+}

--- a/packages/shell/src/WelcomeDialog.tsx
+++ b/packages/shell/src/WelcomeDialog.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useId, useRef, useState } from 'react';
 import { Button, Dialog, ScrollArea } from '@rozenite/ui';
-import { ReleaseContent, WELCOME_RELEASE_ID } from './ReleaseContent';
+import { ReleaseContent } from './ReleaseContent';
 import {
   readWelcomeDismissal,
   shouldShowWelcomeDialog,
@@ -13,25 +13,28 @@ type WelcomeDialogProps = {
 
 export function WelcomeDialog({ runtimeVersion }: WelcomeDialogProps) {
   const [open, setOpen] = useState(false);
-  const dismissedReleaseId = useRef<string | null>(null);
+  const dismissedRuntimeVersion = useRef<string | null>(null);
+  const dismissButtonId = useId();
 
   useEffect(() => {
-    const isDismissed =
-      dismissedReleaseId.current === WELCOME_RELEASE_ID ||
-      readWelcomeDismissal(WELCOME_RELEASE_ID);
+    if (runtimeVersion === undefined) {
+      setOpen(false);
+      return;
+    }
 
-    setOpen(
-      shouldShowWelcomeDialog(
-        runtimeVersion,
-        WELCOME_RELEASE_ID,
-        isDismissed,
-      ),
-    );
+    const dismissedVersion =
+      dismissedRuntimeVersion.current === runtimeVersion
+        ? runtimeVersion
+        : readWelcomeDismissal();
+
+    setOpen(shouldShowWelcomeDialog(runtimeVersion, dismissedVersion));
   }, [runtimeVersion]);
 
   const dismiss = () => {
-    dismissedReleaseId.current = WELCOME_RELEASE_ID;
-    writeWelcomeDismissal(WELCOME_RELEASE_ID);
+    if (runtimeVersion !== undefined) {
+      dismissedRuntimeVersion.current = runtimeVersion;
+      writeWelcomeDismissal(runtimeVersion);
+    }
     setOpen(false);
   };
 
@@ -44,12 +47,18 @@ export function WelcomeDialog({ runtimeVersion }: WelcomeDialogProps) {
         }
       }}
     >
-      <Dialog.Content className="max-w-xl" showCloseButton={false}>
+      <Dialog.Content
+        className="max-w-xl"
+        initialFocus={() => document.getElementById(dismissButtonId)}
+        showCloseButton={false}
+      >
         <ScrollArea className="max-h-80 pr-4">
           <ReleaseContent />
         </ScrollArea>
         <Dialog.Footer>
-          <Button onClick={dismiss}>Got it</Button>
+          <Button id={dismissButtonId} onClick={dismiss}>
+            Got it
+          </Button>
         </Dialog.Footer>
       </Dialog.Content>
     </Dialog>

--- a/packages/shell/src/welcome-dialog-state.test.ts
+++ b/packages/shell/src/welcome-dialog-state.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getWelcomeDismissalStorageKey,
+  shouldShowWelcomeDialog,
+} from './welcome-dialog-state';
+
+describe('shouldShowWelcomeDialog', () => {
+  it('shows an unseen welcome dialog for its matching runtime version', () => {
+    expect(shouldShowWelcomeDialog('1.13.0', '1.13.0', false)).toBe(true);
+  });
+
+  it('does not show a dismissed or non-matching release', () => {
+    expect(shouldShowWelcomeDialog('1.13.0', '1.13.0', true)).toBe(false);
+    expect(shouldShowWelcomeDialog('1.14.0', '1.13.0', false)).toBe(false);
+  });
+});
+
+describe('getWelcomeDismissalStorageKey', () => {
+  it('scopes dismissal state to one release', () => {
+    expect(getWelcomeDismissalStorageKey('1.13.0')).toBe(
+      '@rozenite/shell:welcome-dismissed:1.13.0',
+    );
+  });
+});

--- a/packages/shell/src/welcome-dialog-state.test.ts
+++ b/packages/shell/src/welcome-dialog-state.test.ts
@@ -1,24 +1,24 @@
 import { describe, expect, it } from 'vitest';
 import {
-  getWelcomeDismissalStorageKey,
+  WELCOME_DISMISSAL_STORAGE_KEY,
   shouldShowWelcomeDialog,
 } from './welcome-dialog-state';
 
 describe('shouldShowWelcomeDialog', () => {
-  it('shows an unseen welcome dialog for its matching runtime version', () => {
-    expect(shouldShowWelcomeDialog('1.13.0', '1.13.0', false)).toBe(true);
+  it('shows an unseen welcome dialog for a runtime version', () => {
+    expect(shouldShowWelcomeDialog('1.13.0', null)).toBe(true);
   });
 
-  it('does not show a dismissed or non-matching release', () => {
-    expect(shouldShowWelcomeDialog('1.13.0', '1.13.0', true)).toBe(false);
-    expect(shouldShowWelcomeDialog('1.14.0', '1.13.0', false)).toBe(false);
+  it('does not show a dismissed version or a missing runtime version', () => {
+    expect(shouldShowWelcomeDialog('1.13.0', '1.13.0')).toBe(false);
+    expect(shouldShowWelcomeDialog(undefined, null)).toBe(false);
   });
 });
 
-describe('getWelcomeDismissalStorageKey', () => {
-  it('scopes dismissal state to one release', () => {
-    expect(getWelcomeDismissalStorageKey('1.13.0')).toBe(
-      '@rozenite/shell:welcome-dismissed:1.13.0',
+describe('WELCOME_DISMISSAL_STORAGE_KEY', () => {
+  it('uses one stable storage key', () => {
+    expect(WELCOME_DISMISSAL_STORAGE_KEY).toBe(
+      '@rozenite/shell:welcome-dismissed-version',
     );
   });
 });

--- a/packages/shell/src/welcome-dialog-state.ts
+++ b/packages/shell/src/welcome-dialog-state.ts
@@ -1,0 +1,29 @@
+const STORAGE_KEY_PREFIX = '@rozenite/shell:welcome-dismissed:';
+
+export function getWelcomeDismissalStorageKey(releaseId: string): string {
+  return `${STORAGE_KEY_PREFIX}${releaseId}`;
+}
+
+export function shouldShowWelcomeDialog(
+  runtimeVersion: string | undefined,
+  releaseId: string,
+  isDismissed: boolean,
+): boolean {
+  return runtimeVersion === releaseId && !isDismissed;
+}
+
+export function readWelcomeDismissal(releaseId: string): boolean {
+  try {
+    return localStorage.getItem(getWelcomeDismissalStorageKey(releaseId)) === '1';
+  } catch {
+    return false;
+  }
+}
+
+export function writeWelcomeDismissal(releaseId: string): void {
+  try {
+    localStorage.setItem(getWelcomeDismissalStorageKey(releaseId), '1');
+  } catch {
+    // Storage may be unavailable. The dialog remains dismissed until unmount.
+  }
+}

--- a/packages/shell/src/welcome-dialog-state.ts
+++ b/packages/shell/src/welcome-dialog-state.ts
@@ -1,28 +1,24 @@
-const STORAGE_KEY_PREFIX = '@rozenite/shell:welcome-dismissed:';
-
-export function getWelcomeDismissalStorageKey(releaseId: string): string {
-  return `${STORAGE_KEY_PREFIX}${releaseId}`;
-}
+export const WELCOME_DISMISSAL_STORAGE_KEY =
+  '@rozenite/shell:welcome-dismissed-version';
 
 export function shouldShowWelcomeDialog(
   runtimeVersion: string | undefined,
-  releaseId: string,
-  isDismissed: boolean,
+  dismissedVersion: string | null,
 ): boolean {
-  return runtimeVersion === releaseId && !isDismissed;
+  return runtimeVersion !== undefined && runtimeVersion !== dismissedVersion;
 }
 
-export function readWelcomeDismissal(releaseId: string): boolean {
+export function readWelcomeDismissal(): string | null {
   try {
-    return localStorage.getItem(getWelcomeDismissalStorageKey(releaseId)) === '1';
+    return localStorage.getItem(WELCOME_DISMISSAL_STORAGE_KEY);
   } catch {
-    return false;
+    return null;
   }
 }
 
-export function writeWelcomeDismissal(releaseId: string): void {
+export function writeWelcomeDismissal(runtimeVersion: string): void {
   try {
-    localStorage.setItem(getWelcomeDismissalStorageKey(releaseId), '1');
+    localStorage.setItem(WELCOME_DISMISSAL_STORAGE_KEY, runtimeVersion);
   } catch {
     // Storage may be unavailable. The dialog remains dismissed until unmount.
   }


### PR DESCRIPTION
## Description

Adds a release-specific welcome dialog to the unified Rozenite shell. It appears once when a new runtime version first runs and presents authored release messaging.

## Related Issue

No related issue was provided or found for this work.

## Context

The dialog is always mounted but opens only when the runtime version differs from the version stored under one stable local-storage key. Release content is isolated in a dedicated component so each release can use arbitrary JSX. The dialog displays the themed wordmark, directs focus to its acknowledgement button, and links users to configuration and feedback paths.

## Testing

- `pnpm --filter @rozenite/shell test -- welcome-dialog-state.test.ts` — 3 files, 8 tests passed.
- `pnpm --filter @rozenite/shell typecheck` — passed.
- `pnpm --filter @rozenite/shell lint` — passed.
- `git diff --check` — passed.