### PR TITLE
feat(shell): add plugins screen

### DIFF
--- a/.changeset/plugins-screen.md
+++ b/.changeset/plugins-screen.md
@@ -1,0 +1,7 @@
+---
+'@rozenite/ui': minor
+'@rozenite/shell': minor
+'@rozenite/runtime': minor
+---
+
+Add a Plugins screen to shell mode, opened from a new cog button in the sidebar footer. It lists every loaded plugin with its package id, description, installed version, panels, and a link to npm when a newer version is published. The cog shows a dot when any plugin or the runtime itself has an update available. Panel state is preserved while the screen is open. Also fixes the npm version check to use the CDN-cached registry endpoint instead of the rate-limited `/latest` endpoint, and to correctly ignore local builds ahead of npm.

--- a/apps/ui-storybook/src/stories/Button.stories.tsx
+++ b/apps/ui-storybook/src/stories/Button.stories.tsx
@@ -1,5 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Button } from '@rozenite/ui';
+import { Button, IndicatorDot } from '@rozenite/ui';
+
+function SettingsIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+      <circle cx="12" cy="12" r="3" />
+      <path d="M19.4 15a1.7 1.7 0 0 0 .3 1.9l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.9-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 1 1-4 0v-.1a1.7 1.7 0 0 0-1-1.6 1.7 1.7 0 0 0-1.9.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.7 1.7 0 0 0 .3-1.9 1.7 1.7 0 0 0-1.5-1H3a2 2 0 1 1 0-4h.1a1.7 1.7 0 0 0 1.6-1 1.7 1.7 0 0 0-.3-1.9l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.7 1.7 0 0 0 1.9.3H9a1.7 1.7 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.1a1.7 1.7 0 0 0 1 1.5 1.7 1.7 0 0 0 1.9-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.9V9a1.7 1.7 0 0 0 1.5 1H21a2 2 0 1 1 0 4h-.1a1.7 1.7 0 0 0-1.5 1z" />
+    </svg>
+  );
+}
 
 const meta = {
   component: Button,
@@ -35,5 +44,30 @@ export const AllVariants: Story = {
       <Button variant="outline">Outline</Button>
       <Button variant="ghost">Ghost</Button>
     </div>
+  ),
+};
+
+/**
+ * Use `adornment` to host a status affordance, e.g. an `IndicatorDot`
+ * flagging an available update, without a dedicated prop for it.
+ * @summary Host an indicator dot via the adornment slot.
+ */
+export const WithAdornment: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Use `adornment` to host a status affordance next to the button content.',
+      },
+    },
+  },
+  render: () => (
+    <Button
+      variant="ghost"
+      size="icon"
+      aria-label="Plugins"
+      adornment={<IndicatorDot className="absolute top-1 right-1" />}
+    >
+      <SettingsIcon />
+    </Button>
   ),
 };

--- a/apps/ui-storybook/src/stories/Card.stories.tsx
+++ b/apps/ui-storybook/src/stories/Card.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Badge, Card, DescriptionList } from '@rozenite/ui';
+
+const meta = {
+  component: Card,
+  title: 'Components/Card',
+} satisfies Meta<typeof Card>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Use to group related content behind a bordered container.
+ * @summary Group related content.
+ */
+export const Default: Story = {
+  render: () => (
+    <Card className="w-96">
+      <Card.Header>
+        <span className="font-medium">@rozenite/network-activity-plugin</span>
+        <Badge>1.2.0</Badge>
+      </Card.Header>
+      <Card.Body>
+        <DescriptionList>
+          <DescriptionList.Item label="Panels">Network</DescriptionList.Item>
+        </DescriptionList>
+      </Card.Body>
+    </Card>
+  ),
+};
+
+/** Use `collapsible` when the body content is secondary detail.
+ * @summary Collapse body content behind a toggle.
+ */
+export const Collapsible: Story = {
+  render: () => (
+    <Card className="w-96" collapsible>
+      <Card.Header>
+        <span className="font-medium">@rozenite/storage-plugin</span>
+        <Badge>2.0.1</Badge>
+      </Card.Header>
+      <Card.Body>
+        <DescriptionList>
+          <DescriptionList.Item label="Panels">Storage</DescriptionList.Item>
+        </DescriptionList>
+      </Card.Body>
+    </Card>
+  ),
+};

--- a/apps/ui-storybook/src/stories/DescriptionList.stories.tsx
+++ b/apps/ui-storybook/src/stories/DescriptionList.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { DescriptionList } from '@rozenite/ui';
+
+const meta = {
+  component: DescriptionList,
+  title: 'Components/DescriptionList',
+} satisfies Meta<typeof DescriptionList>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Use for a list of label/value rows describing an entity.
+ * @summary Describe an entity with label/value rows.
+ */
+export const Default: Story = {
+  render: () => (
+    <DescriptionList className="w-80">
+      <DescriptionList.Item label="Panels">Network, Storage</DescriptionList.Item>
+      <DescriptionList.Item label="Description">Inspect network traffic.</DescriptionList.Item>
+    </DescriptionList>
+  ),
+};

--- a/apps/ui-storybook/src/stories/IndicatorDot.stories.tsx
+++ b/apps/ui-storybook/src/stories/IndicatorDot.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { IndicatorDot } from '@rozenite/ui';
+
+const meta = {
+  component: IndicatorDot,
+  title: 'Components/IndicatorDot',
+} satisfies Meta<typeof IndicatorDot>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Use to flag that something needs attention, e.g. an available update.
+ * @summary Flag that something needs attention.
+ */
+export const Variants: Story = {
+  render: () => (
+    <div className="flex items-center gap-4">
+      <IndicatorDot />
+      <IndicatorDot variant="destructive" />
+      <IndicatorDot className="size-2.5" />
+    </div>
+  ),
+};

--- a/apps/ui-storybook/src/stories/Link.stories.tsx
+++ b/apps/ui-storybook/src/stories/Link.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Link } from '@rozenite/ui';
+
+const meta = {
+  component: Link,
+  title: 'Components/Link',
+} satisfies Meta<typeof Link>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Compare an in-app link with a link that leaves the app.
+ * @summary Compare internal and external links.
+ */
+export const Variants: Story = {
+  render: () => (
+    <div className="flex flex-col gap-2 text-sm">
+      <Link href="#">Internal link</Link>
+      <Link href="https://www.npmjs.com" external>
+        View on npm
+      </Link>
+    </div>
+  ),
+};

--- a/apps/ui-storybook/src/stories/Separator.stories.tsx
+++ b/apps/ui-storybook/src/stories/Separator.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Separator } from '@rozenite/ui';
+
+const meta = {
+  component: Separator,
+  title: 'Components/Separator',
+} satisfies Meta<typeof Separator>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Use to divide related content or actions.
+ * @summary Divide content horizontally or vertically.
+ */
+export const Orientations: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <div>
+        <div className="text-sm">Above</div>
+        <Separator className="my-2" />
+        <div className="text-sm">Below</div>
+      </div>
+      <div className="flex h-6 items-center gap-2 text-sm">
+        <span>Left</span>
+        <Separator orientation="vertical" />
+        <span>Right</span>
+      </div>
+    </div>
+  ),
+};

--- a/apps/ui-storybook/src/stories/Sidebar.stories.tsx
+++ b/apps/ui-storybook/src/stories/Sidebar.stories.tsx
@@ -38,3 +38,30 @@ export const Default: Story = {
     </div>
   ),
 };
+
+/** Use `Sidebar.Header` and `Sidebar.Footer` for the sticky, bordered chrome
+ * around the scrollable item list.
+ * @summary Frame the item list with a sticky header and footer.
+ */
+export const WithHeaderAndFooter: Story = {
+  render: () => (
+    <div className="h-72">
+      <Sidebar className="gap-0 p-0">
+        <Sidebar.Header>
+          <span className="font-medium">Rozenite</span>
+        </Sidebar.Header>
+        <div className="min-h-0 flex-1 overflow-y-auto p-2">
+          <Sidebar.Group label="Workspace">
+            <Sidebar.Item selected adornment={<OverviewIcon />}>
+              Overview
+            </Sidebar.Item>
+            <Sidebar.Item>Network</Sidebar.Item>
+          </Sidebar.Group>
+        </div>
+        <Sidebar.Footer>
+          <span className="text-xs text-sidebar-foreground/60">v1.0.0</span>
+        </Sidebar.Footer>
+      </Sidebar>
+    </div>
+  ),
+};

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -35,6 +35,7 @@ export default {
         'sqlite-plugin',
         'rhf-plugin',
         'ui',
+        'shell',
         '',
       ],
     ],

