### PR TITLE
feat: implement feature flags plugin

### DIFF
--- a/apps/playground/src/app/components/ui/KeyValueList.tsx
+++ b/apps/playground/src/app/components/ui/KeyValueList.tsx
@@ -1,0 +1,29 @@
+import { View } from 'react-native';
+import { List } from './List';
+import { KeyValueRow } from './KeyValueRow';
+import { useTheme } from '../../theme/useTheme';
+
+type KeyValueListItem = {
+  key?: string;
+  label: string;
+  value: string;
+};
+
+type KeyValueListProps = {
+  title?: string;
+  items: KeyValueListItem[];
+};
+
+export const KeyValueList = ({ title, items }: KeyValueListProps) => {
+  const { theme } = useTheme();
+
+  return (
+    <List title={title}>
+      {items.map((item) => (
+        <View key={item.key ?? item.label} style={{ paddingHorizontal: theme.spacing['2xl'] }}>
+          <KeyValueRow label={item.label} value={item.value} />
+        </View>
+      ))}
+    </List>
+  );
+};

--- a/apps/playground/src/app/components/ui/index.ts
+++ b/apps/playground/src/app/components/ui/index.ts
@@ -14,3 +14,4 @@ export { Badge } from './Badge';
 export type { BadgeVariant } from './Badge';
 export { EmptyState } from './EmptyState';
 export { KeyValueRow } from './KeyValueRow';
+export { KeyValueList } from './KeyValueList';

