### PR TITLE
docs: add compatibility table and website page

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ Rozenite brings plug-and-play panels to React Native DevTools. Install plugins, 
 - **Production-Safe Controls**: Plugins are automatically disabled in production builds — no plugin code ships to your users.
 - **Easy to Build Your Own**: When you need something custom, create your own panel with type-safe, isomorphic APIs and great DX.
 
+## Compatibility
+
+| Rozenite | Expo SDK | React Native | Re.Pack |
+| -------- | -------- | ------------- | ------- |
+| 1.x      | 52+      | 0.76+          | 5.2+    |
+
+Bare React Native projects are supported too — match your React Native version to the one shipped by the minimum supported Expo SDK above. See the [Compatibility](https://rozenite.dev/docs/compatibility) page for full details.
+
 ## Documentation
 
 The documentation is available at [rozenite.dev](https://rozenite.dev). You can also use the following links to jump to specific topics:

--- a/website/src/docs/_meta.json
+++ b/website/src/docs/_meta.json
@@ -2,6 +2,7 @@
   { "type": "file", "name": "introduction", "label": "Introduction" },
   { "type": "file", "name": "prior-art", "label": "Prior Art" },
   { "type": "file", "name": "getting-started", "label": "Getting started" },
+  { "type": "file", "name": "compatibility", "label": "Compatibility" },
   { "type": "dir", "name": "agent", "label": "Rozenite for Agents" },
   { "type": "file", "name": "rozenite-for-web", "label": "Rozenite for Web" },
   {

--- a/website/src/docs/compatibility.mdx
+++ b/website/src/docs/compatibility.mdx
@@ -1,0 +1,31 @@
+# Compatibility
+
+## Supported versions
+
+| Rozenite | Expo SDK | React Native | Re.Pack |
+| -------- | -------- | ------------ | ------- |
+| 1.x      | 52+      | 0.76+        | 5.2+    |
+
+Rozenite tracks Expo SDK releases as its primary compatibility baseline, since each
+Expo SDK pins a specific React Native version. If you're on bare React Native
+(no Expo), match your React Native version to the one shipped by the minimum
+supported Expo SDK above.
+
+## Bundlers
+
+- **Metro** — supported via `@rozenite/metro`, using whichever Metro version ships with
+  your React Native version. No separate Metro version requirement beyond the React
+  Native minimum above.
+- **Re.Pack** — supported via `@rozenite/repack` for Re.Pack 5.2 and above.
+
+## Platforms
+
+- iOS and Android, via React Native DevTools
+- Web, via [Rozenite for Web](/docs/rozenite-for-web) (experimental)
+
+## Notes
+
+- Older Expo SDK / React Native versions may work but are untested and unsupported.
+- Individual plugins may declare narrower compatibility (for example, a plugin
+  wrapping a native module with its own minimum React Native version). Check the
+  plugin's page under [Official Plugins](/docs/official-plugins/overview) for details.


### PR DESCRIPTION
## Description

Adds a Compatibility section to the README and a new `/docs/compatibility` page on the website, documenting the currently supported Expo SDK / React Native / Re.Pack versions. Rozenite has never explicitly stated this baseline anywhere.

## Related Issue

N/A — documentation-only change, no issue tracked.

## Context

- Baseline is Expo SDK 52+ / React Native 0.76+, matching what the project currently supports.
- Re.Pack minimum (5.2+) comes from `packages/repack/package.json`'s `peerDependencies`.
- Metro has no separate minimum version constraint in `@rozenite/metro` (it only wraps Metro config), so it's documented as tracking whichever Metro ships with the supported React Native version.
- The new page is registered in `website/src/docs/_meta.json` right after "Getting started".

## Testing

- `npx oxfmt --check README.md website/src/docs/compatibility.mdx website/src/docs/_meta.json` — passes.
- Full `pnpm build` in `website/` could not be run in this environment due to a pre-existing, unrelated `core.hooksPath` conflict during `pnpm install`; the change is a straightforward `.mdx` page following the same structure as existing docs pages.