--- a/docs/workplace/shell-plugins-screen.md
+++ b/docs/workplace/shell-plugins-screen.md
@@ -1,0 +1,328 @@
+# Shell Plugins Screen
+
+## Status
+
+Draft for review. Derived from a confirmed statement of intent and from
+investigation evidence recorded under "Findings". The worker must treat the
+decisions and non-goals in this document as requirements. If implementation
+evidence invalidates a decision, stop and ask for direction instead of
+silently changing the design.
+
+## Objective
+
+Give shell mode a screen that answers "what plugins do I have, what do they
+expose, and are they current?".
+
+Shell mode collapsed every plugin behind a single DevTools tab, which removed
+the only surface that showed what was actually loaded. The screen restores
+that visibility. It is an inventory, not a diagnostic tool: a plugin that
+fails to load never reaches shell at all and therefore cannot appear here.
+
+For each plugin the screen shows:
+
+- package id
+- description
+- installed version, and a link to npm when a newer version exists
+- panels contributed by the plugin
+
+## Non-goals
+
+These are explicitly out of scope. Do not add them opportunistically.
+
+- A Settings container or nested settings navigation.
+- An About screen. The runtime version already surfaces through
+  `WelcomeDialog` and the sidebar footer.
+- A generic notices registry or any plugin-facing notification API.
+- A "copy diagnostics" action.
+- A `Skeleton` component in `@rozenite/ui`.
+- Semantic `Badge` variants. The only consumer was the agent tools row.
+- Any display of agent tools.
+- A server-side npm proxy in `@rozenite/middleware`.
+
+The last two are deferred, not rejected. See "Deferred decisions".
+
+## Findings
+
+Three investigation results constrain the design. They are recorded here
+because the design is only correct while they hold.
+
+### npm `/latest` is uncached and rate limited; the abbreviated packument is not
+
+Measured against the live registry with 26 `@rozenite/*` packages:
+
+| Endpoint | 780 requests (30 rounds x 26) | `cf-cache-status` |
+| --- | --- | --- |
+| `GET /<pkg>/latest` | 312 x HTTP 429, 7.6s, then a ~9 minute IP-wide ban | `DYNAMIC` |
+| `GET /<pkg>` with `Accept: application/vnd.npm.install-v1+json` | 780 x HTTP 200, 2.2s | `HIT` (773), `REVALIDATED` (7) |
+
+The abbreviated packument is CDN-cached, carries
+`cache-control: public, max-age=300`, and is the endpoint the npm CLI itself
+uses. It costs ~28KB per package against ~2.2KB for `/latest`, and its data
+can be up to 5 minutes stale. Both costs are accepted.
+
+`packages/shell/src/new-version.ts` currently uses `/latest`. That is the
+uncached endpoint and must change regardless of the rest of this work.
+
+### Plugin version is already fetched, then discarded
+
+`RozeniteManifest` declares `version` (`packages/runtime/src/manifest.ts`).
+`loadPluginFromUrl` logs it (`packages/runtime/src/plugin-loader.ts`) but does
+not return it, so it never reaches `ShellPlugin`. No protocol change is
+required to expose it.
+
+## Agreed architecture
+
+### Navigation
+
+A cog button in the sidebar footer opens a flat Plugins screen. There is no
+intermediate settings container.
+
+The screen replaces the panel iframe area. The sidebar stays mounted and
+visible. Panel iframes must not unmount while the screen is open, otherwise
+every plugin loses its state on a visit. Note that plugins listed in
+`destroyOnDetachPlugins` are already torn down when inactive; that existing
+behavior is unchanged and the screen must not extend it to other plugins.
+
+`ShellSelection` currently addresses a panel. It gains a screen case:
+
+```ts
+type ShellSelection =
+  | { kind: 'panel'; pluginId: string; panelId: string }
+  | { kind: 'plugins' };
+```
+
+`getInitialSelection` and the reconciliation effect in `Shell.tsx` keep their
+current behavior for the panel case. Selecting the cog sets `{ kind: 'plugins' }`
+and leaves the previously selected panel recorded so returning is possible.
+
+Selection is single-valued. While the Plugins screen is open the cog renders
+selected and no sidebar panel item renders selected; the remembered panel is
+restored, with its highlight, when the user navigates back to it. Two
+simultaneous selected affordances are not allowed.
+
+### Sidebar footer
+
+```
+expanded:   [ Update v1.2.3 ->  .................... ] [cog +dot] [collapse]
+collapsed:  [cog +dot] [collapse]
+```
+
+- The runtime update link keeps its current prominent text treatment. It is
+  already conditional and costs nothing when the runtime is current.
+- The cog carries an `IndicatorDot` when any plugin has an update. Plugin
+  updates get no other affordance anywhere in the UI.
+- Today the runtime update link is hidden entirely when the sidebar collapses.
+  That is a defect. When collapsed, the runtime update must remain reachable:
+  the cog's dot covers both signals and the Plugins screen carries the detail.
+
+### npm version checking
+
+One module, used by every npm version check in shell.
+
+```ts
+// packages/shell/src/npm/registry.ts
+
+/** Latest published version for each package, from the CDN-cached
+ *  abbreviated packument. Packages that fail to resolve are omitted. */
+export function getLatestVersions(
+  packageNames: string[],
+): Promise<Map<string, string>>;
+
+/** Semver-ish comparison. Returns false when `candidate` is not strictly
+ *  newer, including when it is a local or prerelease build ahead of npm. */
+export function isNewerVersion(current: string, candidate: string): boolean;
+```
+
+Requirements:
+
+- Requests use `Accept: application/vnd.npm.install-v1+json` against
+  `https://registry.npmjs.org/<encoded name>` and read `dist-tags.latest`.
+- Results are cached at module level for the lifetime of the shell document.
+  Mounting and unmounting the screen must not refetch.
+- Failure is silent. A registry outage must never surface an error state in
+  DevTools. Individual package failures are omitted from the result rather
+  than rejecting the whole call.
+- `new-version.ts` is refactored onto this module and deleted as a separate
+  fetch path. `NewVersionFooter` and the Plugins screen must share one
+  in-flight request, not two.
+
+This also fixes an existing defect: `new-version.ts` compares with
+`latestVersion === currentVersion`, so a local build newer than npm currently
+reports a spurious update. `isNewerVersion` replaces that. Equivalent logic
+already exists in `packages/chrome-extension/src/update-checker.ts`; that
+package cannot be imported from shell, so the shell implementation is written
+fresh and unit tested rather than shared.
+
+### `useOutdatedPlugins`
+
+```ts
+// packages/shell/src/plugins/use-outdated-plugins.ts
+
+export function useOutdatedPlugins(plugins: ShellPlugin[]): {
+  status: 'loading' | 'ready' | 'unavailable';
+  /** pluginId -> latest published version. Only entries strictly newer
+   *  than the installed version are present. */
+  outdated: Map<string, string>;
+};
+```
+
+Requirements:
+
+- This hook is the only caller of `getLatestVersions` for plugin packages.
+- The footer consumes `outdated.size > 0` and nothing else. The cog must not
+  know that npm, semver, or fetching exist.
+- `status: 'unavailable'` renders no dot and no error affordance.
+
+Do not generalize this into a notices abstraction. A second kind of notice
+does not exist yet.
+
+### Screen layout
+
+```
+PluginShell.Body
+  ScrollArea
+    header: "Plugins" + "N installed"
+    Card per plugin
+      title row:  <name>  [Badge: version]  [Link -> npm, when outdated]
+      description
+      DescriptionList
+        Panels      <panel names>
+```
+
+`DescriptionList` carries a single row today. It stays a list rather than a
+bare label/value pair because agent tools are a deferred second row and
+because the component is shared (see "`@rozenite/ui` changes").
+
+Plugins are listed in the order shell receives them. No search, no sort, no
+filtering; the expected population is under thirty entries.
+
+## `@rozenite/ui` changes
+
+Each component below ships with a story in `apps/ui-storybook/src/stories/`
+per `agents/working-on-ui-components.md`, and is exported from
+`packages/ui/src/index.ts` with its prop types.
+
+### New components
+
+| Component | API | Rationale |
+| --- | --- | --- |
+| `Separator` | `orientation?: 'horizontal' \| 'vertical'` | Extracted from `Toolbar.Separator`, which remains as an alias to the new component. No behavior change for existing consumers. |
+| `Link` | anchor props, `external?: boolean` | `NewVersionFooter` hand-rolls ~8 utility classes for exactly this; the screen is the second consumer. External links render the trailing arrow affordance and set `rel="noreferrer" target="_blank"`. |
+| `IndicatorDot` | `variant?`, sizing via className | Standalone so it can be composed into any adornment slot rather than special-cased on one component. |
+| `DescriptionList` | `DescriptionList` + `DescriptionList.Item` with `label` and `children` | See below. |
+| `Card` | `Card` + `Card.Header` + `Card.Body`, `collapsible?: boolean` | See below. |
+
+`DescriptionList` and `Card` are not speculative. Both already exist,
+independently reinvented, inside `network-activity-plugin`:
+`src/ui/components/KeyValueGrid.tsx` is a description list and
+`src/ui/components/Section.tsx` is a collapsible card, and `HeadersTab.tsx`
+composes them exactly as this screen will. `storage-plugin` and `mmkv-plugin`
+hand-roll stacked label/value pairs in their entry detail dialogs. The
+"wait for a second consumer" bar is already met twice over.
+
+Migrating `network-activity-plugin` onto the shared components is desirable
+but is a separate change and must not be bundled into this one. That plugin
+also carries its own `ScrollArea` and `cn` duplicating `@rozenite/ui`; note it
+and leave it.
+
+### Modified components
+
+| Component | Change |
+| --- | --- |
+| `Button` | New `adornment?: ReactNode` slot, rendered after children. Used to host `IndicatorDot` on the cog. Do not add an indicator-specific prop. |
+| `Sidebar` | Add `Sidebar.Header` and `Sidebar.Footer`. `Shell.tsx` currently hand-rolls both as raw `<header>`/`<footer>` with sticky and border classes; that markup moves into the components. |
+
+The existing `Badge` is used unchanged for the version label. Semantic
+variants were dropped along with the agent tools row; add them when something
+actually needs them.
+
+## Runtime changes
+
+`packages/runtime/src/plugin-loader.ts`:
+
+- `LoadedPlugin` gains `version: string`.
+- `loadPluginFromUrl` returns `manifest.version`.
+
+`packages/shell/src/types.ts`:
+
+- `ShellPlugin` gains `version: string`.
+
+No change to `global-namespace.ts`, `entry-point.ts`, or the `postMessage`
+contract. The value already travels inside `shellConfiguration`.
+
+## Testing
+
+- `registry.ts`: unit tests for `isNewerVersion` covering equal versions,
+  patch/minor/major increments, differing segment counts, and a local build
+  ahead of npm. Network calls are mocked; no test hits the registry.
+- `use-outdated-plugins.ts`: caching (one fetch across two mounts), silent
+  failure producing `unavailable`, and correct filtering to strictly-newer.
+- `selection.ts`: existing tests extended for the `plugins` screen case,
+  including that panel selection survives a visit to the screen.
+- Storybook stories for every new and modified `@rozenite/ui` component,
+  verified in the browser per `agents/working-on-ui-components.md`.
+- Existing `NewVersionFooter` tests updated for the shared module.
+
+## Version plan
+
+Required. `@rozenite/ui`, `@rozenite/shell`, and `@rozenite/runtime` all
+change behavior, and `@rozenite/*` packages are pinned in lockstep. Create it
+with `pnpm changeset` per `docs/agents/version-plans.md`.
+
+## Deferred decisions
+
+These are recorded so they are not rediscovered later.
+
+**Server-side version caching.** A `GET /rozenite/plugin-versions` route in
+the middleware would collapse N-reloads-by-M-plugins into M fetches per server
+lifetime, and `auto-discovery.ts` already exposes each plugin's on-disk path so
+installed versions need no network call at all. The CDN-cached endpoint makes
+this unnecessary for correctness. Revisit if request volume becomes a concern.
+
+**Agent tools.** Cut from this change. The investigation is recorded here so it
+does not have to be repeated.
+
+Where tools live:
+
+- Every plugin that exposes agent tools registers them from `src/react-native/`,
+  i.e. from the app, never from panel code. Ten plugins were checked; there are
+  zero panel-side registrations. A message sent to a panel iframe asking for its
+  tools would come back empty from every plugin.
+- Registration is fire-and-forget. `useRozenitePluginAgentTool`
+  (`packages/agent-bridge/src/useRozeniteAgentTool.ts`) sends `register-tool` on
+  mount and re-sends on `agent-session-ready`. Nothing app-side retains a
+  registry; the accumulator lives in the middleware session
+  (`packages/middleware/src/agent/session.ts`).
+- Tools are qualified `` `${pluginId}.${toolName}` ``, so attribution back to a
+  plugin is a prefix match with no new plumbing.
+
+Two ways to read them, both viable:
+
+1. *Middleware session.* `GET /rozenite/agent/sessions` then
+   `GET /rozenite/agent/sessions/:id/tools`, same-origin from shell since the
+   middleware serves both. No protocol change, but requires an active CLI agent
+   session, which is the uncommon case.
+2. *App bridge query.* Shell opens its own `plugin-bridge` client for
+   `AGENT_PLUGIN_ID` and asks the app directly. The transport already works:
+   `getPanelChannel` posts to `window.parent` and `plugin-view.ts` forwards to
+   the app over CDP. Needs a module-level tool registry plus a `list-tools`
+   handler added to `@rozenite/agent-bridge`. Works with no agent session.
+
+Option 2 is the better end state. It requires a change to a published package.
+
+Constraint that survives both options: tools exist only while their hook is
+mounted, so neither approach can report what a plugin *defines* — only what is
+live at that moment. Whatever ships must label the row accordingly ("Active
+tools", with an app-not-connected state) rather than implying a capability
+list.
+
+Declaring tools statically in `rozenite.json` was considered and rejected:
+plugin authors should not have to hand-maintain a list that can drift from what
+actually registers.
+
+## Resolved questions
+
+1. **Sidebar selected state.** The cog renders selected while the screen is
+   open, and selection stays single-valued. See "Navigation".
+2. **Alternate entry points.** None. The cog is the only way into the screen.
+   The welcome dialog does not link to it.

--- a/docs/workplace/shell-plugins-screen.md
+++ b/docs/workplace/shell-plugins-screen.md
@@ -114,6 +114,9 @@ collapsed:  [cog +dot] [collapse]
 - Today the runtime update link is hidden entirely when the sidebar collapses.
   That is a defect. When collapsed, the runtime update must remain reachable:
   the cog's dot covers both signals and the Plugins screen carries the detail.
+- The collapsed rail is 48px, too narrow for two icon buttons side by side.
+  The footer stacks vertically when collapsed. Laying them out in a row clips
+  the collapse button and strands the user with no way to expand again.
 
 ### npm version checking
 
@@ -176,6 +179,35 @@ Requirements:
 Do not generalize this into a notices abstraction. A second kind of notice
 does not exist yet.
 
+### Debug affordance
+
+The update states cannot otherwise be reached without a real npm release, so
+shell carries a debug panel that emulates them.
+
+Overrides are injected at the registry, not at the components:
+
+```ts
+// packages/shell/src/npm/registry.ts
+export function setVersionOverride(packageName: string, version: string | null): void;
+```
+
+`getLatestVersion` consults the override map before both its cache and the
+network. Everything above it — `useOutdatedPlugins`, the cog's dot,
+`NewVersionFooter`, the per-plugin npm link — therefore runs its production
+path against emulated data. A parallel "pretend" flag in the components would
+leave the real path unexercised and is not acceptable.
+
+Overrides persist in `sessionStorage` so a reload keeps the emulated state,
+which is what makes the initial-load path testable. Consumers re-resolve
+through `subscribeToVersionOverrides` / `getVersionOverridesRevision`.
+
+Gating lives in one module (`packages/shell/src/debug/debug-mode.ts`):
+`import.meta.env.DEV`, or `localStorage['rozenite.debug'] === '1'` so a
+released build can be driven into these states when reproducing a report.
+
+The panel renders as the last `Card` on the Plugins screen and is absent
+entirely when the flag is off.
+
 ### Screen layout
 
 ```
@@ -183,7 +215,7 @@ PluginShell.Body
   ScrollArea
     header: "Plugins" + "N installed"
     Card per plugin
-      title row:  <name>  [Badge: version]  [Link -> npm, when outdated]
+      title row:  <name>  ......  [Link -> npm, when outdated]  [Badge: version]
       description
       DescriptionList
         Panels      <panel names>
@@ -192,6 +224,10 @@ PluginShell.Body
 `DescriptionList` carries a single row today. It stays a list rather than a
 bare label/value pair because agent tools are a deferred second row and
 because the component is shared (see "`@rozenite/ui` changes").
+
+Version and npm link are right-aligned; the title keeps the left edge. Most
+manifests set `name` to the package name, so the package id renders as a
+second title line only when the two actually differ.
 
 Plugins are listed in the order shell receives them. No search, no sort, no
 filtering; the expected population is under thirty entries.

--- a/docs/workplace/shell-plugins-screen.md
+++ b/docs/workplace/shell-plugins-screen.md
@@ -225,6 +225,12 @@ PluginShell.Body
 bare label/value pair because agent tools are a deferred second row and
 because the component is shared (see "`@rozenite/ui` changes").
 
+When the runtime itself is behind, a notice card precedes the plugin list with
+the installed version, the latest version, and a link to the release notes.
+That is the detail the cog's dot promises when the sidebar is collapsed and
+the footer link is out of reach. It is a single conditional row, not the
+About screen the non-goals rule out: it appears only when an update exists.
+
 Version and npm link are right-aligned; the title keeps the left edge. Most
 manifests set `name` to the package name, so the package id renders as a
 second title line only when the two actually differ.

--- a/packages/runtime/src/plugin-loader.ts
+++ b/packages/runtime/src/plugin-loader.ts
@@ -4,6 +4,7 @@ export type LoadedPlugin = {
   id: string;
   name: string;
   description: string;
+  version: string;
   panels: {
     id: string;
     name: string;
@@ -32,6 +33,7 @@ export const loadPluginFromUrl = async (url: string, pluginId?: string): Promise
     id,
     name: manifest.name,
     description: manifest.description,
+    version: manifest.version,
     panels: manifest.panels.map((panel) => ({
       id: `${id}:${panel.name}`,
       name: panel.name,

--- a/packages/shell/package.json
+++ b/packages/shell/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.2",
+    "@testing-library/react": "^16.1.0",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "typescript": "~5.9.3",

--- a/packages/shell/src/NewVersionFooter.test.ts
+++ b/packages/shell/src/NewVersionFooter.test.ts
@@ -1,39 +1,53 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { getAvailableRuntimeVersion } from './new-version';
 
 const originalFetch = globalThis.fetch;
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+  vi.resetModules();
 });
 
 describe('getAvailableRuntimeVersion', () => {
   it('returns the npm version when it differs from the installed runtime', async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ version: '1.14.0' }),
+      json: async () => ({ 'dist-tags': { latest: '1.14.0' } }),
     });
 
+    const { getAvailableRuntimeVersion } = await import('./new-version');
     await expect(getAvailableRuntimeVersion('1.13.0')).resolves.toBe('1.14.0');
   });
 
   it('returns null when the installed runtime is current', async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ version: '1.13.0' }),
+      json: async () => ({ 'dist-tags': { latest: '1.13.0' } }),
     });
 
+    const { getAvailableRuntimeVersion } = await import('./new-version');
     await expect(getAvailableRuntimeVersion('1.13.0')).resolves.toBeNull();
   });
 
-  it('rejects failed npm requests', async () => {
+  // Regression guard: new-version.ts used to compare with
+  // `latestVersion === currentVersion`, so a local build ahead of npm
+  // reported a spurious update.
+  it('returns null when the local build is ahead of npm', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ 'dist-tags': { latest: '1.13.0' } }),
+    });
+
+    const { getAvailableRuntimeVersion } = await import('./new-version');
+    await expect(getAvailableRuntimeVersion('1.14.0-dev.1')).resolves.toBeNull();
+  });
+
+  it('returns null instead of rejecting when the registry request fails', async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: false,
       status: 503,
     });
 
-    await expect(getAvailableRuntimeVersion('1.13.0')).rejects.toThrow(
-      'Failed to fetch the latest Rozenite version: 503',
-    );
+    const { getAvailableRuntimeVersion } = await import('./new-version');
+    await expect(getAvailableRuntimeVersion('1.13.0')).resolves.toBeNull();
   });
 });

--- a/packages/shell/src/NewVersionFooter.tsx
+++ b/packages/shell/src/NewVersionFooter.tsx
@@ -1,5 +1,5 @@
-import { ArrowUpRight } from 'lucide-react';
 import { useEffect, useState } from 'react';
+import { Link } from '@rozenite/ui';
 import { getAvailableRuntimeVersion } from './new-version';
 
 const RELEASES_URL = 'https://github.com/callstackincubator/rozenite/releases';
@@ -40,17 +40,12 @@ export function NewVersionFooter({ currentVersion }: NewVersionFooterProps) {
   }
 
   return (
-    <a
-      className="group flex h-8 min-w-0 flex-1 items-center gap-1.5 px-2 text-xs font-medium text-sidebar-foreground outline-none transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 focus-visible:ring-sidebar-ring"
+    <Link
       href={RELEASES_URL}
-      rel="noreferrer"
-      target="_blank"
+      external
+      className="h-8 min-w-0 flex-1 justify-start px-2 text-xs font-medium text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:no-underline focus-visible:ring-sidebar-ring"
     >
       <span className="truncate">{updateLabel}</span>
-      <ArrowUpRight
-        aria-hidden="true"
-        className="size-3.5 shrink-0 text-sidebar-foreground/50 transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5"
-      />
-    </a>
+    </Link>
   );
 }

--- a/packages/shell/src/NewVersionFooter.tsx
+++ b/packages/shell/src/NewVersionFooter.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useSyncExternalStore } from 'react';
 import { Link } from '@rozenite/ui';
 import { getAvailableRuntimeVersion } from './new-version';
+import { getVersionOverridesRevision, subscribeToVersionOverrides } from './npm/registry';
 
 const RELEASES_URL = 'https://github.com/callstackincubator/rozenite/releases';
 
@@ -10,6 +11,10 @@ type NewVersionFooterProps = {
 
 export function NewVersionFooter({ currentVersion }: NewVersionFooterProps) {
   const [latestVersion, setLatestVersion] = useState<string | null>(null);
+  const overridesRevision = useSyncExternalStore(
+    subscribeToVersionOverrides,
+    getVersionOverridesRevision,
+  );
 
   useEffect(() => {
     if (!currentVersion) {
@@ -31,7 +36,7 @@ export function NewVersionFooter({ currentVersion }: NewVersionFooterProps) {
     return () => {
       cancelled = true;
     };
-  }, [currentVersion]);
+  }, [currentVersion, overridesRevision]);
 
   const updateLabel = latestVersion ? `Update v${latestVersion}` : null;
 

--- a/packages/shell/src/Shell.tsx
+++ b/packages/shell/src/Shell.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 import { PanelLeftClose, PanelLeftOpen, Settings } from 'lucide-react';
 import {
   Button,
@@ -26,6 +26,7 @@ import { WelcomeDialog } from './WelcomeDialog';
 import { getAvailableRuntimeVersion } from './new-version';
 import { PluginsScreen } from './plugins/PluginsScreen';
 import { useOutdatedPlugins } from './plugins/use-outdated-plugins';
+import { getVersionOverridesRevision, subscribeToVersionOverrides } from './npm/registry';
 import type { ShellConfiguration, ShellPanel, ShellPlugin } from './types';
 
 const SHELL_CONFIGURATION_TYPE = 'rozenite-shell-configuration';
@@ -42,6 +43,10 @@ export function Shell({ plugins, destroyOnDetachPlugins, runtimeVersion }: Shell
   const contentFrames = useRef(new Map<string, HTMLIFrameElement>());
   const sidebarPanel = useRef<SplitPaneHandle>(null);
   const { outdated } = useOutdatedPlugins(plugins);
+  const overridesRevision = useSyncExternalStore(
+    subscribeToVersionOverrides,
+    getVersionOverridesRevision,
+  );
 
   useEffect(() => {
     setSelectionState((current) => reconcileSelection(current, plugins));
@@ -63,7 +68,7 @@ export function Shell({ plugins, destroyOnDetachPlugins, runtimeVersion }: Shell
     return () => {
       cancelled = true;
     };
-  }, [runtimeVersion]);
+  }, [runtimeVersion, overridesRevision]);
 
   useEffect(() => {
     const forwardToPanels = (event: MessageEvent) => {
@@ -223,13 +228,16 @@ export function Shell({ plugins, destroyOnDetachPlugins, runtimeVersion }: Shell
                   </div>
                 </div>
               )}
-              <Sidebar.Footer>
+              {/* Collapsed, the rail is too narrow for two icon buttons side by
+                  side; stacking keeps the expand button reachable instead of
+                  clipping it and stranding the user in the collapsed state. */}
+              <Sidebar.Footer className={cn(isSidebarCollapsed && 'flex-col items-center')}>
                 {!isSidebarCollapsed && <NewVersionFooter currentVersion={runtimeVersion} />}
                 <Button
                   variant="ghost"
                   size="icon"
                   className={cn(
-                    'ml-auto',
+                    !isSidebarCollapsed && 'ml-auto',
                     isPluginsScreenOpen && 'bg-sidebar-accent text-sidebar-accent-foreground',
                   )}
                   aria-label="Plugins"
@@ -293,7 +301,11 @@ export function Shell({ plugins, destroyOnDetachPlugins, runtimeVersion }: Shell
               </div>
               {isPluginsScreenOpen && (
                 <div className="absolute inset-0">
-                  <PluginsScreen plugins={plugins} outdated={outdated} />
+                  <PluginsScreen
+                    plugins={plugins}
+                    outdated={outdated}
+                    runtimeVersion={runtimeVersion}
+                  />
                 </div>
               )}
             </div>

--- a/packages/shell/src/Shell.tsx
+++ b/packages/shell/src/Shell.tsx
@@ -39,7 +39,7 @@ export function Shell({ plugins, destroyOnDetachPlugins, runtimeVersion }: Shell
     getInitialSelectionState(plugins),
   );
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
-  const [hasRuntimeUpdate, setHasRuntimeUpdate] = useState(false);
+  const [runtimeUpdate, setRuntimeUpdate] = useState<string | null>(null);
   const contentFrames = useRef(new Map<string, HTMLIFrameElement>());
   const sidebarPanel = useRef<SplitPaneHandle>(null);
   const { outdated } = useOutdatedPlugins(plugins);
@@ -61,7 +61,7 @@ export function Shell({ plugins, destroyOnDetachPlugins, runtimeVersion }: Shell
 
     void getAvailableRuntimeVersion(runtimeVersion).then((version) => {
       if (!cancelled) {
-        setHasRuntimeUpdate(version !== null);
+        setRuntimeUpdate(version);
       }
     });
 
@@ -154,7 +154,7 @@ export function Shell({ plugins, destroyOnDetachPlugins, runtimeVersion }: Shell
   // only otherwise surfaced on the Plugins screen; the runtime update link
   // is hidden while the sidebar is collapsed, so its dot keeps that signal
   // reachable too (expanding the sidebar reveals the link again).
-  const hasNotice = outdated.size > 0 || hasRuntimeUpdate;
+  const hasNotice = outdated.size > 0 || runtimeUpdate !== null;
 
   return (
     <PluginShell>
@@ -299,12 +299,16 @@ export function Shell({ plugins, destroyOnDetachPlugins, runtimeVersion }: Shell
                   </div>
                 )}
               </div>
+              {/* Flex column so PluginShell.Body's `flex-1` has a parent to
+                  resolve against; without it the body's height falls to auto
+                  and the screen's ScrollArea grows instead of scrolling. */}
               {isPluginsScreenOpen && (
-                <div className="absolute inset-0">
+                <div className="absolute inset-0 flex flex-col">
                   <PluginsScreen
                     plugins={plugins}
                     outdated={outdated}
                     runtimeVersion={runtimeVersion}
+                    runtimeUpdate={runtimeUpdate}
                   />
                 </div>
               )}

--- a/packages/shell/src/Shell.tsx
+++ b/packages/shell/src/Shell.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { PanelLeftClose, PanelLeftOpen } from 'lucide-react';
+import { PanelLeftClose, PanelLeftOpen, Settings } from 'lucide-react';
 import {
   Button,
+  cn,
   EmptyState,
+  IndicatorDot,
   PluginShell,
   Sidebar,
   Split,
@@ -11,37 +13,57 @@ import {
 import compactLogo from '../../../website/src/public/logo.svg';
 import lightLogo from '../../../website/src/public/logo-light.svg';
 import darkLogo from '../../../website/src/public/logo-dark.svg';
-import { getInitialSelection, type ShellSelection } from './selection';
+import {
+  closePluginsScreen,
+  getInitialSelectionState,
+  openPluginsScreen,
+  reconcileSelection,
+  selectPanel as selectPanelSelection,
+  type SelectionState,
+} from './selection';
 import { NewVersionFooter } from './NewVersionFooter';
 import { WelcomeDialog } from './WelcomeDialog';
+import { getAvailableRuntimeVersion } from './new-version';
+import { PluginsScreen } from './plugins/PluginsScreen';
+import { useOutdatedPlugins } from './plugins/use-outdated-plugins';
 import type { ShellConfiguration, ShellPanel, ShellPlugin } from './types';
 
 const SHELL_CONFIGURATION_TYPE = 'rozenite-shell-configuration';
 const COLLAPSED_SIDEBAR_WIDTH = 48;
 const EXPANDED_SIDEBAR_WIDTH = 224;
 const SIDEBAR_SNAP_POINT = (COLLAPSED_SIDEBAR_WIDTH + EXPANDED_SIDEBAR_WIDTH) / 2;
+
 export function Shell({ plugins, destroyOnDetachPlugins, runtimeVersion }: ShellConfiguration) {
-  const [selection, setSelection] = useState<ShellSelection>(() => getInitialSelection(plugins));
+  const [selectionState, setSelectionState] = useState<SelectionState>(() =>
+    getInitialSelectionState(plugins),
+  );
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
+  const [hasRuntimeUpdate, setHasRuntimeUpdate] = useState(false);
   const contentFrames = useRef(new Map<string, HTMLIFrameElement>());
   const sidebarPanel = useRef<SplitPaneHandle>(null);
+  const { outdated } = useOutdatedPlugins(plugins);
 
   useEffect(() => {
-    setSelection((current) => {
-      if (
-        current &&
-        plugins.some(
-          (plugin) =>
-            plugin.id === current.pluginId &&
-            plugin.panels.some((panel) => panel.id === current.panelId),
-        )
-      ) {
-        return current;
-      }
-
-      return getInitialSelection(plugins);
-    });
+    setSelectionState((current) => reconcileSelection(current, plugins));
   }, [plugins]);
+
+  useEffect(() => {
+    if (!runtimeVersion) {
+      return;
+    }
+
+    let cancelled = false;
+
+    void getAvailableRuntimeVersion(runtimeVersion).then((version) => {
+      if (!cancelled) {
+        setHasRuntimeUpdate(version !== null);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [runtimeVersion]);
 
   useEffect(() => {
     const forwardToPanels = (event: MessageEvent) => {
@@ -63,15 +85,35 @@ export function Shell({ plugins, destroyOnDetachPlugins, runtimeVersion }: Shell
     return () => window.removeEventListener('message', forwardToPanels);
   }, []);
 
+  const isPluginsScreenOpen = selectionState.selection?.kind === 'plugins';
+  const panelSelection =
+    selectionState.selection?.kind === 'panel' ? selectionState.selection : null;
   const activePlugin = useMemo(
-    () => plugins.find((plugin) => plugin.id === selection?.pluginId) ?? null,
-    [plugins, selection?.pluginId],
+    () => plugins.find((plugin) => plugin.id === panelSelection?.pluginId) ?? null,
+    [plugins, panelSelection?.pluginId],
   );
-  const activePanel = activePlugin?.panels.find((panel) => panel.id === selection?.panelId);
+  const activePanel =
+    activePlugin?.panels.find((panel) => panel.id === panelSelection?.panelId) ?? null;
+  // Distinct from `activePanel`: while the Plugins screen is open there is no
+  // active panel, but the panel selected before the screen opened must stay
+  // mounted (just hidden) so a `destroyOnDetach` plugin doesn't lose state on
+  // a visit to the screen.
+  const retainedPanelId =
+    panelSelection?.panelId ??
+    (isPluginsScreenOpen ? (selectionState.lastPanel?.panelId ?? null) : null);
   const destroyedPluginIds = new Set(destroyOnDetachPlugins);
   const panels = plugins.flatMap((plugin) => plugin.panels.map((panel) => ({ plugin, panel })));
+  const hasPlugins = plugins.length > 0;
+
   const selectPanel = (plugin: ShellPlugin, panel: ShellPanel) => {
-    setSelection({ pluginId: plugin.id, panelId: panel.id });
+    setSelectionState(selectPanelSelection(plugin.id, panel.id));
+  };
+  const togglePluginsScreen = () => {
+    setSelectionState((current) =>
+      current.selection?.kind === 'plugins'
+        ? closePluginsScreen(current, plugins)
+        : openPluginsScreen(current),
+    );
   };
   const resizeSidebar = (collapsed: boolean) => {
     sidebarPanel.current?.resize(
@@ -89,7 +131,7 @@ export function Shell({ plugins, destroyOnDetachPlugins, runtimeVersion }: Shell
     resizeSidebar(size < SIDEBAR_SNAP_POINT);
   };
 
-  if (!activePlugin || !activePanel) {
+  if (!hasPlugins) {
     return (
       <PluginShell>
         <WelcomeDialog runtimeVersion={runtimeVersion} />
@@ -102,6 +144,12 @@ export function Shell({ plugins, destroyOnDetachPlugins, runtimeVersion }: Shell
       </PluginShell>
     );
   }
+
+  // The cog's dot flags either kind of pending update. Plugin updates are
+  // only otherwise surfaced on the Plugins screen; the runtime update link
+  // is hidden while the sidebar is collapsed, so its dot keeps that signal
+  // reachable too (expanding the sidebar reveals the link again).
+  const hasNotice = outdated.size > 0 || hasRuntimeUpdate;
 
   return (
     <PluginShell>
@@ -126,7 +174,7 @@ export function Shell({ plugins, destroyOnDetachPlugins, runtimeVersion }: Shell
               aria-label="Rozenite panels"
               className="h-full w-full gap-0 overflow-hidden border-r-0 p-0"
             >
-              <header className="sticky top-0 z-10 flex h-12 shrink-0 items-center border-b border-sidebar-border bg-sidebar px-3">
+              <Sidebar.Header>
                 {isSidebarCollapsed ? (
                   <img src={compactLogo} alt="Rozenite" className="h-6 w-6" />
                 ) : (
@@ -135,7 +183,7 @@ export function Shell({ plugins, destroyOnDetachPlugins, runtimeVersion }: Shell
                     <img src={darkLogo} alt="Rozenite" className="hidden h-6 w-auto dark:block" />
                   </>
                 )}
-              </header>
+              </Sidebar.Header>
               {!isSidebarCollapsed && (
                 <div className="min-h-0 flex-1 overflow-y-auto p-2">
                   <div className="flex flex-col gap-3">
@@ -150,7 +198,7 @@ export function Shell({ plugins, destroyOnDetachPlugins, runtimeVersion }: Shell
                         return (
                           <Sidebar.Item
                             key={panel.id}
-                            selected={panel.id === activePanel.id}
+                            selected={!isPluginsScreenOpen && panel.id === activePanel?.id}
                             onClick={() => selectPanel(plugin, panel)}
                           >
                             {panel.name}
@@ -163,7 +211,7 @@ export function Shell({ plugins, destroyOnDetachPlugins, runtimeVersion }: Shell
                           {plugin.panels.map((panel) => (
                             <Sidebar.Item
                               key={panel.id}
-                              selected={panel.id === activePanel.id}
+                              selected={!isPluginsScreenOpen && panel.id === activePanel?.id}
                               onClick={() => selectPanel(plugin, panel)}
                             >
                               {panel.name}
@@ -175,47 +223,79 @@ export function Shell({ plugins, destroyOnDetachPlugins, runtimeVersion }: Shell
                   </div>
                 </div>
               )}
-              <footer className="mt-auto flex shrink-0 gap-1 border-t border-sidebar-border p-2">
+              <Sidebar.Footer>
                 {!isSidebarCollapsed && <NewVersionFooter currentVersion={runtimeVersion} />}
                 <Button
                   variant="ghost"
                   size="icon"
-                  className="ml-auto"
+                  className={cn(
+                    'ml-auto',
+                    isPluginsScreenOpen && 'bg-sidebar-accent text-sidebar-accent-foreground',
+                  )}
+                  aria-label="Plugins"
+                  aria-pressed={isPluginsScreenOpen}
+                  onClick={togglePluginsScreen}
+                  adornment={hasNotice ? <IndicatorDot className="absolute top-1 right-1" /> : null}
+                >
+                  <Settings />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
                   aria-label={isSidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
                   onClick={() => resizeSidebar(!isSidebarCollapsed)}
                 >
                   {isSidebarCollapsed ? <PanelLeftOpen /> : <PanelLeftClose />}
                 </Button>
-              </footer>
+              </Sidebar.Footer>
             </Sidebar>
           </Split.Pane>
           <Split.Handle className="bg-sidebar-border" />
           <Split.Pane>
-            <div className="h-full min-w-0">
-              {panels.map(({ plugin, panel }) => {
-                const isActive = panel.id === activePanel.id;
-                const shouldDestroy = destroyedPluginIds.has(plugin.id);
+            <div className="relative h-full min-w-0">
+              {/* Panel iframes stay mounted while the Plugins screen is open;
+                  it only covers this area visually so plugin state survives
+                  a visit. */}
+              <div className={cn('h-full min-w-0', isPluginsScreenOpen && 'hidden')}>
+                {panels.map(({ plugin, panel }) => {
+                  const isActive = panel.id === activePanel?.id;
+                  const isRetained = panel.id === retainedPanelId;
+                  const shouldDestroy = destroyedPluginIds.has(plugin.id);
 
-                if (shouldDestroy && !isActive) {
-                  return null;
-                }
+                  if (shouldDestroy && !isRetained) {
+                    return null;
+                  }
 
-                return (
-                  <iframe
-                    key={panel.id}
-                    ref={(frame) => {
-                      if (frame) {
-                        contentFrames.current.set(panel.id, frame);
-                      } else {
-                        contentFrames.current.delete(panel.id);
-                      }
-                    }}
-                    hidden={!isActive}
-                    title={`${plugin.name}: ${panel.name}`}
-                    src={panel.source}
-                  />
-                );
-              })}
+                  return (
+                    <iframe
+                      key={panel.id}
+                      ref={(frame) => {
+                        if (frame) {
+                          contentFrames.current.set(panel.id, frame);
+                        } else {
+                          contentFrames.current.delete(panel.id);
+                        }
+                      }}
+                      hidden={!isActive}
+                      title={`${plugin.name}: ${panel.name}`}
+                      src={panel.source}
+                    />
+                  );
+                })}
+                {!activePanel && (
+                  <div className="flex h-full items-center justify-center">
+                    <EmptyState
+                      title="No panel selected"
+                      description="Select a panel from the sidebar."
+                    />
+                  </div>
+                )}
+              </div>
+              {isPluginsScreenOpen && (
+                <div className="absolute inset-0">
+                  <PluginsScreen plugins={plugins} outdated={outdated} />
+                </div>
+              )}
             </div>
           </Split.Pane>
         </Split>

--- a/packages/shell/src/debug/DebugCard.tsx
+++ b/packages/shell/src/debug/DebugCard.tsx
@@ -1,0 +1,87 @@
+import { Button, Card, DescriptionList, Switch } from '@rozenite/ui';
+import {
+  getVersionOverrides,
+  getVersionOverridesRevision,
+  setVersionOverride,
+  subscribeToVersionOverrides,
+} from '../npm/registry';
+import type { ShellPlugin } from '../types';
+import { useSyncExternalStore } from 'react';
+
+const RUNTIME_PACKAGE_NAME = '@rozenite/runtime';
+
+/** A version comfortably ahead of anything real, so the override reads as an
+ *  update regardless of what is actually installed. */
+function emulatedNewerVersion(currentVersion: string): string {
+  const [major] = currentVersion.split('.');
+  const majorNumber = Number.parseInt(major, 10);
+
+  return `${Number.isNaN(majorNumber) ? 1 : majorNumber + 1}.0.0`;
+}
+
+type DebugCardProps = {
+  plugins: ShellPlugin[];
+  runtimeVersion?: string;
+};
+
+/** Drives the update states into view without waiting on a real npm release.
+ *  Overrides are injected at the registry, so everything above it — the cog's
+ *  dot, the footer link, the per-plugin npm link — runs its production path. */
+export function DebugCard({ plugins, runtimeVersion }: DebugCardProps) {
+  useSyncExternalStore(subscribeToVersionOverrides, getVersionOverridesRevision);
+  const overrides = getVersionOverrides();
+
+  const isRuntimeOverridden = overrides.has(RUNTIME_PACKAGE_NAME);
+  const arePluginsOverridden = plugins.some((plugin) => overrides.has(plugin.id));
+
+  const toggleRuntime = (emulate: boolean) => {
+    setVersionOverride(
+      RUNTIME_PACKAGE_NAME,
+      emulate ? emulatedNewerVersion(runtimeVersion ?? '0.0.0') : null,
+    );
+  };
+
+  const togglePlugins = (emulate: boolean) => {
+    for (const plugin of plugins) {
+      setVersionOverride(plugin.id, emulate ? emulatedNewerVersion(plugin.version) : null);
+    }
+  };
+
+  const reset = () => {
+    for (const packageName of [...overrides.keys()]) {
+      setVersionOverride(packageName, null);
+    }
+  };
+
+  return (
+    <Card>
+      <Card.Header>
+        <span className="font-medium">Debug</span>
+        <span className="text-xs text-muted-foreground">
+          Emulated states, not real registry data
+        </span>
+        <Button variant="ghost" size="compact" className="ml-auto" onClick={reset}>
+          Reset
+        </Button>
+      </Card.Header>
+      <Card.Body>
+        <DescriptionList>
+          <DescriptionList.Item label="Rozenite update available">
+            <Switch
+              checked={isRuntimeOverridden}
+              onCheckedChange={toggleRuntime}
+              disabled={!runtimeVersion}
+            />
+          </DescriptionList.Item>
+          <DescriptionList.Item label="Plugin updates available">
+            <Switch
+              checked={arePluginsOverridden}
+              onCheckedChange={togglePlugins}
+              disabled={plugins.length === 0}
+            />
+          </DescriptionList.Item>
+        </DescriptionList>
+      </Card.Body>
+    </Card>
+  );
+}

--- a/packages/shell/src/debug/debug-mode.ts
+++ b/packages/shell/src/debug/debug-mode.ts
@@ -1,0 +1,19 @@
+const DEBUG_STORAGE_KEY = 'rozenite.debug';
+
+/** Whether shell's debug affordances are available. Always on when running
+ *  from source; otherwise opt in from the shell frame's console with
+ *  `localStorage.setItem('rozenite.debug', '1')` so a released build can be
+ *  driven into states that would otherwise need a real npm release. */
+export function isDebugEnabled(): boolean {
+  if (import.meta.env.DEV) {
+    return true;
+  }
+
+  try {
+    return localStorage.getItem(DEBUG_STORAGE_KEY) === '1';
+  } catch {
+    // Storage can be unavailable in a sandboxed frame. Debug is off, which
+    // is the same as the default.
+    return false;
+  }
+}

--- a/packages/shell/src/new-version.ts
+++ b/packages/shell/src/new-version.ts
@@ -1,27 +1,14 @@
-const NPM_RUNTIME_URL = 'https://registry.npmjs.org/%40rozenite%2Fruntime/latest';
+import { getLatestVersions, isNewerVersion } from './npm/registry';
 
-type NpmPackageMetadata = {
-  version?: unknown;
-};
-
-async function fetchLatestRuntimeVersion(): Promise<string> {
-  const response = await fetch(NPM_RUNTIME_URL);
-
-  if (!response.ok) {
-    throw new Error(`Failed to fetch the latest Rozenite version: ${response.status}`);
-  }
-
-  const metadata = (await response.json()) as NpmPackageMetadata;
-
-  if (typeof metadata.version !== 'string') {
-    throw new Error('The npm response did not contain a package version.');
-  }
-
-  return metadata.version;
-}
+const RUNTIME_PACKAGE_NAME = '@rozenite/runtime';
 
 export async function getAvailableRuntimeVersion(currentVersion: string): Promise<string | null> {
-  const latestVersion = await fetchLatestRuntimeVersion();
+  const latestVersions = await getLatestVersions([RUNTIME_PACKAGE_NAME]);
+  const latestVersion = latestVersions.get(RUNTIME_PACKAGE_NAME);
 
-  return latestVersion === currentVersion ? null : latestVersion;
+  if (!latestVersion || !isNewerVersion(currentVersion, latestVersion)) {
+    return null;
+  }
+
+  return latestVersion;
 }

--- a/packages/shell/src/npm/registry.test.ts
+++ b/packages/shell/src/npm/registry.test.ts
@@ -58,9 +58,10 @@ describe('getLatestVersions', () => {
     expect(result.get('@rozenite/runtime')).toBe('2.0.0');
     expect(globalThis.fetch).toHaveBeenCalledWith(
       'https://registry.npmjs.org/%40rozenite%2Fruntime',
-      {
+      expect.objectContaining({
         headers: { Accept: 'application/vnd.npm.install-v1+json' },
-      },
+        signal: expect.any(AbortSignal),
+      }),
     );
   });
 

--- a/packages/shell/src/npm/registry.test.ts
+++ b/packages/shell/src/npm/registry.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.resetModules();
+});
+
+describe('isNewerVersion', () => {
+  it('returns false for equal versions', async () => {
+    const { isNewerVersion } = await import('./registry');
+    expect(isNewerVersion('1.2.3', '1.2.3')).toBe(false);
+  });
+
+  it('detects a patch bump', async () => {
+    const { isNewerVersion } = await import('./registry');
+    expect(isNewerVersion('1.2.3', '1.2.4')).toBe(true);
+  });
+
+  it('detects a minor bump', async () => {
+    const { isNewerVersion } = await import('./registry');
+    expect(isNewerVersion('1.2.3', '1.3.0')).toBe(true);
+  });
+
+  it('detects a major bump', async () => {
+    const { isNewerVersion } = await import('./registry');
+    expect(isNewerVersion('1.2.3', '2.0.0')).toBe(true);
+  });
+
+  it('treats differing segment counts as zero-padded', async () => {
+    const { isNewerVersion } = await import('./registry');
+    expect(isNewerVersion('1.2', '1.2.0')).toBe(false);
+    expect(isNewerVersion('1.2', '1.3')).toBe(true);
+  });
+
+  it('returns false when the current build is a local build ahead of npm', async () => {
+    const { isNewerVersion } = await import('./registry');
+    expect(isNewerVersion('1.15.0-dev.3', '1.14.0')).toBe(false);
+  });
+
+  it('returns false when the only difference is a prerelease tag', async () => {
+    const { isNewerVersion } = await import('./registry');
+    expect(isNewerVersion('1.14.0', '1.14.0-beta.1')).toBe(false);
+  });
+});
+
+describe('getLatestVersions', () => {
+  it('resolves dist-tags.latest from the abbreviated packument', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ 'dist-tags': { latest: '2.0.0' } }),
+    });
+
+    const { getLatestVersions } = await import('./registry');
+    const result = await getLatestVersions(['@rozenite/runtime']);
+
+    expect(result.get('@rozenite/runtime')).toBe('2.0.0');
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'https://registry.npmjs.org/%40rozenite%2Fruntime',
+      {
+        headers: { Accept: 'application/vnd.npm.install-v1+json' },
+      },
+    );
+  });
+
+  it('omits packages that fail to resolve rather than rejecting the whole call', async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ 'dist-tags': { latest: '2.0.0' } }) })
+      .mockResolvedValueOnce({ ok: false, status: 500 });
+
+    const { getLatestVersions } = await import('./registry');
+    const result = await getLatestVersions(['@rozenite/a', '@rozenite/b']);
+
+    expect(result.get('@rozenite/a')).toBe('2.0.0');
+    expect(result.has('@rozenite/b')).toBe(false);
+  });
+
+  it('never rejects when the registry is unreachable', async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error('network down'));
+
+    const { getLatestVersions } = await import('./registry');
+    await expect(getLatestVersions(['@rozenite/runtime'])).resolves.toEqual(new Map());
+  });
+
+  it('caches results at module level, so a later call does not refetch', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ 'dist-tags': { latest: '2.0.0' } }),
+    });
+    globalThis.fetch = fetchMock;
+
+    const { getLatestVersions } = await import('./registry');
+    await getLatestVersions(['@rozenite/runtime']);
+    await getLatestVersions(['@rozenite/runtime']);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('dedupes concurrent in-flight requests for the same package', async () => {
+    let resolveFetch: (value: unknown) => void = () => {};
+    const fetchMock = vi.fn().mockReturnValue(
+      new Promise((resolve) => {
+        resolveFetch = resolve;
+      }),
+    );
+    globalThis.fetch = fetchMock;
+
+    const { getLatestVersions } = await import('./registry');
+    const first = getLatestVersions(['@rozenite/runtime']);
+    const second = getLatestVersions(['@rozenite/runtime']);
+
+    resolveFetch({ ok: true, json: async () => ({ 'dist-tags': { latest: '2.0.0' } }) });
+
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(firstResult.get('@rozenite/runtime')).toBe('2.0.0');
+    expect(secondResult.get('@rozenite/runtime')).toBe('2.0.0');
+  });
+});

--- a/packages/shell/src/npm/registry.test.ts
+++ b/packages/shell/src/npm/registry.test.ts
@@ -120,3 +120,53 @@ describe('getLatestVersions', () => {
     expect(secondResult.get('@rozenite/runtime')).toBe('2.0.0');
   });
 });
+
+describe('version overrides', () => {
+  it('short-circuits the network for an overridden package', async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock;
+
+    const { getLatestVersions, setVersionOverride } = await import('./registry');
+    setVersionOverride('@rozenite/runtime', '9.0.0');
+
+    const versions = await getLatestVersions(['@rozenite/runtime']);
+
+    expect(versions.get('@rozenite/runtime')).toBe('9.0.0');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the registry once an override is cleared', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ 'dist-tags': { latest: '1.0.0' } }),
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const { getLatestVersions, setVersionOverride } = await import('./registry');
+    setVersionOverride('@rozenite/runtime', '9.0.0');
+    setVersionOverride('@rozenite/runtime', null);
+
+    const versions = await getLatestVersions(['@rozenite/runtime']);
+
+    expect(versions.get('@rozenite/runtime')).toBe('1.0.0');
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it('notifies subscribers and bumps the revision on change', async () => {
+    const { getVersionOverridesRevision, setVersionOverride, subscribeToVersionOverrides } =
+      await import('./registry');
+
+    const listener = vi.fn();
+    const unsubscribe = subscribeToVersionOverrides(listener);
+    const before = getVersionOverridesRevision();
+
+    setVersionOverride('@rozenite/runtime', '9.0.0');
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(getVersionOverridesRevision()).toBeGreaterThan(before);
+
+    unsubscribe();
+    setVersionOverride('@rozenite/runtime', null);
+    expect(listener).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/shell/src/npm/registry.ts
+++ b/packages/shell/src/npm/registry.ts
@@ -1,4 +1,5 @@
 const ABBREVIATED_PACKUMENT_ACCEPT = 'application/vnd.npm.install-v1+json';
+const REQUEST_TIMEOUT_MS = 10_000;
 
 type AbbreviatedPackument = {
   'dist-tags'?: {
@@ -39,6 +40,10 @@ async function fetchLatestVersion(packageName: string): Promise<string | null> {
   try {
     const response = await fetch(`https://registry.npmjs.org/${encodeURIComponent(packageName)}`, {
       headers: { Accept: ABBREVIATED_PACKUMENT_ACCEPT },
+      // Without a deadline a stalled response leaves this request pending
+      // forever, and every later caller would join that dead promise through
+      // the in-flight map rather than retrying.
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     });
 
     if (!response.ok) {

--- a/packages/shell/src/npm/registry.ts
+++ b/packages/shell/src/npm/registry.ts
@@ -1,0 +1,108 @@
+const ABBREVIATED_PACKUMENT_ACCEPT = 'application/vnd.npm.install-v1+json';
+
+type AbbreviatedPackument = {
+  'dist-tags'?: {
+    latest?: unknown;
+  };
+};
+
+// Module-level cache for the lifetime of the shell document. Mounting and
+// unmounting consumers (NewVersionFooter, the Plugins screen) must not
+// refetch a package once its latest version is known.
+const latestVersionCache = new Map<string, string>();
+
+// In-flight requests are deduped here, not at call sites, so that two
+// consumers asking about the same package concurrently share one request.
+const inFlightRequests = new Map<string, Promise<string | null>>();
+
+async function fetchLatestVersion(packageName: string): Promise<string | null> {
+  try {
+    const response = await fetch(`https://registry.npmjs.org/${encodeURIComponent(packageName)}`, {
+      headers: { Accept: ABBREVIATED_PACKUMENT_ACCEPT },
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const packument = (await response.json()) as AbbreviatedPackument;
+    const latest = packument['dist-tags']?.latest;
+
+    return typeof latest === 'string' ? latest : null;
+  } catch {
+    // A registry outage must never surface an error in DevTools. The
+    // package is simply omitted from the result.
+    return null;
+  }
+}
+
+function getLatestVersion(packageName: string): Promise<string | null> {
+  const cached = latestVersionCache.get(packageName);
+  if (cached !== undefined) {
+    return Promise.resolve(cached);
+  }
+
+  const inFlight = inFlightRequests.get(packageName);
+  if (inFlight) {
+    return inFlight;
+  }
+
+  const request = fetchLatestVersion(packageName)
+    .then((version) => {
+      if (version !== null) {
+        latestVersionCache.set(packageName, version);
+      }
+      return version;
+    })
+    .finally(() => {
+      inFlightRequests.delete(packageName);
+    });
+
+  inFlightRequests.set(packageName, request);
+  return request;
+}
+
+/** Latest published version for each package, from the CDN-cached
+ *  abbreviated packument. Packages that fail to resolve are omitted. */
+export async function getLatestVersions(packageNames: string[]): Promise<Map<string, string>> {
+  const entries = await Promise.all(
+    packageNames.map(async (name) => [name, await getLatestVersion(name)] as const),
+  );
+
+  return new Map(entries.filter((entry): entry is [string, string] => entry[1] !== null));
+}
+
+function parseVersionCore(version: string): number[] {
+  // Semver-ish: only the dot-separated numeric core is compared.
+  // Prerelease/build metadata (`-beta.1`, `+build.5`) is stripped rather
+  // than ranked, so a differently-tagged build of the same release never
+  // reads as an update.
+  const core = version.split(/[-+]/, 1)[0];
+  return core.split('.').map((segment) => {
+    const value = Number.parseInt(segment, 10);
+    return Number.isNaN(value) ? 0 : value;
+  });
+}
+
+/** Semver-ish comparison. Returns false when `candidate` is not strictly
+ *  newer, including when it is a local or prerelease build ahead of npm. */
+export function isNewerVersion(current: string, candidate: string): boolean {
+  const currentParts = parseVersionCore(current);
+  const candidateParts = parseVersionCore(candidate);
+  const length = Math.max(currentParts.length, candidateParts.length);
+
+  for (let i = 0; i < length; i++) {
+    const currentSegment = currentParts[i] ?? 0;
+    const candidateSegment = candidateParts[i] ?? 0;
+
+    if (candidateSegment > currentSegment) {
+      return true;
+    }
+
+    if (candidateSegment < currentSegment) {
+      return false;
+    }
+  }
+
+  return false;
+}

--- a/packages/shell/src/npm/registry.ts
+++ b/packages/shell/src/npm/registry.ts
@@ -15,6 +15,26 @@ const latestVersionCache = new Map<string, string>();
 // consumers asking about the same package concurrently share one request.
 const inFlightRequests = new Map<string, Promise<string | null>>();
 
+// Debug-only: pretend a package publishes a given version. Persisted in
+// sessionStorage so a reload keeps the emulated state, which is what makes
+// the initial-load and welcome-dialog paths testable.
+const OVERRIDES_STORAGE_KEY = 'rozenite.debug.versionOverrides';
+
+function loadVersionOverrides(): Map<string, string> {
+  try {
+    const stored = sessionStorage.getItem(OVERRIDES_STORAGE_KEY);
+    return stored
+      ? new Map(Object.entries(JSON.parse(stored) as Record<string, string>))
+      : new Map();
+  } catch {
+    return new Map();
+  }
+}
+
+const versionOverrides = loadVersionOverrides();
+const overrideListeners = new Set<() => void>();
+let overridesRevision = 0;
+
 async function fetchLatestVersion(packageName: string): Promise<string | null> {
   try {
     const response = await fetch(`https://registry.npmjs.org/${encodeURIComponent(packageName)}`, {
@@ -37,6 +57,13 @@ async function fetchLatestVersion(packageName: string): Promise<string | null> {
 }
 
 function getLatestVersion(packageName: string): Promise<string | null> {
+  // Debug overrides short-circuit both the cache and the network so that the
+  // emulated state travels the same path a real published version would.
+  const override = versionOverrides.get(packageName);
+  if (override !== undefined) {
+    return Promise.resolve(override);
+  }
+
   const cached = latestVersionCache.get(packageName);
   if (cached !== undefined) {
     return Promise.resolve(cached);
@@ -70,6 +97,45 @@ export async function getLatestVersions(packageNames: string[]): Promise<Map<str
   );
 
   return new Map(entries.filter((entry): entry is [string, string] => entry[1] !== null));
+}
+
+/** Debug only. Makes `packageName` resolve to `version` instead of hitting
+ *  the registry, or clears the override when `version` is null. */
+export function setVersionOverride(packageName: string, version: string | null): void {
+  if (version === null) {
+    versionOverrides.delete(packageName);
+  } else {
+    versionOverrides.set(packageName, version);
+  }
+
+  try {
+    sessionStorage.setItem(
+      OVERRIDES_STORAGE_KEY,
+      JSON.stringify(Object.fromEntries(versionOverrides)),
+    );
+  } catch {
+    // Overrides stay in memory for this document if storage is unavailable.
+  }
+
+  overridesRevision++;
+  for (const listener of overrideListeners) {
+    listener();
+  }
+}
+
+/** Debug only. The currently overridden packages. */
+export function getVersionOverrides(): ReadonlyMap<string, string> {
+  return versionOverrides;
+}
+
+/** Bumped whenever an override changes, so consumers can re-resolve. */
+export function getVersionOverridesRevision(): number {
+  return overridesRevision;
+}
+
+export function subscribeToVersionOverrides(listener: () => void): () => void {
+  overrideListeners.add(listener);
+  return () => overrideListeners.delete(listener);
 }
 
 function parseVersionCore(version: string): number[] {

--- a/packages/shell/src/plugins/PluginsScreen.tsx
+++ b/packages/shell/src/plugins/PluginsScreen.tsx
@@ -1,13 +1,16 @@
 import { Badge, Card, DescriptionList, Link, PluginShell, ScrollArea } from '@rozenite/ui';
+import { DebugCard } from '../debug/DebugCard';
+import { isDebugEnabled } from '../debug/debug-mode';
 import type { ShellPlugin } from '../types';
 
 type PluginsScreenProps = {
   plugins: ShellPlugin[];
   /** pluginId -> latest published version, from `useOutdatedPlugins`. */
   outdated: Map<string, string>;
+  runtimeVersion?: string;
 };
 
-export function PluginsScreen({ plugins, outdated }: PluginsScreenProps) {
+export function PluginsScreen({ plugins, outdated, runtimeVersion }: PluginsScreenProps) {
   return (
     <PluginShell.Body>
       <ScrollArea className="h-full">
@@ -24,21 +27,27 @@ export function PluginsScreen({ plugins, outdated }: PluginsScreenProps) {
                 <Card key={plugin.id}>
                   <Card.Header>
                     <div className="flex min-w-0 flex-col">
-                      <span className="font-medium">{plugin.name}</span>
-                      <span className="truncate font-mono text-xs text-muted-foreground">
-                        {plugin.id}
-                      </span>
+                      <span className="truncate font-medium">{plugin.name}</span>
+                      {/* Most manifests name the plugin after its package, so
+                          the id is only worth a second line when it differs. */}
+                      {plugin.id !== plugin.name && (
+                        <span className="truncate font-mono text-xs text-muted-foreground">
+                          {plugin.id}
+                        </span>
+                      )}
                     </div>
-                    <Badge variant="secondary">{plugin.version}</Badge>
-                    {latestVersion && (
-                      <Link
-                        href={`https://www.npmjs.com/package/${plugin.id}`}
-                        external
-                        className="text-xs"
-                      >
-                        Update to v{latestVersion}
-                      </Link>
-                    )}
+                    <div className="ml-auto flex shrink-0 items-center gap-3">
+                      {latestVersion && (
+                        <Link
+                          href={`https://www.npmjs.com/package/${plugin.id}`}
+                          external
+                          className="text-xs"
+                        >
+                          Update to v{latestVersion}
+                        </Link>
+                      )}
+                      <Badge variant="secondary">{plugin.version}</Badge>
+                    </div>
                   </Card.Header>
                   <Card.Body className="flex flex-col gap-3">
                     {plugin.description && (
@@ -56,6 +65,7 @@ export function PluginsScreen({ plugins, outdated }: PluginsScreenProps) {
               );
             })}
           </div>
+          {isDebugEnabled() && <DebugCard plugins={plugins} runtimeVersion={runtimeVersion} />}
         </div>
       </ScrollArea>
     </PluginShell.Body>

--- a/packages/shell/src/plugins/PluginsScreen.tsx
+++ b/packages/shell/src/plugins/PluginsScreen.tsx
@@ -8,9 +8,18 @@ type PluginsScreenProps = {
   /** pluginId -> latest published version, from `useOutdatedPlugins`. */
   outdated: Map<string, string>;
   runtimeVersion?: string;
+  /** Latest published runtime version when one is newer, otherwise null. */
+  runtimeUpdate: string | null;
 };
 
-export function PluginsScreen({ plugins, outdated, runtimeVersion }: PluginsScreenProps) {
+const RELEASES_URL = 'https://github.com/callstackincubator/rozenite/releases';
+
+export function PluginsScreen({
+  plugins,
+  outdated,
+  runtimeVersion,
+  runtimeUpdate,
+}: PluginsScreenProps) {
   return (
     <PluginShell.Body>
       <ScrollArea className="h-full">
@@ -19,6 +28,25 @@ export function PluginsScreen({ plugins, outdated, runtimeVersion }: PluginsScre
             <h1 className="text-lg font-semibold">Plugins</h1>
             <span className="text-sm text-muted-foreground">{plugins.length} installed</span>
           </div>
+          {/* The cog's dot covers runtime updates too, and the footer link is
+              hidden while the sidebar is collapsed, so the detail behind that
+              dot has to be reachable here. */}
+          {runtimeUpdate && (
+            <Card>
+              <Card.Header>
+                <span className="font-medium">Rozenite update available</span>
+                {runtimeVersion && (
+                  <span className="text-sm text-muted-foreground">Installed v{runtimeVersion}</span>
+                )}
+                <div className="ml-auto flex shrink-0 items-center gap-3">
+                  <Link href={RELEASES_URL} external className="text-xs">
+                    Release notes
+                  </Link>
+                  <Badge variant="secondary">v{runtimeUpdate}</Badge>
+                </div>
+              </Card.Header>
+            </Card>
+          )}
           <div className="flex flex-col gap-3">
             {plugins.map((plugin) => {
               const latestVersion = outdated.get(plugin.id);

--- a/packages/shell/src/plugins/PluginsScreen.tsx
+++ b/packages/shell/src/plugins/PluginsScreen.tsx
@@ -1,0 +1,63 @@
+import { Badge, Card, DescriptionList, Link, PluginShell, ScrollArea } from '@rozenite/ui';
+import type { ShellPlugin } from '../types';
+
+type PluginsScreenProps = {
+  plugins: ShellPlugin[];
+  /** pluginId -> latest published version, from `useOutdatedPlugins`. */
+  outdated: Map<string, string>;
+};
+
+export function PluginsScreen({ plugins, outdated }: PluginsScreenProps) {
+  return (
+    <PluginShell.Body>
+      <ScrollArea className="h-full">
+        <div className="flex flex-col gap-4 p-4">
+          <div className="flex items-baseline gap-2">
+            <h1 className="text-lg font-semibold">Plugins</h1>
+            <span className="text-sm text-muted-foreground">{plugins.length} installed</span>
+          </div>
+          <div className="flex flex-col gap-3">
+            {plugins.map((plugin) => {
+              const latestVersion = outdated.get(plugin.id);
+
+              return (
+                <Card key={plugin.id}>
+                  <Card.Header>
+                    <div className="flex min-w-0 flex-col">
+                      <span className="font-medium">{plugin.name}</span>
+                      <span className="truncate font-mono text-xs text-muted-foreground">
+                        {plugin.id}
+                      </span>
+                    </div>
+                    <Badge variant="secondary">{plugin.version}</Badge>
+                    {latestVersion && (
+                      <Link
+                        href={`https://www.npmjs.com/package/${plugin.id}`}
+                        external
+                        className="text-xs"
+                      >
+                        Update to v{latestVersion}
+                      </Link>
+                    )}
+                  </Card.Header>
+                  <Card.Body className="flex flex-col gap-3">
+                    {plugin.description && (
+                      <p className="text-sm text-muted-foreground">{plugin.description}</p>
+                    )}
+                    <DescriptionList>
+                      <DescriptionList.Item label="Panels">
+                        {plugin.panels.length > 0
+                          ? plugin.panels.map((panel) => panel.name).join(', ')
+                          : '—'}
+                      </DescriptionList.Item>
+                    </DescriptionList>
+                  </Card.Body>
+                </Card>
+              );
+            })}
+          </div>
+        </div>
+      </ScrollArea>
+    </PluginShell.Body>
+  );
+}

--- a/packages/shell/src/plugins/use-outdated-plugins.test.ts
+++ b/packages/shell/src/plugins/use-outdated-plugins.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ShellPlugin } from '../types';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.resetModules();
+});
+
+const makePlugin = (id: string, version: string): ShellPlugin => ({
+  id,
+  name: id,
+  description: '',
+  version,
+  panels: [],
+});
+
+describe('useOutdatedPlugins', () => {
+  it('reports only plugins with a strictly newer published version', async () => {
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      const latest = url.includes('storage') ? '2.0.0' : '1.0.0';
+
+      return {
+        ok: true,
+        json: async () => ({ 'dist-tags': { latest } }),
+      } as Response;
+    });
+
+    const { useOutdatedPlugins } = await import('./use-outdated-plugins');
+    const plugins = [makePlugin('storage', '1.0.0'), makePlugin('network', '1.0.0')];
+
+    const { result } = renderHook(() => useOutdatedPlugins(plugins));
+
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    expect(result.current.outdated).toEqual(new Map([['storage', '2.0.0']]));
+  });
+
+  it('caches across mounts, fetching each package only once', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ 'dist-tags': { latest: '2.0.0' } }),
+    }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const { useOutdatedPlugins } = await import('./use-outdated-plugins');
+    const plugins = [makePlugin('storage', '1.0.0')];
+
+    const first = renderHook(() => useOutdatedPlugins(plugins));
+    await waitFor(() => expect(first.result.current.status).toBe('ready'));
+    first.unmount();
+
+    const second = renderHook(() => useOutdatedPlugins(plugins));
+    await waitFor(() => expect(second.result.current.status).toBe('ready'));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(second.result.current.outdated).toEqual(new Map([['storage', '2.0.0']]));
+  });
+
+  it('reports unavailable, with no outdated entries, when every registry lookup fails', async () => {
+    // `getLatestVersions` never rejects on its own contract: every request
+    // failing for real (fetch itself rejecting) is what drives the
+    // `unavailable` status here, not a mocked violation of that contract.
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error('network down'));
+
+    const { useOutdatedPlugins } = await import('./use-outdated-plugins');
+    const plugins = [makePlugin('storage', '1.0.0'), makePlugin('network', '1.0.0')];
+
+    const { result } = renderHook(() => useOutdatedPlugins(plugins));
+
+    await waitFor(() => expect(result.current.status).toBe('unavailable'));
+    expect(result.current.outdated.size).toBe(0);
+  });
+
+  it('is ready, not unavailable, when only some packages fail to resolve', async () => {
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).includes('storage')) {
+        return { ok: true, json: async () => ({ 'dist-tags': { latest: '2.0.0' } }) } as Response;
+      }
+      return { ok: false, status: 500 } as Response;
+    });
+
+    const { useOutdatedPlugins } = await import('./use-outdated-plugins');
+    const plugins = [makePlugin('storage', '1.0.0'), makePlugin('network', '1.0.0')];
+
+    const { result } = renderHook(() => useOutdatedPlugins(plugins));
+
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+    expect(result.current.outdated).toEqual(new Map([['storage', '2.0.0']]));
+  });
+
+  it('is ready with no outdated entries when there are no plugins', async () => {
+    const { useOutdatedPlugins } = await import('./use-outdated-plugins');
+
+    const { result } = renderHook(() => useOutdatedPlugins([]));
+
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+    expect(result.current.outdated.size).toBe(0);
+  });
+});

--- a/packages/shell/src/plugins/use-outdated-plugins.ts
+++ b/packages/shell/src/plugins/use-outdated-plugins.ts
@@ -1,5 +1,10 @@
-import { useEffect, useState } from 'react';
-import { getLatestVersions, isNewerVersion } from '../npm/registry';
+import { useEffect, useState, useSyncExternalStore } from 'react';
+import {
+  getLatestVersions,
+  getVersionOverridesRevision,
+  isNewerVersion,
+  subscribeToVersionOverrides,
+} from '../npm/registry';
 import type { ShellPlugin } from '../types';
 
 export type OutdatedPluginsResult = {
@@ -18,6 +23,11 @@ export function useOutdatedPlugins(plugins: ShellPlugin[]): OutdatedPluginsResul
     status: 'loading',
     outdated: new Map(),
   });
+  // Debug version overrides re-resolve through the same path as real data.
+  const overridesRevision = useSyncExternalStore(
+    subscribeToVersionOverrides,
+    getVersionOverridesRevision,
+  );
 
   useEffect(() => {
     if (plugins.length === 0) {
@@ -70,7 +80,7 @@ export function useOutdatedPlugins(plugins: ShellPlugin[]): OutdatedPluginsResul
     // `plugins` is derived fresh on every ShellConfiguration update; identity
     // rather than a stable id list would refetch on every render, but shell
     // config only changes when plugins actually change.
-  }, [plugins]);
+  }, [plugins, overridesRevision]);
 
   return result;
 }

--- a/packages/shell/src/plugins/use-outdated-plugins.ts
+++ b/packages/shell/src/plugins/use-outdated-plugins.ts
@@ -1,0 +1,76 @@
+import { useEffect, useState } from 'react';
+import { getLatestVersions, isNewerVersion } from '../npm/registry';
+import type { ShellPlugin } from '../types';
+
+export type OutdatedPluginsResult = {
+  status: 'loading' | 'ready' | 'unavailable';
+  /** pluginId -> latest published version. Only entries strictly newer
+   *  than the installed version are present. */
+  outdated: Map<string, string>;
+};
+
+const EMPTY_RESULT: OutdatedPluginsResult = { status: 'ready', outdated: new Map() };
+
+/** The only caller of `getLatestVersions` for plugin packages. A plugin's
+ *  `id` is its npm package name. */
+export function useOutdatedPlugins(plugins: ShellPlugin[]): OutdatedPluginsResult {
+  const [result, setResult] = useState<OutdatedPluginsResult>({
+    status: 'loading',
+    outdated: new Map(),
+  });
+
+  useEffect(() => {
+    if (plugins.length === 0) {
+      setResult(EMPTY_RESULT);
+      return;
+    }
+
+    let cancelled = false;
+
+    getLatestVersions(plugins.map((plugin) => plugin.id))
+      .then((latestVersions) => {
+        if (cancelled) {
+          return;
+        }
+
+        // `getLatestVersions` never rejects; individual package failures are
+        // silently omitted from its result instead. An empty result for a
+        // non-empty request is therefore the signal that every package
+        // failed to resolve, i.e. a registry outage, distinct from "checked
+        // and nothing is outdated".
+        if (latestVersions.size === 0) {
+          setResult({ status: 'unavailable', outdated: new Map() });
+          return;
+        }
+
+        const outdated = new Map<string, string>();
+
+        for (const plugin of plugins) {
+          const latest = latestVersions.get(plugin.id);
+
+          if (latest && isNewerVersion(plugin.version, latest)) {
+            outdated.set(plugin.id, latest);
+          }
+        }
+
+        setResult({ status: 'ready', outdated });
+      })
+      .catch(() => {
+        // Defensive: `getLatestVersions`'s contract never rejects, but a
+        // registry outage must never surface an error state in DevTools
+        // regardless.
+        if (!cancelled) {
+          setResult({ status: 'unavailable', outdated: new Map() });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+    // `plugins` is derived fresh on every ShellConfiguration update; identity
+    // rather than a stable id list would refetch on every render, but shell
+    // config only changes when plugins actually change.
+  }, [plugins]);
+
+  return result;
+}

--- a/packages/shell/src/selection.test.ts
+++ b/packages/shell/src/selection.test.ts
@@ -1,22 +1,117 @@
 import { describe, expect, it } from 'vitest';
-import { getInitialSelection } from './selection';
+import {
+  closePluginsScreen,
+  getInitialSelection,
+  getInitialSelectionState,
+  openPluginsScreen,
+  reconcileSelection,
+  selectPanel,
+  type SelectionState,
+} from './selection';
+import type { ShellPlugin } from './types';
+
+const emptyPlugin: ShellPlugin = {
+  id: 'empty',
+  name: 'Empty',
+  description: '',
+  version: '1.0.0',
+  panels: [],
+};
+
+const storagePlugin: ShellPlugin = {
+  id: 'storage',
+  name: 'Storage',
+  description: '',
+  version: '1.0.0',
+  panels: [{ id: 'storage:table', name: 'Table', source: '/table' }],
+};
+
+const networkPlugin: ShellPlugin = {
+  id: 'network',
+  name: 'Network',
+  description: '',
+  version: '1.0.0',
+  panels: [{ id: 'network:list', name: 'List', source: '/list' }],
+};
 
 describe('getInitialSelection', () => {
   it('selects the first plugin that exposes a panel', () => {
-    expect(
-      getInitialSelection([
-        { id: 'empty', name: 'Empty', description: '', panels: [] },
-        {
-          id: 'storage',
-          name: 'Storage',
-          description: '',
-          panels: [{ id: 'storage:table', name: 'Table', source: '/table' }],
-        },
-      ]),
-    ).toEqual({ pluginId: 'storage', panelId: 'storage:table' });
+    expect(getInitialSelection([emptyPlugin, storagePlugin])).toEqual({
+      kind: 'panel',
+      pluginId: 'storage',
+      panelId: 'storage:table',
+    });
   });
 
   it('returns null when no plugin has a panel', () => {
     expect(getInitialSelection([])).toBeNull();
+  });
+});
+
+describe('openPluginsScreen / closePluginsScreen', () => {
+  it('selects the plugins screen and deselects any panel', () => {
+    const initial = getInitialSelectionState([storagePlugin]);
+    const opened = openPluginsScreen(initial);
+
+    expect(opened.selection).toEqual({ kind: 'plugins' });
+  });
+
+  it('panel selection survives a visit to the screen', () => {
+    const withPanelSelected = selectPanel('network', 'network:list');
+    const opened = openPluginsScreen(withPanelSelected);
+    const closed = closePluginsScreen(opened, [storagePlugin, networkPlugin]);
+
+    expect(closed.selection).toEqual({
+      kind: 'panel',
+      pluginId: 'network',
+      panelId: 'network:list',
+    });
+  });
+
+  it('falls back to the first available panel if the remembered one no longer exists', () => {
+    const withPanelSelected = selectPanel('network', 'network:list');
+    const opened = openPluginsScreen(withPanelSelected);
+    // The network plugin is gone by the time the screen is closed.
+    const closed = closePluginsScreen(opened, [storagePlugin]);
+
+    expect(closed.selection).toEqual({
+      kind: 'panel',
+      pluginId: 'storage',
+      panelId: 'storage:table',
+    });
+  });
+});
+
+describe('reconcileSelection', () => {
+  it('keeps a panel selection unchanged when it is still valid', () => {
+    const state: SelectionState = selectPanel('storage', 'storage:table');
+    expect(reconcileSelection(state, [storagePlugin, networkPlugin])).toBe(state);
+  });
+
+  it('falls back to the initial selection when the selected panel disappears', () => {
+    const state: SelectionState = selectPanel('network', 'network:list');
+    expect(reconcileSelection(state, [storagePlugin])).toEqual(
+      getInitialSelectionState([storagePlugin]),
+    );
+  });
+
+  it('keeps the Plugins screen selected even if the plugin list changes', () => {
+    const state = openPluginsScreen(selectPanel('storage', 'storage:table'));
+    const reconciled = reconcileSelection(state, [networkPlugin]);
+
+    expect(reconciled.selection).toEqual({ kind: 'plugins' });
+  });
+
+  it('drops a remembered panel from the screen state once it no longer exists', () => {
+    const state = openPluginsScreen(selectPanel('storage', 'storage:table'));
+    const reconciled = reconcileSelection(state, [networkPlugin]);
+
+    expect(reconciled.lastPanel).toBeNull();
+    // Closing the screen now falls back to the first available panel.
+    expect(closePluginsScreen(reconciled, [networkPlugin]).selection).toEqual({
+      kind: 'panel',
+      pluginId: 'network',
+      panelId: 'network:list',
+    });
   });
 });

--- a/packages/shell/src/selection.ts
+++ b/packages/shell/src/selection.ts
@@ -1,13 +1,69 @@
 import type { ShellPlugin } from './types';
 
-export type ShellSelection = {
-  pluginId: string;
-  panelId: string;
-} | null;
+export type PanelSelection = { kind: 'panel'; pluginId: string; panelId: string };
+
+export type ShellSelection = PanelSelection | { kind: 'plugins' } | null;
+
+export type SelectionState = {
+  selection: ShellSelection;
+  /** The most recent panel selection. Kept even while the Plugins screen is
+   *  open so returning to it restores the panel, including its sidebar
+   *  highlight. */
+  lastPanel: PanelSelection | null;
+};
+
+function isPanelValid(panel: PanelSelection, plugins: ShellPlugin[]): boolean {
+  return plugins.some(
+    (plugin) => plugin.id === panel.pluginId && plugin.panels.some((p) => p.id === panel.panelId),
+  );
+}
 
 export function getInitialSelection(plugins: ShellPlugin[]): ShellSelection {
   const plugin = plugins.find((candidate) => candidate.panels.length > 0);
   const panel = plugin?.panels[0];
 
-  return plugin && panel ? { pluginId: plugin.id, panelId: panel.id } : null;
+  return plugin && panel ? { kind: 'panel', pluginId: plugin.id, panelId: panel.id } : null;
+}
+
+export function getInitialSelectionState(plugins: ShellPlugin[]): SelectionState {
+  const selection = getInitialSelection(plugins);
+  return { selection, lastPanel: selection?.kind === 'panel' ? selection : null };
+}
+
+export function selectPanel(pluginId: string, panelId: string): SelectionState {
+  const panel: PanelSelection = { kind: 'panel', pluginId, panelId };
+  return { selection: panel, lastPanel: panel };
+}
+
+export function openPluginsScreen(state: SelectionState): SelectionState {
+  return { selection: { kind: 'plugins' }, lastPanel: state.lastPanel };
+}
+
+/** Returns from the Plugins screen to the panel that was selected before it
+ *  opened, falling back to the first available panel if that plugin or
+ *  panel no longer exists. */
+export function closePluginsScreen(state: SelectionState, plugins: ShellPlugin[]): SelectionState {
+  if (state.lastPanel && isPanelValid(state.lastPanel, plugins)) {
+    return { selection: state.lastPanel, lastPanel: state.lastPanel };
+  }
+
+  return getInitialSelectionState(plugins);
+}
+
+/** Keeps the current selection valid as the plugin list changes. The Plugins
+ *  screen is always valid and is never reconciled away; only its remembered
+ *  panel is kept in sync so a later return doesn't restore a stale one. */
+export function reconcileSelection(state: SelectionState, plugins: ShellPlugin[]): SelectionState {
+  if (state.selection?.kind === 'plugins') {
+    if (state.lastPanel && !isPanelValid(state.lastPanel, plugins)) {
+      return { selection: state.selection, lastPanel: null };
+    }
+    return state;
+  }
+
+  if (state.selection?.kind === 'panel' && isPanelValid(state.selection, plugins)) {
+    return state;
+  }
+
+  return getInitialSelectionState(plugins);
 }

--- a/packages/shell/src/types.ts
+++ b/packages/shell/src/types.ts
@@ -8,6 +8,7 @@ export type ShellPlugin = {
   id: string;
   name: string;
   description: string;
+  version: string;
   panels: ShellPanel[];
 };
 

--- a/packages/ui/src/button/button.tsx
+++ b/packages/ui/src/button/button.tsx
@@ -1,10 +1,10 @@
-import type { ComponentProps } from 'react';
+import type { ComponentProps, ReactNode } from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '../utils/cn';
 
 export const buttonVariants = cva(
   cn(
-    'inline-flex shrink-0 items-center justify-center gap-1.5 whitespace-nowrap rounded-md text-sm font-medium transition-colors',
+    'relative inline-flex shrink-0 items-center justify-center gap-1.5 whitespace-nowrap rounded-md text-sm font-medium transition-colors',
     'outline-none focus-visible:ring-2 focus-visible:ring-ring',
     'disabled:pointer-events-none disabled:opacity-50',
     '[&_svg]:pointer-events-none [&_svg]:shrink-0',
@@ -32,16 +32,31 @@ export const buttonVariants = cva(
   },
 );
 
-export type ButtonProps = ComponentProps<'button'> & VariantProps<typeof buttonVariants>;
+export type ButtonProps = ComponentProps<'button'> &
+  VariantProps<typeof buttonVariants> & {
+    /** Rendered after `children`, e.g. an `IndicatorDot` flagging an update. */
+    adornment?: ReactNode;
+  };
 
 /** A styled button for actions that change state or submit work. */
-export function Button({ className, variant, size, type = 'button', ...props }: ButtonProps) {
+export function Button({
+  className,
+  variant,
+  size,
+  type = 'button',
+  adornment,
+  children,
+  ...props
+}: ButtonProps) {
   return (
     <button
       type={type}
       data-slot="button"
       className={cn(buttonVariants({ variant, size }), className)}
       {...props}
-    />
+    >
+      {children}
+      {adornment}
+    </button>
   );
 }

--- a/packages/ui/src/card/card.tsx
+++ b/packages/ui/src/card/card.tsx
@@ -1,0 +1,88 @@
+import { createContext, useContext, useState, type ComponentProps } from 'react';
+import { ChevronRight } from 'lucide-react';
+import { cn } from '../utils/cn';
+
+type CardContextValue = {
+  collapsible: boolean;
+  open: boolean;
+  toggle: () => void;
+};
+
+const CardContext = createContext<CardContextValue | null>(null);
+
+export type CardProps = ComponentProps<'div'> & {
+  /** Whether `Card.Body` can be collapsed via a toggle in `Card.Header`. */
+  collapsible?: boolean;
+  defaultOpen?: boolean;
+};
+
+function CardRoot({ collapsible = false, defaultOpen = true, className, ...props }: CardProps) {
+  const [open, setOpen] = useState(defaultOpen);
+
+  return (
+    <CardContext.Provider
+      value={{ collapsible, open, toggle: () => setOpen((current) => !current) }}
+    >
+      <div
+        data-slot="card"
+        className={cn('rounded-lg border border-border bg-card text-card-foreground', className)}
+        {...props}
+      />
+    </CardContext.Provider>
+  );
+}
+
+export type CardHeaderProps = ComponentProps<'div'>;
+
+function CardHeader({ className, children, ...props }: CardHeaderProps) {
+  const context = useContext(CardContext);
+
+  return (
+    <div
+      data-slot="card-header"
+      className={cn('flex items-center gap-2 p-3', className)}
+      {...props}
+    >
+      {context?.collapsible && (
+        <button
+          type="button"
+          data-slot="card-collapse-toggle"
+          aria-expanded={context.open}
+          aria-label={context.open ? 'Collapse' : 'Expand'}
+          className={cn(
+            'flex size-5 shrink-0 items-center justify-center rounded outline-none',
+            'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+            'focus-visible:ring-2 focus-visible:ring-ring',
+          )}
+          onClick={context.toggle}
+        >
+          <ChevronRight
+            aria-hidden="true"
+            className={cn('size-4 transition-transform', context.open && 'rotate-90')}
+          />
+        </button>
+      )}
+      <div className="flex min-w-0 flex-1 items-center gap-2">{children}</div>
+    </div>
+  );
+}
+
+export type CardBodyProps = ComponentProps<'div'>;
+
+function CardBody({ className, ...props }: CardBodyProps) {
+  const context = useContext(CardContext);
+
+  if (context?.collapsible && !context.open) {
+    return null;
+  }
+
+  return (
+    <div data-slot="card-body" className={cn('border-t border-border p-3', className)} {...props} />
+  );
+}
+
+/** A bordered container for grouping related content, optionally collapsible. */
+export const Card = Object.assign(CardRoot, {
+  Header: CardHeader,
+  Body: CardBody,
+});

--- a/packages/ui/src/description-list/description-list.tsx
+++ b/packages/ui/src/description-list/description-list.tsx
@@ -1,0 +1,35 @@
+import type { ComponentProps, ReactNode } from 'react';
+import { cn } from '../utils/cn';
+
+export type DescriptionListProps = ComponentProps<'div'>;
+
+function DescriptionListRoot({ className, ...props }: DescriptionListProps) {
+  return (
+    <div
+      data-slot="description-list"
+      className={cn(
+        'grid grid-cols-[minmax(7rem,25%)_minmax(3rem,1fr)] gap-x-2 gap-y-2 text-sm',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export type DescriptionListItemProps = ComponentProps<'div'> & {
+  label: ReactNode;
+};
+
+function DescriptionListItem({ label, className, children, ...props }: DescriptionListItemProps) {
+  return (
+    <div data-slot="description-list-item" className={cn('contents', className)} {...props}>
+      <span className="text-muted-foreground">{label}</span>
+      <span className="min-w-0">{children}</span>
+    </div>
+  );
+}
+
+/** A list of label/value rows, e.g. metadata about an entity. */
+export const DescriptionList = Object.assign(DescriptionListRoot, {
+  Item: DescriptionListItem,
+});

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -84,6 +84,24 @@ export type {
   ToolbarGroupProps,
 } from './toolbar/toolbar';
 
+export { Separator } from './separator/separator';
+export type { SeparatorProps } from './separator/separator';
+
+export { Link } from './link/link';
+export type { LinkProps } from './link/link';
+
+export { IndicatorDot, indicatorDotVariants } from './indicator-dot/indicator-dot';
+export type { IndicatorDotProps } from './indicator-dot/indicator-dot';
+
+export { DescriptionList } from './description-list/description-list';
+export type {
+  DescriptionListProps,
+  DescriptionListItemProps,
+} from './description-list/description-list';
+
+export { Card } from './card/card';
+export type { CardProps, CardHeaderProps, CardBodyProps } from './card/card';
+
 export { Toast, useToast } from './toast/toast';
 export type { ToastProviderProps } from './toast/toast';
 
@@ -120,7 +138,13 @@ export { NestedList } from './list/nested-list';
 export type { NestedListProps, NestedListItemProps } from './list/nested-list';
 
 export { Sidebar } from './sidebar/sidebar';
-export type { SidebarProps, SidebarGroupProps, SidebarItemProps } from './sidebar/sidebar';
+export type {
+  SidebarProps,
+  SidebarGroupProps,
+  SidebarItemProps,
+  SidebarHeaderProps,
+  SidebarFooterProps,
+} from './sidebar/sidebar';
 
 export { EmptyState } from './empty-state/empty-state';
 export type { EmptyStateProps } from './empty-state/empty-state';

--- a/packages/ui/src/indicator-dot/indicator-dot.tsx
+++ b/packages/ui/src/indicator-dot/indicator-dot.tsx
@@ -1,0 +1,29 @@
+import type { ComponentProps } from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '../utils/cn';
+
+export const indicatorDotVariants = cva('size-1.5 shrink-0 rounded-full', {
+  variants: {
+    variant: {
+      default: 'bg-primary',
+      destructive: 'bg-destructive',
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+  },
+});
+
+export type IndicatorDotProps = ComponentProps<'span'> & VariantProps<typeof indicatorDotVariants>;
+
+/** A small dot for flagging that something needs attention. Composes into
+ *  any adornment slot, e.g. `Button`'s `adornment` prop. Size via `className`. */
+export function IndicatorDot({ className, variant, ...props }: IndicatorDotProps) {
+  return (
+    <span
+      data-slot="indicator-dot"
+      className={cn(indicatorDotVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}

--- a/packages/ui/src/link/link.tsx
+++ b/packages/ui/src/link/link.tsx
@@ -1,0 +1,34 @@
+import type { ComponentProps } from 'react';
+import { ArrowUpRight } from 'lucide-react';
+import { cn } from '../utils/cn';
+
+export type LinkProps = ComponentProps<'a'> & {
+  /** Renders the trailing arrow affordance and opens the link in a new tab
+   *  with `rel="noreferrer" target="_blank"`. */
+  external?: boolean;
+};
+
+/** A styled anchor for inline and standalone navigation. */
+export function Link({ external = false, className, children, ...props }: LinkProps) {
+  return (
+    <a
+      data-slot="link"
+      rel={external ? 'noreferrer' : undefined}
+      target={external ? '_blank' : undefined}
+      className={cn(
+        'group inline-flex items-center gap-1 text-sm font-medium text-primary outline-none',
+        'hover:underline focus-visible:ring-2 focus-visible:ring-ring',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      {external && (
+        <ArrowUpRight
+          aria-hidden="true"
+          className="size-3.5 shrink-0 transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5"
+        />
+      )}
+    </a>
+  );
+}

--- a/packages/ui/src/separator/separator.tsx
+++ b/packages/ui/src/separator/separator.tsx
@@ -1,0 +1,20 @@
+import { Separator as SeparatorPrimitive } from '@base-ui/react/separator';
+import { cn } from '../utils/cn';
+
+export type SeparatorProps = SeparatorPrimitive.Props;
+
+/** A visual divider between related content or actions. */
+export function Separator({ orientation = 'horizontal', className, ...props }: SeparatorProps) {
+  return (
+    <SeparatorPrimitive
+      data-slot="separator"
+      orientation={orientation}
+      className={cn(
+        'shrink-0 bg-border',
+        orientation === 'vertical' ? 'h-4 w-px' : 'h-px w-full',
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/packages/ui/src/sidebar/sidebar.tsx
+++ b/packages/ui/src/sidebar/sidebar.tsx
@@ -20,8 +20,37 @@ function SidebarRoot({ className, ...props }: SidebarProps) {
 export type SidebarGroupProps = ListGroupProps;
 export type SidebarItemProps = ListItemProps;
 
+export type SidebarHeaderProps = ComponentProps<'header'>;
+
+function SidebarHeader({ className, ...props }: SidebarHeaderProps) {
+  return (
+    <header
+      data-slot="sidebar-header"
+      className={cn(
+        'sticky top-0 z-10 flex h-12 shrink-0 items-center border-b border-sidebar-border bg-sidebar px-3',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export type SidebarFooterProps = ComponentProps<'footer'>;
+
+function SidebarFooter({ className, ...props }: SidebarFooterProps) {
+  return (
+    <footer
+      data-slot="sidebar-footer"
+      className={cn('mt-auto flex shrink-0 gap-1 border-t border-sidebar-border p-2', className)}
+      {...props}
+    />
+  );
+}
+
 /** A navigation rail with grouped, selectable items and optional trailing content. */
 export const Sidebar = Object.assign(SidebarRoot, {
   Group: List.Group,
   Item: List.Item,
+  Header: SidebarHeader,
+  Footer: SidebarFooter,
 });

--- a/packages/ui/src/toolbar/toolbar.tsx
+++ b/packages/ui/src/toolbar/toolbar.tsx
@@ -1,5 +1,6 @@
 import { Toolbar as ToolbarPrimitive } from '@base-ui/react/toolbar';
 import { cn } from '../utils/cn';
+import { Separator, type SeparatorProps } from '../separator/separator';
 
 export type ToolbarProps = ToolbarPrimitive.Root.Props;
 
@@ -34,13 +35,19 @@ function ToolbarButton({ className, ...props }: ToolbarButtonProps) {
   );
 }
 
-export type ToolbarSeparatorProps = ToolbarPrimitive.Separator.Props;
+export type ToolbarSeparatorProps = SeparatorProps;
 
-function ToolbarSeparator({ className, ...props }: ToolbarSeparatorProps) {
+/** An alias for `Separator`, styled for use inside a `Toolbar`. */
+function ToolbarSeparator({
+  orientation = 'vertical',
+  className,
+  ...props
+}: ToolbarSeparatorProps) {
   return (
-    <ToolbarPrimitive.Separator
+    <Separator
       data-slot="toolbar-separator"
-      className={cn('mx-1 h-4 w-px bg-border', className)}
+      orientation={orientation}
+      className={cn('mx-1', className)}
       {...props}
     />
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1332,6 +1332,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@7.3.5(@types/node@22.17.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.8.1))
+      '@testing-library/react':
+        specifier: ^16.1.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.14


### PR DESCRIPTION
## Description

Adds a Plugins screen to shell mode, opened from a cog in the sidebar footer.

Shell mode put every plugin behind a single DevTools tab, which removed the only surface that showed what was actually loaded. The screen restores that visibility. For each plugin it lists the package id, description, installed version, the panels it contributes, and a link to npm when a newer version is published. It is an inventory, not a diagnostic tool — a plugin that fails to load never reaches shell and so cannot appear here.

Alongside it:

- `@rozenite/runtime` now returns `manifest.version` through `LoadedPlugin` instead of logging and discarding it.
- One shared npm module (`packages/shell/src/npm/registry.ts`) backs every version check in shell. The existing runtime check is refactored onto it.
- The cog carries an indicator dot when the runtime or any plugin has an update pending.
- `@rozenite/ui` gains `Separator`, `Link`, `IndicatorDot`, `DescriptionList` and `Card`, plus `Button`'s `adornment` slot and `Sidebar.Header` / `Sidebar.Footer`.

Two pre-existing defects are fixed as a consequence:

- The runtime version check used `https://registry.npmjs.org/<pkg>/latest`, which is uncached and rate limited.
- It compared with `latestVersion === currentVersion`, so a local build ahead of npm reported a spurious update.

## Related Issue

Not tied to an issue — this is a self-contained addition to shell mode rather than a reported bug or a discussed feature request.

## Context

**Why a flat screen rather than a Settings container.** The obvious shape was Settings, with Plugins as one entry. That was dropped because there is no second setting to put beside it: shell has no user-configurable state today. VS Code, Chrome DevTools, Figma and Linear all keep an extensions or plugins inventory as its own destination rather than nesting it under preferences. A container can be introduced later if real settings appear; building it now would be an empty shell.

**Why the abbreviated packument instead of `/latest`.** Measured against the live registry with 26 `@rozenite/*` packages, 780 requests (30 rounds):

| Endpoint | Result | `cf-cache-status` |
| --- | --- | --- |
| `GET /<pkg>/latest` | 312 × HTTP 429, then a ~9 minute IP-wide ban | `DYNAMIC` |
| `GET /<pkg>` with `Accept: application/vnd.npm.install-v1+json` | 780 × HTTP 200 in 2.2s | `HIT` (773), `REVALIDATED` (7) |

The ban affects `npm install` from the same IP, not just DevTools. The abbreviated packument is CDN-cached, carries `max-age=300`, and is what the npm CLI itself uses. It costs ~28KB per package against ~2.2KB, and data can be up to 5 minutes stale. Both were accepted.

**Panel state survives a visit.** The screen covers the panel area visually, but the iframes stay mounted — including for plugins in `destroyOnDetachPlugins`, whose remembered panel is retained rather than torn down. Unmounting them would cost every plugin its state on each visit.

**Debug affordance.** The update states cannot be reached without a real npm release, so a debug card emulates them. Overrides are injected at the registry, below the cache, so the cog's dot, the footer link and the per-plugin npm link all run their production path against emulated data — a flag in the components would have left the real path unexercised. It is hidden unless running from source or `localStorage['rozenite.debug']` is set.

**Scoped out deliberately.** No Settings container, no About screen, no agent tools row, no server-side npm proxy. Agent tools were investigated and cut: every plugin registers them app-side from `src/react-native/`, never from panel code, and nothing app-side retains a registry to answer a query — so exposing them needs a change to `@rozenite/agent-bridge`. The findings are recorded under "Deferred decisions" in `docs/workplace/shell-plugins-screen.md` so the work is not repeated.

`network-activity-plugin` already contains independently reinvented versions of `DescriptionList` and `Card` (`KeyValueGrid.tsx`, `Section.tsx`). Migrating it onto the shared components is worth doing but is a separate change.

## Testing

Automated:

- `pnpm typecheck:all` — 61/61 tasks pass
- `pnpm lint:all` — 60/60 tasks pass
- `pnpm format:all` — clean apart from `.claude/settings.local.json`, which is pre-existing and untouched by this branch
- `pnpm turbo run test --filter=@rozenite/shell --filter=@rozenite/ui --filter=@rozenite/runtime` — 36 shell tests, 33 ui tests, all passing

Tests cover the logic rather than the markup: `isNewerVersion` semantics, `getLatestVersions` caching / in-flight dedup / silent per-package failure / override short-circuit, `useOutdatedPlugins` caching and status derivation, and the selection state machine including panel selection surviving a visit to the screen.

Manual:

- Verified the screen against the playground's 13 installed plugins.
- Confirmed the collapsed sidebar keeps the expand button reachable — the 48px rail cannot fit two icon buttons in a row, and laying them out that way clipped the collapse button and stranded the user.

Not verified: the new Storybook stories were written but not opened in a browser. `apps/ui-storybook`'s `@storybook/*` dependencies are not installed in this environment and its `tsc -b` fails on every story file, new and pre-existing alike. Worth a visual pass before merge.