--- a/apps/playground/src/app/screens/ControlsPluginScreen.tsx
+++ b/apps/playground/src/app/screens/ControlsPluginScreen.tsx
@@ -5,7 +5,7 @@ import {
   Card,
   Field,
   Input,
-  KeyValueRow,
+  KeyValueList,
   PluginHeader,
   Row,
   Screen,
@@ -49,11 +49,7 @@ export const ControlsPluginScreen = () => {
         subtitle="Change state here or from DevTools — the panel mirrors the device."
       />
 
-      <Card>
-        {diagnostics.map(([label, value]) => (
-          <KeyValueRow key={label} label={label} value={value} />
-        ))}
-      </Card>
+      <KeyValueList items={diagnostics.map(([label, value]) => ({ label, value }))} />
 
       <Card>
         {(Object.entries(featureFlags) as [keyof typeof featureFlags, boolean][]).map(

--- a/apps/playground/src/app/screens/FeatureFlagsPluginScreen.tsx
+++ b/apps/playground/src/app/screens/FeatureFlagsPluginScreen.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import type { FeatureFlag } from '@rozenite/feature-flags-plugin';
-import { Button, KeyValueRow, List, PluginHeader, Row, Screen } from '../components/ui';
+import { Button, KeyValueList, PluginHeader, Row, Screen } from '../components/ui';
 import { featureFlagsOverrides, featureFlagsPluginAdapter } from '../feature-flags-plugin-adapters';
 import { useTheme } from '../theme/useTheme';
 
@@ -41,7 +41,6 @@ export const FeatureFlagsPluginScreen = () => {
 
   const newCheckoutEnabled = flagValue(flags, 'new-checkout-flow', false);
   const welcomeMessage = flagValue(flags, 'welcome-message', '');
-  const maxRetryCount = flagValue(flags, 'max-retry-count', 0);
   const themeConfig = flagValue<ThemeConfig>(flags, 'theme-config', {});
 
   return (
@@ -72,19 +71,14 @@ export const FeatureFlagsPluginScreen = () => {
         </Text>
       </View>
 
-      <Text style={[styles.retryText, { color: theme.colors.foreground }]}>
-        Retries on failure: {maxRetryCount}
-      </Text>
-
-      <List title="Effective flags">
-        {flags.map((flag) => (
-          <KeyValueRow
-            key={flag.key}
-            label={`${flag.key} (${flag.type}${flag.overridden ? ', overridden' : ''})`}
-            value={formatValue(flag)}
-          />
-        ))}
-      </List>
+      <KeyValueList
+        title="Effective flags"
+        items={flags.map((flag) => ({
+          key: flag.key,
+          label: `${flag.key} (${flag.type}${flag.overridden ? ', overridden' : ''})`,
+          value: formatValue(flag),
+        }))}
+      />
 
       <Row>
         <Button label="Refresh" variant="secondary" onPress={() => void refresh()} />
@@ -105,9 +99,5 @@ const styles = StyleSheet.create({
   },
   bannerSubtitle: {
     fontSize: 13,
-  },
-  retryText: {
-    fontSize: 13,
-    fontWeight: '500',
   },
 });

--- a/packages/feature-flags-plugin/src/ui/flag-value-cell.tsx
+++ b/packages/feature-flags-plugin/src/ui/flag-value-cell.tsx
@@ -3,6 +3,18 @@ import { useState } from 'react';
 import type { FeatureFlag, FeatureFlagValue } from '../shared/types';
 import { parseNumberInput } from './value-parsing';
 
+const JSON_PREVIEW_MAX_LENGTH = 120;
+
+/** A one-line `JSON.stringify` preview, clipped with an ellipsis -- the
+ * `{…}` chip used to be a static placeholder that never reflected the
+ * flag's actual value, so two different json flags looked identical. */
+const previewJson = (value: FeatureFlagValue): string => {
+  const serialized = JSON.stringify(value) ?? String(value);
+  return serialized.length > JSON_PREVIEW_MAX_LENGTH
+    ? `${serialized.slice(0, JSON_PREVIEW_MAX_LENGTH)}…`
+    : serialized;
+};
+
 export type FlagValueCellProps = {
   flag: FeatureFlag;
   disabled?: boolean;
@@ -40,10 +52,11 @@ export function FlagValueCell({
         type="button"
         onClick={onOpenJson}
         disabled={disabled}
+        title={JSON.stringify(flag.value)}
         aria-label={`Edit JSON value for ${flag.key}`}
-        className="rounded-sm border border-border bg-muted px-2 py-0.5 font-mono text-xs text-foreground hover:bg-accent disabled:pointer-events-none disabled:opacity-50"
+        className="max-w-md truncate rounded-sm border border-border bg-muted px-2 py-0.5 font-mono text-xs text-foreground hover:bg-accent disabled:pointer-events-none disabled:opacity-50"
       >
-        {'{…}'}
+        {previewJson(flag.value)}
       </button>
     );
   }
@@ -75,7 +88,8 @@ function TextValueCell({
           setEditing(true);
         }}
         aria-label={`Edit value for ${flag.key}`}
-        className="w-full rounded-sm px-1 py-0.5 text-left font-mono text-sm text-foreground hover:bg-accent/50 disabled:pointer-events-none disabled:opacity-50"
+        title={String(flag.value)}
+        className="block w-full truncate rounded-sm px-1 py-0.5 text-left font-mono text-sm text-foreground hover:bg-accent/50 disabled:pointer-events-none disabled:opacity-50"
       >
         {String(flag.value)}
       </button>

--- a/packages/feature-flags-plugin/src/ui/panel.tsx
+++ b/packages/feature-flags-plugin/src/ui/panel.tsx
@@ -13,7 +13,7 @@ import {
   useToast,
   VirtualizedDataTable,
 } from '@rozenite/ui';
-import { Flag, Loader2, RefreshCw, RotateCcw } from 'lucide-react';
+import { Eraser, Flag, Loader2, RefreshCw } from 'lucide-react';
 import { useEffect, useState, type ReactNode } from 'react';
 import type { FeatureFlagsProviderSnapshot } from '../shared/messaging';
 import type { FeatureFlag, FeatureFlagValue, JsonValue } from '../shared/types';
@@ -167,7 +167,7 @@ function FeatureFlagsPanelContent() {
           aria-label={`Reset ${row.original.key} to its default value`}
           title={`Reset ${row.original.key} to its default value`}
         >
-          <RotateCcw className="h-3.5 w-3.5" />
+          <Eraser className="h-3.5 w-3.5" />
         </Button>
       ),
     },
@@ -234,7 +234,7 @@ function FeatureFlagsPanelContent() {
           aria-label="Reset all overrides"
           title="Reset all overrides"
         >
-          <RotateCcw className="h-3.5 w-3.5" />
+          <Eraser className="h-3.5 w-3.5" />
           Reset all
         </Toolbar.Button>
         <Toolbar.Button

--- a/packages/ui/src/components/virtualized-data-table.tsx
+++ b/packages/ui/src/components/virtualized-data-table.tsx
@@ -110,7 +110,7 @@ const VirtualizedEmptyState = ({ context }: { context: VirtualizedTableContext<u
     <td colSpan={context.columnCount}>
       {context.renderEmptyState?.() ?? (
         <div className="flex min-h-56 w-full items-center justify-center px-4 py-10 text-center">
-          <span className="text-sm text-muted">
+          <span className="text-sm text-muted-foreground">
             {context.isLoading ? 'Loading…' : context.emptyMessage}
           </span>
         </div>


### PR DESCRIPTION
## Summary

Implements `@rozenite/feature-flags-plugin` following the adapter pattern established by the storage plugin. This addresses the need for unified debug tooling around feature flags in React Native.

## What's included

- **Adapter interface**: Generic pattern with first-party adapters for LaunchDarkly, Statsig, and a custom/local flags adapter
- **Feature flags panel**: UI to list all flags with current values and sources, search/filter, toggle overrides, and reset
- **Override store**: Device-side persistence that survives DevTools disconnects (dev-only)
- **Device hook**: Lightweight hook for accessing flags with RPC handlers
- **Agent tools**: `list-flags`, `get-flag`, `override-flag`, `clear-overrides` for agent-driven testing
- **Documentation**: Full docs with playground example and version plan

## Production readiness

- Hook is a no-op in production builds
- Hardened against malformed calls
- Proper lifecycle management to prevent RPC teardown on re-renders

Fixes #383