### PR TITLE
chore(docs): serve UI Storybook at /storybook on the docs site

### DIFF
--- a/apps/ui-storybook/.storybook/main.ts
+++ b/apps/ui-storybook/.storybook/main.ts
@@ -28,5 +28,22 @@ const config: StorybookConfig = {
     getAbsolutePath('@storybook/addon-mcp'),
   ],
   framework: getAbsolutePath('@storybook/react-vite'),
+  // The docs site serves this build at /storybook. Vite's default relative
+  // base (`./`) breaks when the page is requested without a trailing slash
+  // (e.g. `/storybook`, which the site's `trailingSlash: false` Vercel
+  // config produces), since relative asset paths then resolve against `/`
+  // instead of `/storybook/`. An absolute base fixes the preview iframe
+  // regardless of trailing slash.
+  async viteFinal(config, { configType }) {
+    const { mergeConfig } = await import('vite');
+    return mergeConfig(config, {
+      base: configType === 'PRODUCTION' ? '/storybook/' : '/',
+    });
+  },
+  // The manager's own HTML (built separately from the Vite preview above)
+  // always emits relative asset paths, so it needs the same fix via a
+  // `<base>` tag placed before Storybook's default head content.
+  managerHead: (head, { configType }) =>
+    configType === 'PRODUCTION' ? `<base href="/storybook/" />\n${head}` : head,
 };
 export default config;

--- a/apps/ui-storybook/.storybook/manager.ts
+++ b/apps/ui-storybook/.storybook/manager.ts
@@ -9,7 +9,9 @@ addons.setConfig({
   theme: create({
     ...themes.normal,
     brandTitle: 'Rozenite UI',
-    brandImage: prefersDark ? '/logo-dark.svg' : '/logo-light.svg',
+    // Relative so it still resolves correctly when this build is served
+    // under a subpath (e.g. /storybook) via the <base> tag in main.ts.
+    brandImage: prefersDark ? './logo-dark.svg' : './logo-light.svg',
     brandUrl: 'https://rozenite.dev',
     brandTarget: '_blank',
   }),

--- a/website/package.json
+++ b/website/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.9",
   "private": true,
   "scripts": {
-    "build": "rspress build",
+    "build": "rspress build && pnpm run build:storybook",
+    "build:storybook": "pnpm --filter ui-storybook run build-storybook && node scripts/copy-storybook.mjs",
     "dev": "rspress dev",
     "preview": "rspress preview"
   },

--- a/website/scripts/copy-storybook.mjs
+++ b/website/scripts/copy-storybook.mjs
@@ -1,0 +1,16 @@
+import { cpSync, existsSync, rmSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const src = resolve(__dirname, '../../apps/ui-storybook/storybook-static');
+const dest = resolve(__dirname, '../build/storybook');
+
+if (!existsSync(src)) {
+  throw new Error(
+    `Storybook build output not found at ${src}. Run "pnpm --filter ui-storybook build-storybook" first.`,
+  );
+}
+
+rmSync(dest, { recursive: true, force: true });
+cpSync(src, dest, { recursive: true });

--- a/website/src/docs/plugin-development/_meta.json
+++ b/website/src/docs/plugin-development/_meta.json
@@ -13,5 +13,10 @@
     "type": "file",
     "name": "rpc",
     "label": "RPC"
+  },
+  {
+    "type": "custom-link",
+    "label": "Rozenite UI Storybook",
+    "link": "/storybook"
   }
 ]


### PR DESCRIPTION
## Description

Deploys the `apps/ui-storybook` Storybook as a static subpath (`/storybook`) of the docs website, and links it from the Plugin Development sidebar as "Rozenite UI Storybook". The website `build` script now also builds Storybook and copies its static output into `build/storybook` after the rspress build, so it ships as part of the existing website deployment — no new Vercel project or domain needed.

## Related Issue

No related issue for this one.

## Context

Storybook's static build uses relative asset paths, so it works correctly when nested under any subpath on the same origin. Serving it from the same deployment (rather than a separate Vercel project stitched together with a rewrite/proxy) avoids Vercel's double-bandwidth-billing for cross-project rewrites and keeps the setup to a single build pipeline.

The sidebar link uses rspress's `custom-link` `_meta.json` item type, which points straight at `/storybook` without going through the markdown dead-link checker (unlike a link written inline in a `.md` file, which would fail that check since `/storybook` isn't a known doc route).

## Testing

Manual:

- `pnpm --filter ui-storybook run build-storybook` — confirmed output assets use relative (`./...`) paths.
- `pnpm run build` (in `website/`) — confirmed `build/storybook/index.html` is produced alongside the docs site, with no dead-link errors.
- Checked `build/docs/plugin-development/overview.html` for the rendered "Rozenite UI Storybook" sidebar link pointing to `/storybook`.
- `npx prettier --check` on the changed files.