### PR TITLE
docs: simplify and humanize plugin and getting-started docs

### DIFF
--- a/website/src/docs/agent/skills.mdx
+++ b/website/src/docs/agent/skills.mdx
@@ -2,11 +2,9 @@
 
 If you use Codex or another coding agent that supports the Vercel `skills` CLI, you can install the Rozenite skill so the agent can use Rozenite for Agents efficiently.
 
-Rozenite ships a single skill, `rozenite`. It is a thin router: the installed skill contains no workflow content of its own, only a pointer telling the agent to discover and read the real content through the `rozenite skills` CLI command.
+Rozenite ships a single skill, `rozenite`. It's a thin router — installing it just points your agent at the `rozenite skills` CLI command, which serves the actual guidance (ground truths, CLI and SDK workflows, one doc per plugin domain) straight from the `rozenite` package. That guarantees the content always matches the version of Rozenite installed in your project.
 
-The actual guidance — ground truths, CLI and SDK workflows, and one doc per plugin domain — lives inside the `rozenite` CLI package itself and is versioned together with it. That's why the content moved out of the skill: whatever the agent reads through `rozenite skills` always matches the version of Rozenite actually installed in the project, instead of drifting out of sync with a separately-installed skill.
-
-Because of that, installing the skill is a convenience, not a requirement. If your coding agent doesn't use a skills CLI at all, you can point it straight at `npx rozenite skills list` and `npx rozenite skills show <id>` and it gets the exact same content.
+Because of that, installing the skill is a convenience, not a requirement. If your coding agent doesn't use a skills CLI at all, point it straight at `npx rozenite skills list` and `npx rozenite skills show <id>` and it gets the exact same content.
 
 This skill complements Rozenite; it does not replace it. Your app still needs Rozenite installed and configured because the agent ultimately talks to the running app through the Rozenite agent runtime.
 

--- a/website/src/docs/getting-started.mdx
+++ b/website/src/docs/getting-started.mdx
@@ -4,17 +4,11 @@ import { PackageManagerTabs } from '@rspress/core/theme';
 
 ## Pre-requisites
 
-If you're already familiar with JavaScript, React and React Native, then you'll be able to get moving quickly! Otherwise, it's highly recommended to get yourself familiar with these topics and then come back here:
+Rozenite assumes you're comfortable with a React Native project. If you're new to React Native, start with the [React Native documentation](https://reactnative.dev/) first.
 
-- [React Native documentation](https://reactnative.dev/)
-- [Metro bundler documentation](https://facebook.github.io/metro/)
-- [Re.Pack documentation](https://re-pack.dev/)
+## Install
 
-## Installation
-
-### Automatic Installation (Recommended)
-
-The easiest way to get started is with the `rozenite init` command. This command will automatically install the necessary packages and make the required configuration changes for your project.
+Run the `rozenite init` command in your project. It detects your bundler, installs the right package, and updates your config for you.
 
 <PackageManagerTabs
   command={{
@@ -25,169 +19,32 @@ The easiest way to get started is with the `rozenite init` command. This command
   }}
 />
 
-This command will:
+That's it — start your app as usual and open React Native DevTools. If everything worked, you'll see plugin panels for anything you've installed (see [Official Plugins](/docs/official-plugins/overview) to add some).
 
-- Detect your bundler (Metro or Re.Pack)
-- Install the appropriate Rozenite package
-- Modify your bundler configuration automatically
-- Set up plugin auto-discovery
+If the command fails, or you'd rather wire things up yourself, follow the manual steps below.
 
-If the automatic installation fails or you prefer to configure manually, follow the manual installation steps below.
+## Manual setup
 
-### Manual Installation
+### 1. Install the package for your bundler
 
-#### Choose Your Bundler
-
-Rozenite supports both Metro and Re.Pack bundlers. Choose the package that matches your setup:
-
-**For Metro bundler (default React Native bundler):**
+**Metro** (the default React Native bundler):
 
 <PackageManagerTabs command="install -D @rozenite/metro" />
 
-**For Re.Pack bundler:**
+**Re.Pack**:
 
 <PackageManagerTabs command="install -D @rozenite/repack" />
 
-## Configuration
+### 2. Enable Rozenite in your bundler config
 
-Rozenite integrates with your bundler configuration (Metro or Re.Pack) and requires explicit enablement through the `enabled` property. This section covers how to configure Rozenite for both bundlers.
-
-:::warning Manual Enablement Required
-Rozenite is disabled by default and must be explicitly enabled by providing the `enabled` configuration property in your bundler config. Without this property, Rozenite will not load any plugins or provide debugging functionality.
-:::
-
-### Metro Configuration
-
-To enable Rozenite's auto-discovery and plugin system with Metro, you need to modify your Metro configuration and **explicitly set the `enabled` property**. Rozenite will automatically discover and enable all installed plugins when enabled.
-
-**Important**: You must manually set the `enabled` property to `true` (or a condition that evaluates to `true`) for Rozenite to work. This ensures Rozenite only runs when you want it to.
-
-The most common pattern is to derive this from an environment variable:
+Rozenite is off by default, so it never runs in production by accident. Enable it explicitly, typically behind an environment variable so you can turn it on and off per run:
 
 ```bash
 # Enable Rozenite in development
 WITH_ROZENITE=true npm start
-
-# Or disable it
-WITH_ROZENITE=false npm start
 ```
 
-This approach provides several benefits:
-
-- **Production Safety**: Rozenite is automatically disabled in production builds
-- **Team Flexibility**: Different team members can enable/disable Rozenite as needed
-- **CI/CD Control**: Build systems can control when Rozenite is active
-- **Performance**: Disable Rozenite when not needed to reduce overhead
-
-##### Basic Configuration
-
-Update your `metro.config.js` file:
-
-```javascript title="metro.config.js"
-const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
-const { withRozenite } = require('@rozenite/metro');
-
-const defaultConfig = getDefaultConfig(__dirname);
-
-const customConfig = {
-  // Your existing Metro configuration
-};
-
-module.exports = withRozenite(mergeConfig(defaultConfig, customConfig), {
-  enabled: process.env.WITH_ROZENITE === 'true', // Required: Rozenite is disabled by default
-});
-```
-
-##### Advanced Configuration
-
-If you're using additional Metro plugins or configurations:
-
-```javascript title="metro.config.js"
-const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
-const { withRozenite } = require('@rozenite/metro');
-const { withNxMetro } = require('@nx/react-native'); // Example with Nx
-
-const defaultConfig = getDefaultConfig(__dirname);
-
-const customConfig = {
-  // Your existing Metro configuration
-};
-
-module.exports = withRozenite(withNxMetro(mergeConfig(defaultConfig, customConfig)), {
-  enabled: process.env.WITH_ROZENITE === 'true',
-});
-```
-
-### Re.Pack Configuration
-
-To enable Rozenite's auto-discovery and plugin system with Re.Pack, you need to modify your Re.Pack configuration. Rozenite integrates seamlessly with Re.Pack's DevServer.
-
-**Important**: Just like with Metro, you must manually set the `enabled` property to `true` (or a condition that evaluates to `true`) for Rozenite to work. This ensures Rozenite only runs when you want it to.
-
-#### Basic Configuration
-
-Update your `rspack.config.mjs` file:
-
-```javascript title="rspack.config.mjs"
-import { withRozenite } from '@rozenite/repack';
-
-export default withRozenite(
-  {
-    // Your existing Re.Pack configuration
-  },
-  {
-    enabled: process.env.WITH_ROZENITE === 'true', // Required: Rozenite is disabled by default
-  },
-);
-```
-
-#### With Custom Options
-
-Configure plugin discovery and filtering:
-
-```javascript title="rspack.config.mjs"
-import { withRozenite } from '@rozenite/repack';
-
-export default withRozenite(
-  {
-    // Your existing Re.Pack configuration
-  },
-  {
-    enabled: process.env.WITH_ROZENITE === 'true',
-    include: ['@rozenite/mmkv-plugin', '@rozenite/network-activity-plugin'],
-    exclude: ['unwanted-plugin'],
-    destroyOnDetachPlugins: ['@rozenite/network-activity-plugin'],
-  },
-);
-```
-
-## Auto-Discovery
-
-Once configured, Rozenite will automatically:
-
-- **Discover installed plugins** in your `node_modules`
-- **Enable all found plugins** without manual configuration
-- **Load plugin panels** into React Native DevTools
-- **Handle plugin communication** between DevTools and your React Native app
-
-### Plugin Discovery
-
-Rozenite automatically discovers plugins by looking for `rozenite.json` files in the `/dist` directory of packages. If a package contains this file, it's recognized as a Rozenite plugin.
-Rozenite searches for plugins by crawling the entire `node_modules` directory tree, starting from your project's `node_modules` and traversing up to the root of the file system. This means it will find plugins in:
-
-- Your project's `node_modules`
-- Parent directories' `node_modules` (if using workspaces or monorepos)
-- Global `node_modules` (if any)
-
-By default, Rozenite will automatically discover and load all plugins found in your `node_modules`.
-
-### Plugin Filtering
-
-While Rozenite automatically discovers all plugins by default, you can control which plugins are loaded using the configuration options:
-
-#### Include Specific Plugins
-
-If you want to load only specific plugins, you can use the `include` option. When this option is provided, auto-discovery is disabled and only the listed plugins will be loaded:
+**Metro** — update `metro.config.js`:
 
 ```javascript title="metro.config.js"
 const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
@@ -201,9 +58,10 @@ const customConfig = {
 
 module.exports = withRozenite(mergeConfig(defaultConfig, customConfig), {
   enabled: process.env.WITH_ROZENITE === 'true',
-  include: ['@rozenite/mmkv-plugin', '@rozenite/network-activity-plugin'],
 });
 ```
+
+**Re.Pack** — update `rspack.config.mjs`:
 
 ```javascript title="rspack.config.mjs"
 import { withRozenite } from '@rozenite/repack';
@@ -214,99 +72,34 @@ export default withRozenite(
   },
   {
     enabled: process.env.WITH_ROZENITE === 'true',
-    include: ['@rozenite/mmkv-plugin', '@rozenite/network-activity-plugin'],
   },
 );
 ```
 
-#### Exclude Specific Plugins
+### 3. Start your app
 
-To prevent certain plugins from loading while keeping auto-discovery enabled, use the `exclude` option:
+<PackageManagerTabs command="start" />
+
+Open React Native DevTools — any Rozenite plugins you've installed will show up automatically, no extra wiring needed.
+
+## Choosing which plugins load
+
+By default, every installed plugin loads automatically. If you want to limit that, pass `include` or `exclude` to `withRozenite`:
 
 ```javascript title="metro.config.js"
-const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
-const { withRozenite } = require('@rozenite/metro');
-
-const defaultConfig = getDefaultConfig(__dirname);
-
-const customConfig = {
-  // Your existing Metro configuration
-};
-
 module.exports = withRozenite(mergeConfig(defaultConfig, customConfig), {
   enabled: process.env.WITH_ROZENITE === 'true',
-  exclude: ['@rozenite/mmkv-plugin'],
+  include: ['@rozenite/mmkv-plugin', '@rozenite/network-activity-plugin'], // only load these
+  // or
+  exclude: ['@rozenite/mmkv-plugin'], // load everything except these
 });
 ```
 
-```javascript title="rspack.config.mjs"
-import { withRozenite } from '@rozenite/repack';
+The same options work in `withRozenite` for Re.Pack. If both `include` and `exclude` are set, `exclude` is applied after `include`.
 
-export default withRozenite(
-  {
-    // Your existing Re.Pack configuration
-  },
-  {
-    enabled: process.env.WITH_ROZENITE === 'true',
-    exclude: ['@rozenite/mmkv-plugin'],
-  },
-);
-```
+## Panel layout
 
-#### Combining Include and Exclude
-
-You can also combine both options. When both are provided, the `exclude` list is applied to the `include` list:
-
-```javascript title="metro.config.js"
-const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
-const { withRozenite } = require('@rozenite/metro');
-
-const defaultConfig = getDefaultConfig(__dirname);
-
-const customConfig = {
-  // Your existing Metro configuration
-};
-
-module.exports = withRozenite(mergeConfig(defaultConfig, customConfig), {
-  enabled: process.env.WITH_ROZENITE === 'true',
-  include: [
-    '@rozenite/mmkv-plugin',
-    '@rozenite/network-activity-plugin',
-    '@rozenite/tanstack-query-plugin',
-  ],
-  exclude: ['@rozenite/mmkv-plugin'], // This will be filtered out from the include list
-});
-```
-
-```javascript title="rspack.config.mjs"
-import { withRozenite } from '@rozenite/repack';
-
-export default withRozenite(
-  {
-    // Your existing Re.Pack configuration
-  },
-  {
-    enabled: process.env.WITH_ROZENITE === 'true',
-    include: [
-      '@rozenite/mmkv-plugin',
-      '@rozenite/network-activity-plugin',
-      '@rozenite/tanstack-query-plugin',
-    ],
-    exclude: ['@rozenite/mmkv-plugin'], // This will be filtered out from the include list
-  },
-);
-```
-
-**Note**: When using the `include` option, auto-discovery is completely disabled. Only the explicitly listed plugins will be loaded, and any plugins not in the list will be ignored, even if they are installed in your `node_modules`.
-
-## Plugin display
-
-By default, Rozenite puts all available plugin panels in one DevTools tab. Use
-the sidebar to move between panels. Plugins with one panel appear directly in
-the list, while plugins with several panels are grouped together.
-
-If you prefer each panel to have its own DevTools tab, set `pluginDisplay` to
-`'tabs'` in your Rozenite configuration:
+Plugins with multiple panels are grouped together in one sidebar by default; plugins with a single panel appear directly in the list. If you'd rather give every panel its own DevTools tab, set `pluginDisplay: 'tabs'`:
 
 ```javascript title="metro.config.js"
 module.exports = withRozenite(mergeConfig(defaultConfig, customConfig), {
@@ -315,66 +108,22 @@ module.exports = withRozenite(mergeConfig(defaultConfig, customConfig), {
 });
 ```
 
-## Plugin State Management
-
-By default, Rozenite preserves plugin UI state when switching between DevTools panels. This provides a smooth user experience where data doesn't get lost when navigating between different plugins. However, for plugins that consume significant memory or resources, you may want to destroy them when they're not active.
-
-### Configuring Plugin Destruction
-
-Use the `destroyOnDetachPlugins` option to specify which plugins should be destroyed when switching panels:
+Rozenite also keeps a plugin's UI state in memory when you switch away from its panel, so you don't lose data by navigating around. For plugins that use a lot of memory, you can opt out per plugin with `destroyOnDetachPlugins` — the trade-off is that the plugin resets and reloads each time you come back to it:
 
 ```javascript title="metro.config.js"
-const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
-const { withRozenite } = require('@rozenite/metro');
-
-const defaultConfig = getDefaultConfig(__dirname);
-
-const customConfig = {
-  // Your existing Metro configuration
-};
-
 module.exports = withRozenite(mergeConfig(defaultConfig, customConfig), {
   enabled: process.env.WITH_ROZENITE === 'true',
-  destroyOnDetachPlugins: ['@rozenite/network-activity-plugin', '@rozenite/tanstack-query-plugin'],
+  destroyOnDetachPlugins: ['@rozenite/network-activity-plugin'],
 });
 ```
 
-```javascript title="rspack.config.mjs"
-import { withRozenite } from '@rozenite/repack';
+## Verifying it worked
 
-export default withRozenite(
-  {
-    // Your existing Re.Pack configuration
-  },
-  {
-    enabled: process.env.WITH_ROZENITE === 'true',
-    destroyOnDetachPlugins: [
-      '@rozenite/network-activity-plugin',
-      '@rozenite/tanstack-query-plugin',
-    ],
-  },
-);
-```
+- Your bundler's server logs should mention discovering Rozenite plugins.
+- React Native DevTools should show a panel for each plugin you've installed.
 
-Trade-offs when using this option:
+If nothing shows up, double check that `enabled` evaluates to `true` and that you restarted the bundler after changing the config.
 
-- **Lost state** - Plugin state is reset every time you switch to another panel
-- **Slower navigation** - Plugin needs to reinitialize when switching back
-
-## Usage
-
-After configuration, start your development server as usual:
-
-<PackageManagerTabs command="start" />
-
-Rozenite will automatically load and enable all discovered plugins. You can verify this by checking your bundler server logs for plugin discovery messages.
+## Using Rozenite with AI coding agents
 
 If you use AI or coding agents in your workflow, continue with the [Rozenite for Agents overview](/docs/agent/overview).
-
-## Verification
-
-To verify that Rozenite is working correctly:
-
-1. **Check bundler logs** - You should see plugin discovery messages in Metro or Re.Pack server logs
-2. **Open React Native DevTools** - Your app should show additional panels from discovered plugins
-3. **Check Chrome DevTools** - Open Chrome DevTools within the React Native DevTools window (DevTools inception!) and look for Rozenite logs in the console

--- a/website/src/docs/official-plugins/controls.mdx
+++ b/website/src/docs/official-plugins/controls.mdx
@@ -4,17 +4,7 @@ import { PackageManagerTabs } from '@rspress/core/theme';
 
 ![](/controls-plugin.png)
 
-The Controls plugin lets you expose app-defined runtime controls inside React Native DevTools. Instead of adding temporary debug screens or hidden menus, you can give your team a dedicated panel for toggles, pickers, inputs, actions, and read-only status values.
-
-## What is Controls Plugin?
-
-The Controls plugin is a lightweight way to build a custom DevTools surface for your app. It provides:
-
-- **Read-only Status Fields**: Show current runtime values such as environment, build label, counters, or sync state
-- **Toggles**: Turn feature flags and boolean options on or off from DevTools
-- **Select Menus**: Switch between predefined options such as local, staging, and production
-- **Text Inputs**: Update text-based settings without changing in-app UI
-- **Action Buttons**: Trigger one-off actions such as reset, sync, refetch, or checkpoint creation
+The Controls plugin lets you build your own DevTools panel out of app-defined controls — status fields, toggles, selects, text inputs, and buttons — instead of adding temporary debug screens or hidden menus to your app.
 
 ## Installation
 
@@ -104,61 +94,22 @@ With [Rozenite for Web](/docs/rozenite-for-web), this plugin is available when y
 
 ## Usage
 
-Once configured, the Controls plugin appears in your React Native DevTools sidebar as `Controls`.
+Once configured, the Controls plugin appears in your React Native DevTools sidebar as `Controls`. Typical uses: flipping feature flags during manual testing, switching between local/staging/production, resetting temporary app state, or triggering checkpoints for demos and QA — all without adding a debug screen to your app.
 
-Use it when you want to:
+## Control types
 
-- flip feature flags without building dedicated debug UI
-- change runtime targets such as environment or API variant
-- submit text values like labels, tokens, or test identifiers
-- trigger app actions directly from DevTools
-- keep read-only status values visible while testing flows
+- **`text`** — a read-only value you want to observe, like status, counters, or a timestamp.
+- **`toggle`** — a boolean setting, like a feature flag or logging switch.
+- **`select`** — a choice from a fixed list of options.
+- **`input`** — an editable text value, like a release label or test ID.
+- **`button`** — a one-off action, like reset, sync, or retry.
 
-## Control Types
+## Organizing sections
 
-### Text
+Keep diagnostics and editable controls in separate sections, use short titles, and add a description when a control has side effects. Keep section and item IDs stable across reloads so the panel doesn't jump around.
 
-Use `text` items for values you want to observe but not edit, such as status, counters, or last action timestamps.
+## Validation
 
-### Toggle
-
-Use `toggle` items for boolean settings such as feature flags, logging switches, and debug modes.
-
-### Select
-
-Use `select` items when the user must choose from a fixed list of options.
-
-### Input
-
-Use `input` items for text-based values. This is useful for release labels, test IDs, user identifiers, or other string settings you want to edit from DevTools.
-
-### Button
-
-Use `button` items for single actions. Good examples are reset, sync, refresh, retry, and seed actions.
-
-## Organizing Sections
-
-Sections help keep the panel understandable:
-
-- Put diagnostics and editable controls in separate sections.
-- Prefer short titles so the panel stays easy to scan.
-- Add descriptions when a control has side effects or temporary constraints.
-- Keep section and item IDs stable across reloads.
-
-## Validation and Availability
-
-You can shape the user experience without exposing implementation details in the panel:
-
-- Use `validate` to reject invalid values with a clear message.
-- Use `disabled` when a control should stay visible but unavailable.
-- Use `applyLabel` on text inputs when a custom action label reads better than the default.
-
-## Common Uses
-
-- feature flag management during manual testing
-- switching between local, staging, and production services
-- resetting temporary app state
-- triggering checkpoints for demos or QA flows
-- exposing internal diagnostics without adding a screen to the app
+Use `validate` to reject invalid input with a clear message, `disabled` to keep a control visible but unavailable, and `applyLabel` to customize a text input's action label.
 
 **Next**: Explore other [Official Plugins](./overview.md) or learn how to build your own in the [Plugin Development guide](../plugin-development/plugin-development.md).

--- a/website/src/docs/official-plugins/expo-atlas.mdx
+++ b/website/src/docs/official-plugins/expo-atlas.mdx
@@ -4,27 +4,15 @@ import { PackageManagerTabs } from '@rspress/core/theme';
 
 ![](/expo-atlas-plugin.png)
 
-The Expo Atlas plugin integrates [Expo Atlas](https://github.com/expo/expo-atlas) directly into your React Native DevTools, providing powerful bundle analysis and optimization capabilities for your React Native applications.
-
-## What is Expo Atlas?
-
-Expo Atlas is a bundle analyzer and visualizer that helps you understand and optimize your React Native app's Metro bundle. It provides:
-
-- **Bundle Visualization**: Interactive view of your Metro bundle structure
-- **Module Analysis**: Detailed information about each module in your bundle
-- **Size Optimization**: Identify large dependencies and optimize bundle size
-- **Dependency Mapping**: Visualize module relationships and dependencies
-- **Performance Insights**: Understand how your bundle affects app performance
+The Expo Atlas plugin brings [Expo Atlas](https://github.com/expo/expo-atlas) into React Native DevTools, so you can explore your Metro bundle, see what's taking up space, and trace dependencies without leaving DevTools.
 
 ## Installation
 
 Make sure to go through the [Getting Started guide](/docs/getting-started) before installing the plugin.
 
-Install the Expo Atlas plugin as a development dependency using your preferred package manager:
-
 <PackageManagerTabs command="install -D @rozenite/expo-atlas-plugin" />
 
-Update your Metro configuration to enable the Expo Atlas plugin:
+Update your Metro configuration to enable the plugin:
 
 ```javascript title="metro.config.js"
 const { withRozenite } = require('@rozenite/metro');
@@ -42,44 +30,11 @@ module.exports = withRozenite(config, {
 
 ## Usage
 
-Once configured, the Expo Atlas plugin will automatically appear in your React Native DevTools sidebar as "Expo Atlas". Click on it to access:
+Once configured, "Expo Atlas" appears in your React Native DevTools sidebar. From there you can:
 
-### Bundle Overview
+- See total bundle size broken down by module and file type
+- Inspect an individual module's size, source, and dependency chain
+- Spot large dependencies, duplicated code, and unused code
+- Analyze your development bundle live, or export and analyze a production bundle
 
-- **Bundle Size Analysis**: View total bundle size and breakdown by module
-- **Module Distribution**: See how your bundle is distributed across different file types
-- **Entry Points**: Identify main entry points and their dependencies
-
-### Module Details
-
-- **Individual Module Sizes**: Analyze the size contribution of each module
-- **Source Code Inspection**: View the actual source code of modules in your bundle
-- **Dependency Chains**: Trace how modules depend on each other
-
-### Optimization Insights
-
-- **Large Dependencies**: Identify modules that significantly impact bundle size
-- **Duplicate Code**: Find potential code duplication across modules
-- **Unused Code**: Detect potentially unused dependencies
-
-### Development vs Production
-
-- **Development Bundle**: Analyze your development bundle in real-time
-- **Production Bundle**: Export and analyze production bundles for optimization
-
-## Contributing
-
-The Expo Atlas plugin is open source and welcomes contributions! Check out the [Plugin Development Guide](../plugin-development/plugin-development.md) to learn how to contribute or create your own plugins.
-
-## Support
-
-If you encounter issues with the Expo Atlas plugin:
-
-1. **Check Documentation**: Review this guide for common solutions
-2. **Search Issues**: Look for similar issues in the repository
-3. **Create Issue**: Report bugs or request features
-4. **Community**: Reach out to the Rozenite community for help
-
----
-
-**Next**: Learn about [Plugin Development](../plugin-development/plugin-development.md) to create your own plugins, or explore other [Official Plugins](./overview.md).
+**Next**: Explore other [Official Plugins](./overview.md), or learn to build your own in the [Plugin Development guide](../plugin-development/plugin-development.md).

--- a/website/src/docs/official-plugins/file-system.mdx
+++ b/website/src/docs/official-plugins/file-system.mdx
@@ -2,29 +2,15 @@ import { PackageManagerTabs } from '@rspress/core/theme';
 
 # File System Plugin
 
-The File System plugin provides an in-app file explorer for React Native DevTools, so you can inspect app directories and preview text or image files directly from the DevTools UI.
-
-## What is File System Plugin?
-
-The File System plugin helps you browse the files your app can access at runtime. It provides:
-
-- **Directory Browsing**: Inspect document, cache, temporary, library, and bundle directories
-- **Provider Support**: Works with Expo FileSystem and RNFS-compatible libraries
-- **Text Preview**: Open text files directly in DevTools
-- **Image Preview**: Preview image files inline
-- **Binary Fallback Preview**: Show a hex-style dump when a file cannot be decoded as text
-- **File Transfer**: Import and export single files through explicit opt-in workflows
-- **Path Navigation**: Jump between roots, navigate nested folders, and move back through history
+The File System plugin adds a file explorer to React Native DevTools, so you can browse your app's directories and preview files without leaving the DevTools window.
 
 ## Installation
 
 Make sure to go through the [Getting Started guide](/docs/getting-started) before installing the plugin.
 
-Install the File System plugin:
-
 <PackageManagerTabs command="install -D @rozenite/file-system-plugin" />
 
-Install one supported filesystem provider in your app:
+Install whichever filesystem library your app already uses:
 
 <PackageManagerTabs command="install -D expo-file-system" />
 
@@ -68,11 +54,11 @@ function App() {
 }
 ```
 
-Once configured, the plugin appears in React Native DevTools as "File System".
+Once configured, the plugin appears in DevTools as "File System". You can jump between roots (document, cache, bundle, and others depending on your library), navigate folders, and preview text and image files inline. Files that can't be decoded as text fall back to a hex-style preview.
 
-## File Transfer
+## File transfer
 
-File import and export are disabled by default. Enable them explicitly with the `fileTransfer` option when you want the DevTools panel to move raw files in or out of app-accessible directories.
+Importing and exporting files is off by default. Turn it on with `fileTransfer` when you want the panel to move files in or out of your app:
 
 ```ts title="App.tsx"
 useFileSystemDevTools({
@@ -84,9 +70,9 @@ useFileSystemDevTools({
 });
 ```
 
-When enabled, the File System panel lets you import a single file into the currently viewed directory and export a selected file. Imports keep the original filename and ask before overwriting an existing file.
+Imports keep the original filename and ask before overwriting an existing file.
 
-Agent-triggered file transfer is controlled separately. Enable it only when agents should be allowed to import or export exact file contents through Rozenite for Agents.
+If you also want coding agents to import or export files through Rozenite for Agents, opt in separately:
 
 ```ts title="App.tsx"
 useFileSystemDevTools({
@@ -94,80 +80,27 @@ useFileSystemDevTools({
   fileTransfer: {
     import: true,
     export: true,
-    agent: {
-      import: true,
-      export: true,
-    },
+    agent: { import: true, export: true },
   },
 });
 ```
-
-## Available Roots
-
-### Expo FileSystem
-
-When available, the plugin exposes these roots:
-
-- `documentDirectory`
-- `cacheDirectory`
-- `bundleDirectory`
-
-### RNFS
-
-When available, the plugin exposes these roots:
-
-- `DocumentDirectoryPath`
-- `CachesDirectoryPath`
-- `TemporaryDirectoryPath`
-- `LibraryDirectoryPath`
-- `MainBundlePath`
 
 ## Notes
 
-:::warning Provider Required
-The plugin does not auto-detect a filesystem library. Pass `adapter` to `useFileSystemDevTools()`.
+:::warning Provider required
+The plugin doesn't auto-detect a filesystem library — you always need to pass an `adapter`.
 :::
 
-:::info Preview Limits
-File previews are size-limited to keep DevTools responsive. Very large files may fail to preview, and very large Expo directories are truncated in the listing UI.
+:::info Preview limits
+Previews are size-limited to keep DevTools responsive. Very large files may not preview, and very large directories are truncated in the listing.
 :::
 
-- `createExpoFileSystemAdapter` supports both the modern `expo-file-system` API and `expo-file-system/legacy`.
-- `createRNFSAdapter` wraps `react-native-fs` and `@dr.pogodin/react-native-fs`.
-- Text previews fall back to a binary hex-style dump when UTF-8 decoding fails.
-- Expo and RNFS expose slightly different root directories depending on platform and runtime environment.
-- File transfer supports single files only and is restricted to visible filesystem roots.
+- `createExpoFileSystemAdapter` works with both the modern `expo-file-system` API and `expo-file-system/legacy`.
+- `createRNFSAdapter` supports both `react-native-fs` and `@dr.pogodin/react-native-fs`.
+- File transfer handles one file at a time, within visible filesystem roots.
 
 ## Agent Tools (LLM Integration)
 
-When this plugin is active, it registers agent tools under the `@rozenite/file-system-plugin` domain.
+When active, this plugin registers agent tools under the `@rozenite/file-system-plugin` domain: `list-roots`, `list-entries`, `read-entry`, `read-text-file`, `read-image-file`, plus `export-file` / `import-file` when the matching `fileTransfer.agent` option is enabled.
 
-Available tools:
-
-- `list-roots`
-- `list-entries`
-- `read-entry`
-- `read-text-file`
-- `read-image-file`
-- `export-file` when `fileTransfer.agent.export` is enabled
-- `import-file` when `fileTransfer.agent.import` is enabled
-
-This makes the plugin usable from Rozenite for Agents workflows in Codex, Cursor, and other coding agents that speak to the `rozenite agent` CLI.
-
-## Contributing
-
-The File System plugin is open source and welcomes contributions. Check out the [Plugin Development Guide](../plugin-development/plugin-development.md) to learn how to contribute or create your own plugins.
-
-## Support
-
-If you encounter issues with the File System plugin:
-
-1. **Check Documentation**: Review this guide for common solutions
-2. **Verify Setup**: Ensure your chosen filesystem library is installed and passed into the hook
-3. **Search Issues**: Look for similar issues in the repository
-4. **Create Issue**: Report bugs or request features
-5. **Community**: Reach out to the Rozenite community for help
-
----
-
-**Next**: Learn about [Plugin Development](../plugin-development/plugin-development.md) to create your own plugins, or explore other [Official Plugins](./overview.md).
+**Next**: Learn about [Plugin Development](../plugin-development/plugin-development.md), or explore other [Official Plugins](./overview.md).

--- a/website/src/docs/official-plugins/mmkv.mdx
+++ b/website/src/docs/official-plugins/mmkv.mdx
@@ -4,151 +4,54 @@ import { PackageManagerTabs } from '@rspress/core/theme';
 
 ![](/mmkv-plugin.png)
 
-The MMKV plugin provides comprehensive storage inspection and management for React Native applications using MMKV, offering real-time data visualization and editing capabilities directly within your DevTools environment.
+The MMKV plugin lets you inspect and edit [MMKV](https://github.com/mrousavy/react-native-mmkv) storage from React Native DevTools in real time.
 
-:::warning Deprecation Notice
-The MMKV plugin is planned to be deprecated in favor of the generic [Storage plugin](./storage.md), which supports MMKV and additional storage backends through adapters.
+:::warning Deprecation notice
+This plugin is being phased out in favor of the generic [Storage plugin](./storage.md), which covers MMKV plus other storage backends.
 :::
-
-## What is MMKV Plugin?
-
-The MMKV plugin is a powerful debugging tool that helps you inspect and manage MMKV storage instances in your React Native application. It provides:
-
-- **Real-time Storage Inspection**: View all MMKV instances and their contents in real-time
-- **Multi-Instance Support**: Manage and inspect multiple MMKV instances simultaneously
-- **Data Type Detection**: Automatically detects and displays different data types (string, number, boolean, buffer)
-- **Search & Filter**: Quickly find specific keys with real-time search functionality
-- **Visual Data Representation**: Color-coded type indicators and formatted value display
-- **Data Management**: Add, edit, and delete entries directly from the DevTools interface
-- **Type-aware Editing**: Input validation based on data types when editing entries
-- **Blacklist Filtering**: Filter out sensitive data or large binary blobs using regex patterns
 
 ## Installation
 
 Make sure to go through the [Getting Started guide](/docs/getting-started) before installing the plugin.
 
-Install the MMKV plugin and its peer dependencies:
-
 <PackageManagerTabs command="install -D @rozenite/mmkv-plugin react-native-mmkv" />
-
-Add the DevTools hook to your React Native app to enable MMKV storage inspection:
 
 ```typescript title="App.tsx"
 import { MMKV } from 'react-native-mmkv';
 import { useMMKVDevTools } from '@rozenite/mmkv-plugin';
 
-// Create your MMKV instances
 const userStorage = new MMKV({ id: 'user-storage' });
 const appSettings = new MMKV({ id: 'app-settings' });
-const cacheStorage = new MMKV({ id: 'cache-storage' });
 
 function App() {
-  // Enable MMKV DevTools with your storage instances
   useMMKVDevTools({
     storages: {
       'user-storage': userStorage,
       'app-settings': appSettings,
-      'cache-storage': cacheStorage,
     },
   });
 
   return <YourApp />;
 }
 ```
+
+:::warning Explicit registration
+Only the storages you pass into `storages` are visible in DevTools — the plugin can't auto-detect MMKV instances.
+:::
 
 ## Usage
 
-Once configured, the MMKV plugin will automatically appear in your React Native DevTools sidebar as "MMKV Storage". Click on it to access:
+Once configured, "MMKV Storage" appears in your React Native DevTools sidebar. Switch between registered instances, search keys, and add, edit, or delete entries with type-aware validation.
 
-### Storage Instance Management
+## Hiding sensitive data
 
-- **Instance Selection**: Choose which MMKV instance to inspect from a dropdown
-- **Multi-Instance View**: Switch between different storage instances easily
-- **Real-time Updates**: See changes to your MMKV storage as they happen
-
-### Data Inspection and Management
-
-- **Key-Value Display**: View all stored keys with their types and values
-- **Type Indicators**: Visual indicators for different data types:
-  - **String**: Text values with proper formatting
-  - **Number**: Numeric values (integers and floats)
-  - **Boolean**: True/false values
-  - **Buffer**: Binary data representation
-- **Search Functionality**: Filter entries by key name for quick access
-- **Blacklist Filtering**: Hide sensitive or large data using RegExp patterns
-- **Data Editing**: Modify existing values with type validation
-- **Entry Management**: Add new entries or delete existing ones
-
-## Configuration
-
-### Blacklist Filtering
-
-The MMKV plugin supports filtering out specific properties using RegExp patterns. This is useful for hiding sensitive data or large binary blobs that might slow down the DevTools.
-
-The blacklist RegExp is matched against `{storageId}:{key}` format:
+Use `blacklist` to hide keys by pattern — useful for tokens, secrets, or large binary blobs. The pattern is matched against `{storageId}:{key}`:
 
 ```typescript title="App.tsx"
-function App() {
-  useMMKVDevTools({
-    storages: {
-      'user-storage': userStorage,
-      'app-settings': appSettings,
-      'cache-storage': cacheStorage,
-    },
-    // Hide sensitive tokens, large binary data, and temporary cache entries
-    blacklist: /.*:(token|password|secret)|cache-storage:.*Binary.*|.*:temp.*/,
-  });
-
-  return <YourApp />;
-}
+useMMKVDevTools({
+  storages: { 'user-storage': userStorage, 'cache-storage': cacheStorage },
+  blacklist: /.*:(token|password|secret)|cache-storage:.*Binary.*/,
+});
 ```
 
-This example filters out:
-
-- Any key containing "token", "password", or "secret" across all storages
-- Keys ending with "Binary" in the cache-storage instance
-- Any key containing "temp" in any storage instance
-
-You can combine multiple patterns using the `|` operator to create comprehensive filtering rules that hide sensitive data while keeping your DevTools interface clean and performant.
-
-### Important Notes
-
-:::warning Explicit Storage Registration
-You must explicitly provide all MMKV instances you want to inspect to the `useMMKVDevTools` hook. The plugin cannot automatically detect MMKV instances - only the storages you pass in the `storages` record will be available in the DevTools interface.
-:::
-
-:::info Development Only
-The MMKV plugin is automatically disabled in production builds for security and performance reasons.
-:::
-
-## Best Practices
-
-### Storage Organization
-
-- **Use Descriptive IDs**: Give your MMKV instances meaningful identifiers
-- **Separate Concerns**: Use different instances for different data types (user data, settings, cache)
-- **Consistent Naming**: Follow a naming convention for your storage instances
-
-### Development Workflow
-
-- **Monitor Storage Changes**: Use the real-time updates to debug storage-related issues
-- **Test Data Persistence**: Verify that data is stored and retrieved correctly
-- **Debug State Issues**: Inspect storage contents when debugging app state problems
-
-## Contributing
-
-The MMKV plugin is open source and welcomes contributions! Check out the [Plugin Development Guide](../plugin-development/plugin-development.md) to learn how to contribute or create your own plugins.
-
-## Support
-
-If you encounter issues with the MMKV plugin:
-
-1. **Check Documentation**: Review this guide for common solutions
-2. **Verify Setup**: Ensure `react-native-mmkv` is properly installed and configured
-3. **Search Issues**: Look for similar issues in the repository
-4. **Create Issue**: Report bugs or request features
-5. **Community**: Reach out to the Rozenite community for help
-
----
-
-**Next**: Learn about [Plugin Development](../plugin-development/plugin-development.md) to create your own plugins, or explore other [Official Plugins](./overview.md).
+**Next**: Learn about [Plugin Development](../plugin-development/plugin-development.md), or explore other [Official Plugins](./overview.md).

--- a/website/src/docs/official-plugins/network-activity.mdx
+++ b/website/src/docs/official-plugins/network-activity.mdx
@@ -4,51 +4,29 @@ import { PackageManagerTabs } from '@rspress/core/theme';
 
 ![](/network-activity-plugin.png)
 
-The Network Activity plugin provides comprehensive network request monitoring for React Native applications, offering real-time network debugging capabilities similar to Chrome DevTools Network panel.
+The Network Activity plugin brings a Chrome-DevTools-style network inspector into React Native DevTools: every HTTP/HTTPS request, WebSocket connection, and Server-Sent Event your app makes, in real time.
 
-## What is Network Activity Plugin?
-
-The Network Activity plugin is a powerful debugging tool that helps you monitor and analyze all network requests in your React Native application. It provides:
-
-- **Real-time Network Monitoring**: Track all HTTP/HTTPS requests as they happen
-- **Request Details**: View request headers, method, URL, and timing information
-- **Response Inspection**: Examine response headers, status codes, and timing data
-- **Performance Analysis**: Analyze request duration, connection timing, and performance metrics
-- **Request History**: Maintain a searchable history of network activity
-- **Nitro Support**: Merge `react-native-nitro-fetch` HTTP and WebSocket traffic into the same inspector when available
-
-:::warning JavaScript Thread Only
-Built-in React Native inspectors only capture traffic coming from the JavaScript thread. If your app uses `react-native-nitro-fetch`, Rozenite also listens to nitro's inspector events and displays that traffic in the same panel. Other native networking stacks still won't appear automatically.
+:::warning JavaScript thread only
+Built-in React Native inspectors only see traffic from the JavaScript thread. If your app uses `react-native-nitro-fetch`, install it alongside this plugin and its traffic shows up in the same panel. Other native networking stacks won't appear automatically.
 :::
 
 ## Installation
 
-Make sure to go through the [Getting Started guide](/docs/getting-started) before installing the plugin
-
-Install the Network Activity plugin as a development dependency using your preferred package manager:
+Make sure to go through the [Getting Started guide](/docs/getting-started) before installing the plugin.
 
 <PackageManagerTabs command="install -D @rozenite/network-activity-plugin" />
-
-If your app uses nitro networking, install `react-native-nitro-fetch` as well:
-
-```bash
-npm install react-native-nitro-fetch
-```
-
-Add the DevTools hook to your React Native app to enable network monitoring:
 
 ```typescript title="App.tsx"
 import { useNetworkActivityDevTools } from '@rozenite/network-activity-plugin';
 
 function App() {
-  // Enable Network Activity DevTools in development
   useNetworkActivityDevTools();
 
   return <YourApp />;
 }
 ```
 
-To capture network requests happening before your React Native app initialization, add this to your entrypoint:
+To also capture requests made before your app finishes initializing, add this to your entry point:
 
 ```typescript title="index.js"
 import { withOnBootNetworkActivityRecording } from '@rozenite/network-activity-plugin';
@@ -56,105 +34,38 @@ import { withOnBootNetworkActivityRecording } from '@rozenite/network-activity-p
 withOnBootNetworkActivityRecording();
 ```
 
+If your app uses nitro networking, install it too, and its HTTP and WebSocket traffic merges into the same panel automatically:
+
+```bash
+npm install react-native-nitro-fetch
+```
+
 ## Usage
 
-Once configured, the Network Activity plugin will automatically appear in your React Native DevTools sidebar as "Network Activity". Click on it to access:
+Once configured, "Network Activity" appears in your React Native DevTools sidebar. The request list shows method, status, timing, and a `Built-in` / `Nitro` badge for where each request came from. Click any request for full details: headers, query parameters, and request/response bodies.
 
-### Network Request List
+### Viewing responses
 
-- **Real-time Updates**: See network requests as they happen in your app
-- **Request Status**: View request status (pending, completed, failed)
-- **HTTP Methods**: Identify GET, POST, PUT, DELETE, and other HTTP methods
-- **Response Codes**: See HTTP status codes and their meanings
-- **Request Timing**: Monitor request duration and performance
-- **Source Badges**: Distinguish built-in React Native traffic from nitro traffic with `Built-in` and `Nitro` badges
+The response body view adapts to the content type, with a Preview / Raw toggle when both are useful:
 
-### Request Details
-
-- **Headers**: Inspect request and response headers
-- **Query Parameters**: View URL parameters and their values
-- **Request Body**: Examine POST/PUT request payloads
-- **Response Body**: View response content and structure (see [Response Viewing](#response-viewing) below)
-- **Source Metadata**: See whether an entry came from the built-in inspector or the nitro inspector
-
-### Response Viewing
-
-The response body view adapts to the format of each captured response and exposes a Preview / Raw sub-tab when both views are useful:
-
-- **Images** (`image/png`, `image/jpeg`, `image/gif`, `image/webp`, ...) render inline in the Preview tab via a data URL. The Raw tab shows a **metadata card** (decoded size, `Content-Length` header when present, derived filename, Download button) and a **hex viewer** with offset / hex / ASCII columns.
-- **SVG** (`image/svg+xml`) renders inline in the Preview tab and shows the source XML in the Raw tab — SVG is text on the wire, not bytes, so there is no hex view for it.
-- **Non-image binary** (`application/pdf`, `application/zip`, `audio/*`, `video/*`, `font/*`, `application/octet-stream`, ...) shows the same metadata card + hex viewer pair. There is no Preview for these formats — the hex view _is_ the inspection surface, and the Preview / Raw toggle is hidden.
-- **JSON** renders as a collapsible tree with copy affordances on every key and value in the Preview tab. The Raw tab shows the body pretty-printed with 2-space indent, so minified JSON is readable without leaving the panel.
-- **HTML** (`text/html`) renders inside a sandboxed iframe in the Preview tab — scripts are blocked and external subresources (images, stylesheets, fonts) are disallowed via Content-Security-Policy, so the preview cannot make outbound requests on behalf of the captured response. The Raw tab shows the HTML source.
-- **XML** (`application/xml`, `text/xml`, and RFC 7303 composite types like `application/atom+xml`, `application/rss+xml`, `application/soap+xml`, `application/xhtml+xml`, ...) renders as a collapsible tree with copy affordances on elements, text, and CDATA values in the Preview tab. The Raw tab shows the XML source verbatim. Malformed XML falls back to source with a warning.
-- **Text and other source formats** (`text/plain`, `text/css`, `application/javascript`, ...) render as raw monospace text.
-- **Empty or oversized responses** show a clear placeholder. Binary responses above an in-capture 5 MB cap surface as "Response too large for preview" instead of crossing the bridge; the Download button is disabled for those entries with a tooltip explaining the cap.
-
-The Preview / Raw toggle remembers your choice across requests in a panel session — once you toggle to Raw, subsequent responses whose renderer supports Raw stay on Raw. Formats with only one meaningful view hide the toggle entirely.
-
-Text response bodies above 50 KB render inside a virtualized 500 px scrollable window so the panel stays responsive on multi-megabyte payloads (pretty-printed JSON, minified bundles served as text, large logs). Smaller bodies render as a flat block. No content is truncated.
-
-#### Downloading bytes
-
-Every binary response (image, PDF, font, audio, ...) ships with a Download button on its metadata card. The filename is derived in three tiers:
-
-1. `Content-Disposition` header's `filename` parameter (RFC 5987 `filename*` is preferred when both forms are present).
-2. The last path segment of the response URL.
-3. `response.<ext>` where the extension comes from a small content-type → extension map (e.g. `application/pdf` → `.pdf`, `font/woff2` → `.woff2`); unknown content-types fall back to `.bin`.
-
-## Nitro Behavior
-
-When `react-native-nitro-fetch` is installed, the plugin automatically subscribes to nitro's network inspector.
-
-- Nitro HTTP entries appear in the same request list as built-in requests
-- Nitro WebSocket entries use their original string IDs, so they line up naturally with message history
-- Nitro HTTP response bodies can be requested from the UI and from agent tools
-- HTTP response overrides are intentionally unavailable for nitro entries
-
-Nitro's inspector reports HTTP entries as snapshots, so Rozenite reconstructs the familiar request lifecycle from those updates. In practice that means nitro traffic appears in the same panel, but the underlying capture path is different from the built-in XHR interceptor.
+- **Images and SVGs** render inline; other binary formats (PDF, zip, audio, video, fonts) show a byte-level view instead, since there's nothing to preview.
+- **JSON and XML** render as a collapsible, copyable tree, with the raw body pretty-printed in the Raw tab.
+- **HTML** renders in a sandboxed preview that can't make outbound requests, with the source available in Raw.
+- **Text formats** (plain text, CSS, JS) render as monospace text.
+- Every binary response has a **Download** button; very large or empty responses show a placeholder instead of a preview.
 
 ## Configuration
 
-### Ignoring Certain Types of Traffic
-
-Sometimes you don't want certain types of traffic like WebSockets or server-side events to show up in the inspector for convenience or because of the performance penalty. You can disable them with the configuration property:
+By default all traffic types are monitored. Disable ones you don't need — useful when a type is noisy or expensive to capture:
 
 ```typescript title="App.tsx"
-import { useNetworkActivityDevTools } from '@rozenite/network-activity-plugin';
-
-function App() {
-  // Configure which network traffic types to monitor
-  useNetworkActivityDevTools({
-    inspectors: {
-      http: true, // Monitor HTTP/HTTPS requests
-      websocket: false, // Disable WebSocket monitoring
-      sse: false, // Disable Server-Sent Events monitoring
-    },
-  });
-
-  return <YourApp />;
-}
+useNetworkActivityDevTools({
+  inspectors: {
+    http: true,
+    websocket: false,
+    sse: false, // requires http to be enabled
+  },
+});
 ```
 
-#### Available Inspector Types
-
-- **`http`**: Monitor HTTP/HTTPS requests (fetch, XMLHttpRequest)
-- **`websocket`**: Monitor WebSocket connections and messages
-- **`sse`**: Monitor Server-Sent Events (requires `http` to be enabled)
-
-## Contributing
-
-The Network Activity plugin is open source and welcomes contributions! Check out the [Plugin Development Guide](../plugin-development/plugin-development.md) to learn how to contribute or create your own plugins.
-
-## Support
-
-If you encounter issues with the Network Activity plugin:
-
-1. **Check Documentation**: Review this guide for common solutions
-2. **Search Issues**: Look for similar issues in the repository
-3. **Create Issue**: Report bugs or request features
-4. **Community**: Reach out to the Rozenite community for help
-
----
-
-**Next**: Learn about [Plugin Development](../plugin-development/plugin-development.md) to create your own plugins, or explore other [Official Plugins](./overview.md).
+**Next**: Learn about [Plugin Development](../plugin-development/plugin-development.md), or explore other [Official Plugins](./overview.md).

--- a/website/src/docs/official-plugins/overlay.mdx
+++ b/website/src/docs/official-plugins/overlay.mdx
@@ -2,29 +2,15 @@ import { PackageManagerTabs } from '@rspress/core/theme';
 
 # Overlay Plugin
 
-The Overlay plugin provides visual debugging overlays for React Native applications, including customizable grids and image comparison tools to help with UI alignment and visual testing.
-
-This plugin was inspired by [RocketSim](https://www.rocketsim.app/) - an enhanced iOS simulator.
-
-## What is Overlay Plugin?
-
-The Overlay plugin is a powerful debugging tool that helps you visualize and debug UI elements in your React Native application. It provides:
-
-- **Grid Overlay**: Display customizable grids over your app for pixel-perfect alignment and spacing verification
-- **Image Overlay**: Overlay images on your app for visual comparison and design validation
-- **Image Comparison**: Side-by-side image comparison with adjustable slider for A/B testing
-- **Real-time Configuration**: Adjust overlay settings in real-time through the DevTools interface
-- **Non-intrusive Design**: Overlays don't interfere with app interaction (pointerEvents: 'none')
+The Overlay plugin draws grids and reference images over your running app, so you can check spacing, alignment, and how closely your UI matches a design. It was inspired by [RocketSim](https://www.rocketsim.app/).
 
 ## Installation
 
 Make sure to go through the [Getting Started guide](/docs/getting-started) before installing the plugin.
 
-Install the Overlay plugin and its peer dependency `react-native-svg` as development dependencies:
-
 <PackageManagerTabs command="install -D @rozenite/overlay-plugin react-native-svg" />
 
-Add the DevTools hook to your React Native app to enable overlay functionality:
+Add the overlay component at the root of your app:
 
 ```typescript title="App.tsx"
 import { RozeniteOverlay } from '@rozenite/overlay-plugin';
@@ -42,70 +28,28 @@ function App() {
 
 ## Web (React Native for Web)
 
-With [Rozenite for Web](/docs/rozenite-for-web), this plugin is available when you debug your React Native web app.
+With [Rozenite for Web](/docs/rozenite-for-web), this plugin is also available when debugging your React Native web app.
 
 ## Usage
 
-Once configured, the Overlay plugin will automatically appear in your React Native DevTools sidebar as "Overlay". Click on it to access the overlay controls:
+Once configured, "Overlay" appears in your React Native DevTools sidebar with two controls:
 
-### Grid Overlay
+### Grid
 
-The grid overlay helps you verify spacing, alignment, and layout consistency:
+Toggle a grid over your app to check spacing and alignment. Adjust cell size (4–100px), line color, and opacity. Off by default; when enabled, starts at an 8px red grid at 70% opacity.
 
-- **Enable/Disable**: Toggle grid visibility on and off
-- **Grid Size**: Adjust grid cell size (in pixels) from 4px to 100px
-- **Color**: Choose grid line color using a color picker
-- **Opacity**: Control grid transparency from 0.1 to 1.0
+### Image overlay
 
-### Image Overlay
+Overlay a reference image over your app to compare it against a design — either as a plain overlay or as a slider you drag to reveal each side. Adjust the image URL, resize mode (cover, contain, stretch, center), and opacity.
 
-The image overlay allows you to superimpose reference images over your app:
+Settings persist for your development session but aren't saved between app restarts.
 
-- **Enable/Disable**: Toggle image overlay visibility
-- **Image URL**: Enter the URL of the image to overlay
-- **Overlay Mode**: Choose between simple overlay or slider comparison
-- **Resize Mode**: Select how the image fits (cover, contain, stretch, center)
-- **Opacity**: Adjust image transparency
-
-### Image Comparison Mode
-
-When using slider mode, you get an interactive comparison tool:
-
-- **Side-by-Side View**: Compare your app with a reference image
-- **Adjustable Slider**: Drag to reveal different portions of each image
-- **Real-time Adjustment**: Change slider position while the app is running
-
-### Default Settings
-
-- **Grid**: Disabled by default, 8px size, red color (#FF0000), 70% opacity
-- **Image**: Disabled by default, 70% opacity, overlay mode, contain resize mode
-
-All settings are controlled through the DevTools panel and persist during your development session.
-
-### Important Notes
-
-:::warning Overlay Positioning
-The `RozeniteOverlay` component should be placed at the root level of your app, after all other content, to ensure overlays appear on top of your entire application.
+:::warning Positioning
+Place `RozeniteOverlay` at the root of your app, after everything else, so overlays render on top.
 :::
 
-:::info Development Only
-The Overlay plugin components are automatically disabled in production builds. The overlay will not render in release builds of your app.
+:::info Development only
+The overlay never renders in production builds.
 :::
 
-## Contributing
-
-The Overlay plugin is open source and welcomes contributions! Check out the [Plugin Development Guide](../plugin-development/plugin-development.md) to learn how to contribute or create your own plugins.
-
-## Support
-
-If you encounter issues with the Overlay plugin:
-
-1. **Check Documentation**: Review this guide for common solutions
-2. **Verify Setup**: Ensure the `RozeniteOverlay` component is properly placed in your app hierarchy
-3. **Search Issues**: Look for similar issues in the repository
-4. **Create Issue**: Report bugs or request features
-5. **Community**: Reach out to the Rozenite community for help
-
----
-
-**Next**: Learn about [Plugin Development](../plugin-development/plugin-development.md) to create your own plugins, or explore other [Official Plugins](./overview.md).
+**Next**: Explore other [Official Plugins](./overview.md), or learn to build your own in the [Plugin Development guide](../plugin-development/plugin-development.md).

--- a/website/src/docs/official-plugins/overview.mdx
+++ b/website/src/docs/official-plugins/overview.mdx
@@ -2,148 +2,42 @@ import { PackageManagerTabs } from '@rspress/core/theme';
 
 # Official Plugins
 
-As the creators of Rozenite, we maintain several plugins that demonstrate the framework's capabilities and provide essential debugging tools for React Native development.
+We maintain a set of plugins that cover the most common debugging needs, each one a thin bridge between a library you're probably already using and a DevTools panel.
 
-:::info Rozenite is currently in beta.
-Our official plugins are also in beta and may not work in all possible use-cases. We're actively working to improve stability and compatibility. If you encounter any issues, please [report them](https://github.com/callstackincubator/rozenite/issues) or help us make it better by [contributing to the repository](https://github.com/callstackincubator/rozenite).
+:::info Beta
+Rozenite and its official plugins are in beta. If something doesn't work, please [report it](https://github.com/callstackincubator/rozenite/issues) or [contribute a fix](https://github.com/callstackincubator/rozenite).
 :::
 
-## Available Plugins
+## Available plugins
 
-### [Expo Atlas](./expo-atlas.md)
+- **[Expo Atlas](./expo-atlas.md)** — visualize your Metro bundle to find large dependencies and duplicate code.
+- **[TanStack Query](./tanstack-query.md)** — monitor and manage TanStack Query's cache and queries.
+- **[Network Activity Inspector](./network-activity.md)** — a Chrome-DevTools-style network panel for your app's HTTP and WebSocket traffic.
+- **[Redux DevTools](./redux-devtools.md)** — inspect state, actions, and diffs for a Redux store.
+- **[Performance Monitor](./performance-monitor.md)** — track startup timing and custom performance marks.
+- **[MMKV](./mmkv.md)** — inspect and edit MMKV storage instances. Being superseded by the [Storage](./storage.md) plugin.
+- **[Storage](./storage.md)** — one panel for MMKV, AsyncStorage, and Expo SecureStore.
+- **[Feature Flags](./feature-flags.md)** — inspect and override flags from a custom store, LaunchDarkly, or Statsig.
+- **[File System](./file-system.md)** — browse app-accessible directories and preview file contents.
+- **[Controls](./controls.md)** — build a custom panel of toggles, inputs, and buttons for your own app.
+- **[React Navigation](./react-navigation.md)** — track navigation actions and inspect navigation state.
+- **[React Hook Form](./react-hook-form.md)** — inspect field values, validation, and form state.
+- **[SQLite](./sqlite.md)** — browse tables and run queries against your app's databases.
+- **[Overlay](./overlay.md)** — grid and reference-image overlays for pixel-perfect UI work.
+- **[Require Profiler](./require-profiler.md)** — a flame graph of your app's startup `require()` calls.
 
-Integrate Expo Atlas directly into your React Native DevTools for bundle analysis and optimization. This plugin provides:
+## Installing a plugin
 
-- **Bundle Visualization**: Interactive Metro bundle structure analysis
-- **Module Analysis**: Detailed information about each module in your bundle
-- **Size Optimization**: Identify large dependencies and optimize bundle size
-- **Dependency Mapping**: Visualize module relationships and dependencies
-
-### [TanStack Query](./tanstack-query.md)
-
-Integrate TanStack Query DevTools directly into your React Native DevTools for query monitoring and cache management. This plugin provides:
-
-- **Query Monitoring**: Real-time monitoring of all queries and mutations
-- **Cache Management**: Visual cache inspection and management tools
-- **Query Actions**: Refetch, invalidate, reset, and remove queries
-- **State Manipulation**: Trigger loading states and error conditions for testing
-
-### [Network Activity Inspector](./network-activity.md)
-
-Monitor network requests in your React Native app with a comprehensive network inspector similar to Chrome DevTools. This plugin provides:
-
-- **Real-time Network Monitoring**: Track all HTTP/HTTPS requests in real-time
-- **Request Details**: View request headers, method, URL, and timing information
-- **Response Inspection**: Examine response headers, status codes, and timing data
-- **Request History**: Maintain a searchable history of network activity
-- **Nitro Coverage**: Integrate `react-native-nitro-fetch` traffic into the same panel when available
-
-### [Redux DevTools](./redux-devtools.md)
-
-Integrate Redux DevTools directly into your React Native DevTools for state inspection and debugging. This plugin provides:
-
-- **State Inspection**: View and explore your Redux store state in real-time
-- **Action History**: Track all dispatched actions with timestamps and payloads
-- **State Diff Viewing**: See exactly how each action changes your state
-- **Production Safety**: Automatically disabled in production builds
-
-### [Performance Monitor](./performance-monitor.md)
-
-Monitor performance metrics in your React Native app with comprehensive real-time performance monitoring. This plugin provides:
-
-- **Real-time Performance Monitoring**: Live tracking of performance marks, measures, and metrics
-- **Session Management**: Start/stop monitoring sessions with real-time duration tracking
-- **Performance Measures**: Track custom performance measurements with details
-- **Performance Marks**: Monitor key performance milestones and events
-- **Performance Metrics**: Real-time metrics with values and details
-- **Data Export**: Export performance data for analysis
-- **Production Safety**: Automatically disabled in production builds
-
-### [MMKV](./mmkv.md)
-
-Inspect and manage MMKV storage instances in your React Native app with comprehensive storage debugging capabilities. This plugin provides:
-
-- **Real-time Storage Inspection**: View all MMKV instances and their contents in real-time
-- **Multi-Instance Support**: Manage and inspect multiple MMKV instances simultaneously
-- **Data Type Detection**: Automatically detects and displays different data types (string, number, boolean, buffer)
-- **Search & Filter**: Quickly find specific keys with real-time search functionality
-- **Visual Data Representation**: Color-coded type indicators and formatted value display
-- **Data Management**: Add, edit, and delete entries directly from the DevTools interface
-
-### [Storage](./storage.md)
-
-Inspect multiple storage backends from one panel using adapters for MMKV, AsyncStorage, and Expo SecureStore. This plugin provides:
-
-- **Multi-Adapter Support**: Combine multiple storage libraries in one DevTools panel
-- **Per-Storage Capabilities**: Enforce supported value types per storage
-- **Per-Storage Blacklist**: Hide sensitive or noisy keys per storage instance
-- **Async + Sync Coverage**: Works with both sync (MMKV) and async (AsyncStorage/SecureStore) APIs
-
-### [Feature Flags](./feature-flags.md)
-
-List, inspect, and force-override feature flags on a running device, across a homegrown flag store, LaunchDarkly, and Statsig. This plugin provides:
-
-- **Adapter-Based Providers**: Custom/local, LaunchDarkly, and Statsig adapters behind one panel
-- **Inline Overrides**: Flip booleans with one click; edit strings, numbers, and JSON inline
-- **Tier A / Tier B Transparency**: Each adapter documents whether overrides need a call-site change and how long they persist
-- **Agent Tools**: List, read, override, and clear flags from a coding agent
-
-### [File System](./file-system.md)
-
-Browse app-accessible directories and preview file contents directly in DevTools. This plugin provides:
-
-- **Runtime File Explorer**: Inspect document, cache, temp, library, and bundle directories
-- **Provider Flexibility**: Works with Expo FileSystem or RNFS-compatible libraries
-- **Inline Previews**: Open text and image files without leaving DevTools
-- **Binary Inspection**: Fall back to a readable hex-style preview for non-text files
-
-### [Controls](./controls.md)
-
-Expose app-defined controls directly in React Native DevTools so your team can inspect state, change flags, update text values, choose predefined options, and trigger actions from one panel. This plugin provides:
-
-- **Custom Runtime Panels**: Organize controls into sections that match your app workflows
-- **Read + Write Controls**: Combine status fields, toggles, selects, inputs, and buttons
-- **Validation Feedback**: Prevent invalid changes and show clear errors in DevTools
-- **No Extra Debug Screens**: Keep temporary controls out of your in-app UI
-
-## Installing Plugins
-
-Plugins should be installed as development dependencies since they are only needed during development:
-
-<PackageManagerTabs command="install -D @rozenite/expo-atlas-plugin" />
-
-<PackageManagerTabs command="install -D @rozenite/tanstack-query-plugin" />
+Each plugin installs as a dev dependency, since it's only needed during development:
 
 <PackageManagerTabs command="install -D @rozenite/network-activity-plugin" />
 
-<PackageManagerTabs command="install -D @rozenite/redux-devtools-plugin" />
+Swap in the package name for the plugin you want — see its page for the exact setup steps, since most plugins also need a small hook added to your app.
 
-<PackageManagerTabs command="install -D @rozenite/performance-monitor-plugin" />
+## Community plugins
 
-<PackageManagerTabs command="install -D @rozenite/mmkv-plugin" />
+Beyond what we maintain, the community builds and shares its own Rozenite plugins. They aren't officially supported, but many are worth a look for specific use cases.
 
-<PackageManagerTabs command="install -D @rozenite/storage-plugin" />
+## Building your own
 
-<PackageManagerTabs command="install -D @rozenite/feature-flags-plugin" />
-
-<PackageManagerTabs command="install -D @rozenite/file-system-plugin" />
-
-<PackageManagerTabs command="install -D @rozenite/controls-plugin" />
-
-See the individual plugin documentation for complete installation instructions including hook setup.
-
-## Configuration
-
-Each plugin has its own configuration requirements. See the individual plugin documentation for setup instructions.
-
-## Community Plugins
-
-In addition to the plugins we maintain, the Rozenite community creates and maintains many useful plugins. While these aren't officially supported, they can provide valuable functionality for specific use cases.
-
-## Contributing
-
-Want to contribute to plugins or suggest new ones? Check out our [Plugin Development Guide](../plugin-development/plugin-development.md) to learn how to create plugins, or reach out to the community to discuss your ideas. We welcome contributions to both our maintained plugins and community plugins.
-
----
-
-**Next**: Learn about the [Expo Atlas plugin](./expo-atlas.md), [TanStack Query plugin](./tanstack-query.md), [Network Activity Inspector](./network-activity.md), [Redux DevTools plugin](./redux-devtools.md), [Performance Monitor plugin](./performance-monitor.md), [MMKV plugin](./mmkv.md), [Storage plugin](./storage.md), [Feature Flags plugin](./feature-flags.md), [File System plugin](./file-system.md), or [Controls plugin](./controls.md).
+If none of the above fit, see the [Plugin Development guide](../plugin-development/plugin-development.md) to build your own.

--- a/website/src/docs/official-plugins/performance-monitor.mdx
+++ b/website/src/docs/official-plugins/performance-monitor.mdx
@@ -4,36 +4,18 @@ import { PackageManagerTabs } from '@rspress/core/theme';
 
 ![](/performance-monitor-plugin.png)
 
-The Performance Monitor plugin provides comprehensive real-time performance monitoring and metrics visualization for React Native applications, helping you identify bottlenecks and optimize your app's performance. It's based on the `react-native-performance` library, so any marks, measures, or metrics you emit using that library will automatically appear in the DevTools interface.
-
-## What is Performance Monitor Plugin?
-
-The Performance Monitor plugin is a powerful debugging tool that helps you monitor and analyze performance metrics in your React Native application. It provides:
-
-- **Startup Insights**: At-a-glance breakdown of Native Launch, JS Bundle, and Initial Mount durations with proportional bars — no extra instrumentation required
-- **Real-time Performance Monitoring**: Live tracking of performance marks, measures, and metrics
-- **Session Management**: Start/stop monitoring sessions with real-time duration tracking
-- **Performance Measures**: Track custom performance measurements with details
-- **Performance Marks**: Monitor key performance milestones and events
-- **Performance Metrics**: Real-time metrics with values and details
-- **Data Export**: Export performance data for analysis
-- **Production Safety**: Automatically disabled in production builds
+The Performance Monitor plugin shows startup timing and performance marks in React Native DevTools. It's built on the [`react-native-performance`](https://github.com/oblador/react-native-performance) library, so anything you already mark or measure with it shows up automatically.
 
 ## Installation
 
 Make sure to go through the [Getting Started guide](/docs/getting-started) before installing the plugin.
 
-Install the Performance Monitor plugin and its peer dependencies:
-
 <PackageManagerTabs command="install -D @rozenite/performance-monitor-plugin react-native-performance" />
-
-Add the DevTools hook to your React Native app to enable performance monitoring:
 
 ```typescript title="App.tsx"
 import { usePerformanceMonitorDevTools } from '@rozenite/performance-monitor-plugin';
 
 function App() {
-  // Enable Performance Monitor DevTools in development
   usePerformanceMonitorDevTools();
 
   return <YourApp />;
@@ -42,83 +24,35 @@ function App() {
 
 ## Web (React Native for Web)
 
-With [Rozenite for Web](/docs/rozenite-for-web), this plugin is available when you debug your React Native web app.
+With [Rozenite for Web](/docs/rozenite-for-web), this plugin is also available when debugging your React Native web app.
 
 ## Usage
 
-Once configured, the Performance Monitor plugin will automatically appear in your React Native DevTools sidebar as "Performance Monitor". Click on it to access:
+Once configured, "Performance Monitor" appears in your React Native DevTools sidebar.
 
-## Startup Insights
+### Startup
 
-The **Startup** tab (shown first) gives you an immediate breakdown of your app's launch time:
+The first tab you see breaks down your app's launch time: native initialization, JS bundle parse/execute, and the first React render. It populates automatically as soon as you start a session — no instrumentation needed. A phase shows "In progress…" while it's still running, or "—" if your app's architecture doesn't report it.
 
-- **Total startup** — the full duration from native process start to the first React render
-- **Native Launch** — time spent in native initialization before the JS engine starts
-- **JS Bundle** — time to parse and execute the JavaScript bundle
-- **Initial Mount** — time for the first React component tree to render
+### Custom marks and measures
 
-The data comes from React Native's built-in buffered marks (`nativeLaunchStart/End`, `runJSBundleStart/End`, `initialMountStart/End`), so the Startup tab populates automatically as soon as you start a session — no extra instrumentation needed in your app.
-
-Phases that are still running show as "In progress…". Phases absent from the event stream (e.g. `runJSBundle` on some New Architecture configurations) show as "—".
-
-### Performance Monitoring
-
-The plugin is based on the `react-native-performance` library and works with React Native's Performance API. Any marks, measures, or metrics you emit using the `react-native-performance` library will automatically appear in the DevTools interface. You can add custom performance marks and measures:
+Add your own marks, measures, and metrics from anywhere in your app using `react-native-performance` directly — they show up in the panel in real time:
 
 ```typescript
 import performance from 'react-native-performance';
 
-// Add performance marks
 performance.mark('app-start');
 performance.mark('data-loaded');
-
-// Measure performance between marks
 performance.measure('app-initialization', 'app-start', 'data-loaded');
-
-// Add custom metrics
 performance.metric('custom-metric', 42, { detail: 'Additional info' });
 ```
 
-### Performance Data Types
+- **Marks** are named points in time — e.g. `user-login-complete`.
+- **Measures** are durations between two marks — e.g. the time between `login-start` and `login-end`.
+- **Metrics** are arbitrary values you want to track, e.g. `performance.metric('memory-usage', 1024, { unit: 'MB' })`.
 
-#### Performance Marks
+### Sessions
 
-- **Purpose**: Mark specific points in time for performance analysis
-- **Use Cases**: App startup, data loading, user interactions
-- **Example**: `performance.mark('user-login-complete')`
+Start and stop a monitoring session from the panel, and export what it captured for further analysis.
 
-#### Performance Measures
-
-- **Purpose**: Measure duration between two marks or specific time periods
-- **Details**: Can include additional context information
-- **Example**: `performance.measure('login-duration', 'login-start', 'login-end')`
-
-#### Performance Metrics
-
-- **Purpose**: Track specific performance indicators
-- **Values**: Can be strings or numbers
-- **Details**: Can include additional context information
-- **Example**: `performance.metric('memory-usage', 1024, { unit: 'MB' })`
-
-### Session Management
-
-- **Start/Stop Monitoring**: Control when performance monitoring is active
-- **Real-time Duration**: Track how long monitoring sessions run
-- **Data Export**: Export performance data for external analysis
-
-## Contributing
-
-The Performance Monitor plugin is open source and welcomes contributions! Check out the [Plugin Development Guide](../plugin-development/plugin-development.md) to learn how to contribute or create your own plugins.
-
-## Support
-
-If you encounter issues with the Performance Monitor plugin:
-
-1. **Check Documentation**: Review this guide for common solutions
-2. **Search Issues**: Look for similar issues in the repository
-3. **Create Issue**: Report bugs or request features
-4. **Community**: Reach out to the Rozenite community for help
-
----
-
-**Next**: Learn about [Plugin Development](../plugin-development/plugin-development.md) to create your own plugins, or explore other [Official Plugins](./overview.md).
+**Next**: Learn about [Plugin Development](../plugin-development/plugin-development.md), or explore other [Official Plugins](./overview.md).

--- a/website/src/docs/official-plugins/react-navigation.mdx
+++ b/website/src/docs/official-plugins/react-navigation.mdx
@@ -4,29 +4,13 @@ import { PackageManagerTabs } from '@rspress/core/theme';
 
 ![](/react-navigation-plugin.png)
 
-The React Navigation plugin provides comprehensive navigation debugging and inspection for React Navigation v7, offering real-time action monitoring, state inspection, and deep linking testing directly within your React Native DevTools environment.
-
-## What is React Navigation Plugin?
-
-The React Navigation plugin is a powerful debugging tool that helps you inspect and debug navigation in your React Native application. It provides:
-
-- **Action Timeline**: Track all navigation actions in real-time with detailed history
-- **Dispatch Origin**: See the source-mapped file and line where each action was dispatched from, with the full call stack
-- **State Inspection**: View and analyze navigation state at any point in time
-- **Time Travel Debugging**: Jump back to any previous navigation state
-- **Deep Link Testing**: Test and validate deep links directly from DevTools
-- **State Reset**: Reset navigation state to any previous point in the timeline
-- **Real-time Updates**: See navigation changes as they happen in your app
+The React Navigation plugin brings navigation debugging to React Native DevTools for React Navigation v7: a live action timeline, navigation state at any point in time, and deep link testing.
 
 ## Installation
 
 Make sure to go through the [Getting Started guide](/docs/getting-started) before installing the plugin.
 
-Install the React Navigation plugin as a development dependency:
-
 <PackageManagerTabs command="install -D @rozenite/react-navigation-plugin" />
-
-Add the DevTools hook to your React Native app to enable navigation debugging:
 
 ### With react-navigation
 
@@ -38,7 +22,6 @@ import { useReactNavigationDevTools } from '@rozenite/react-navigation-plugin';
 function App() {
   const navigationRef = useRef(null);
 
-  // Enable React Navigation DevTools in development
   useReactNavigationDevTools({ ref: navigationRef });
 
   return (
@@ -58,7 +41,6 @@ import { useReactNavigationDevTools } from '@rozenite/react-navigation-plugin';
 function App() {
   const navigationRef = useNavigationContainerRef();
 
-  // Enable React Navigation DevTools in development
   useReactNavigationDevTools({ ref: navigationRef });
 
   return <Stack />;
@@ -67,57 +49,17 @@ function App() {
 
 ## Web (React Native for Web)
 
-With [Rozenite for Web](/docs/rozenite-for-web), this plugin is available when you debug your React Native web app.
+With [Rozenite for Web](/docs/rozenite-for-web), this plugin is also available when debugging your React Native web app.
 
 ## Usage
 
-Once configured, the React Navigation plugin will automatically appear in your React Native DevTools sidebar as "React Navigation". Click on it to access two main features:
+Once configured, "React Navigation" appears in your React Native DevTools sidebar with two main things:
 
-## Dispatch Origin
-
-Every captured action is annotated with where it was dispatched from. The detail panel shows a **Dispatch Origin** section above the action payload:
-
-- A headline summarising the dispatch call site, for example `Dispatched from handlePress in apps/playground/src/screens/Home.tsx:42`. A `low confidence` chip appears when the chosen frame is inside `node_modules/`.
-- The Metro code-frame snippet for the call site when available.
-- A collapsible full stack — application frames are bright, library frames (`node_modules/*`) are muted and tagged.
-- A **Copy raw** button copies the unmodified stack string as React Navigation provided it.
-
-The sidebar's action list shows a compact preview (`↳ Home.tsx:42`) so you can spot the source without opening each action. Symbolication runs against the Metro development server, so origins are only resolvable in development builds; release builds show "symbolication unavailable" and the raw stack remains accessible.
+- **Action timeline** — every navigation action, in order, with the ability to jump back to any previous state or reset to it.
+- **Dispatch origin** — click any action to see where in your code it was dispatched from, including a code snippet and the full call stack. This only resolves in development builds; release builds show "symbolication unavailable" but keep the raw stack available.
 
 ## Agent Integration
 
-This plugin also exposes Agent tools under the `@rozenite/react-navigation-plugin` domain for LLM workflows.
+This plugin exposes agent tools under the `@rozenite/react-navigation-plugin` domain: `navigate` and `go-back` for routine navigation, plus lower-level tools (`get-root-state`, `get-focused-route`, `list-actions`, `reset-root`, `open-link`, `dispatch-action`) for anything `navigate`/`go-back` can't do.
 
-- `navigate` (high-level)
-- `go-back` (high-level)
-- `get-root-state`
-- `get-focused-route`
-- `list-actions`
-- `reset-root` (low-level)
-- `open-link`
-- `dispatch-action` (low-level)
-
-Use `navigate` and `go-back` first for routine movement across stacks/tabs. Use `dispatch-action` and `reset-root` only when high-level tools are insufficient.
-
-These tools allow read access to the current navigation state and recent action timeline (rolling in-memory history), plus mutation actions for navigation control and deep linking.
-
-Entries returned by `list-actions` include an `origin` payload (when React Navigation supplied a stack) with the source-mapped frames, the chosen origin frame, a confidence level, and the symbolication status. Agents should read `origin.originFrame` after confirming `origin.symbolicationStatus === 'complete'`.
-
-## Contributing
-
-The React Navigation plugin is open source and welcomes contributions! Check out the [Plugin Development Guide](../plugin-development/plugin-development.md) to learn how to contribute or create your own plugins.
-
-## Support
-
-If you encounter issues with the React Navigation plugin:
-
-1. **Check Documentation**: Review this guide for common solutions
-2. **Verify Setup**: Ensure React Navigation v7 is properly installed and configured
-3. **Check Ref**: Verify that you're passing the NavigationContainer ref correctly
-4. **Search Issues**: Look for similar issues in the repository
-5. **Create Issue**: Report bugs or request features
-6. **Community**: Reach out to the Rozenite community for help
-
----
-
-**Next**: Learn about [Plugin Development](../plugin-development/plugin-development.md) to create your own plugins, or explore other [Official Plugins](./overview.md).
+**Next**: Learn about [Plugin Development](../plugin-development/plugin-development.md), or explore other [Official Plugins](./overview.md).

--- a/website/src/docs/official-plugins/redux-devtools.mdx
+++ b/website/src/docs/official-plugins/redux-devtools.mdx
@@ -4,32 +4,17 @@ import { PackageManagerTabs } from '@rspress/core/theme';
 
 ![](/redux-devtools-plugin.png)
 
-The Redux DevTools plugin integrates Redux DevTools directly into your React Native DevTools, providing powerful state inspection and debugging capabilities for your Redux-powered React Native applications.
-
-## What is Redux DevTools?
-
-Redux DevTools is a powerful debugging tool for Redux applications that provides:
-
-- **State Inspection**: View and explore your Redux store state in real-time
-- **Action History**: Track all dispatched actions with timestamps and payloads
-- **State Diff Viewing**: See exactly how each action changes your state
-- **Agent Tools**: Let coding agents inspect stores and drive safe Redux DevTools history actions
+The Redux DevTools plugin brings the familiar Redux DevTools experience into React Native DevTools: state inspection, action history, and state diffs for your store.
 
 ## Installation
 
 Make sure to go through the [Getting Started guide](/docs/getting-started) before installing the plugin.
 
-### Install dependencies
-
-Install the Redux DevTools plugin as a development dependency:
-
 <PackageManagerTabs command="install -D @rozenite/redux-devtools-plugin" />
 
-### Instrument Redux store
+Add the enhancer to your store:
 
-Add the Redux DevTools enhancer to your Redux store:
-
-#### For Redux Toolkit (Recommended)
+#### Redux Toolkit (recommended)
 
 ```typescript title="store.ts"
 import { configureStore } from '@reduxjs/toolkit';
@@ -44,7 +29,7 @@ const store = configureStore({
 export default store;
 ```
 
-#### For Classic Redux
+#### Classic Redux
 
 ```typescript title="store.ts"
 import { createStore, applyMiddleware } from 'redux';
@@ -60,9 +45,9 @@ const store = createStore(
 export default store;
 ```
 
-#### For Rematch
+#### Rematch
 
-If you're using Rematch, follow the [Rematch documentation](https://rematchjs.org/docs/guides/devtools/) and use `composeWithRozeniteDevTools` as the `devtoolComposer`:
+Follow the [Rematch documentation](https://rematchjs.org/docs/guides/devtools/) and use `composeWithRozeniteDevTools` as the `devtoolComposer`:
 
 ```typescript title="store.ts"
 import { init } from '@rematch/core';
@@ -82,19 +67,55 @@ export default store;
 
 ## Web (React Native for Web)
 
-With [Rozenite for Web](/docs/rozenite-for-web), this plugin is available when you debug your React Native web app.
+With [Rozenite for Web](/docs/rozenite-for-web), this plugin is also available when debugging your React Native web app.
 
 ## Usage
 
-Once configured, the Redux DevTools plugin will automatically appear in your React Native DevTools sidebar as "Redux DevTools".
+Once configured, "Redux DevTools" appears in your React Native DevTools sidebar.
+
+### Multiple stores
+
+Give each store a distinct name so you can tell them apart in the panel:
+
+```ts
+const appStoreEnhancer = rozeniteDevToolsEnhancer({ name: 'app-store' });
+const sessionStoreEnhancer = rozeniteDevToolsEnhancer({ name: 'session-store' });
+```
+
+### Large stores
+
+State is serialized and sent to DevTools over the device bridge, so a large store combined with a lot of action history can use a lot of memory — on Android this can even crash the app when you open the panel. If your store is large (RTK Query caches, big entity maps), lower `maxAge` (default `50`) and strip bulky slices with `stateSanitizer` / `actionSanitizer`:
+
+```ts
+rozeniteDevToolsEnhancer({
+  maxAge: 20,
+  stateSanitizer: (state) => ({
+    ...(state as Record<string, unknown>),
+    api: '[omitted]',
+  }),
+  actionSanitizer: (action) => ({
+    ...action,
+    payload: action.type === 'large/payload' ? '[omitted]' : action.payload,
+  }),
+});
+```
+
+### Dispatch traces
+
+Set `trace: true` to capture where each action was dispatched from, symbolicated back to your source files through Metro:
+
+```ts
+rozeniteDevToolsEnhancer({
+  trace: true,
+  traceLimit: 25,
+});
+```
+
+Pass `traceSymbolication: false` to keep raw stacks without the Metro round-trip.
 
 ## Agent Integration
 
-This plugin can also expose agent tools under the `@rozenite/redux-devtools-plugin` domain.
-
-This is a separate manual integration step. Instrumenting the Redux store with `rozeniteDevToolsEnhancer` or `composeWithRozeniteDevTools` does not automatically register agent tools.
-
-If you want agent access, mount the hook once near your app root by hand:
+Agent tools are a separate, manual step — instrumenting your store with the enhancer doesn't register them on its own. Mount this once near your app root:
 
 ```tsx title="App.tsx"
 import { useReduxDevToolsAgentTools } from '@rozenite/redux-devtools-plugin';
@@ -106,79 +127,6 @@ function App() {
 }
 ```
 
-Without this hook, the Redux DevTools panel still works, but the Redux plugin domain will not be available through `rozenite agent`.
+This registers curated tools under the `@rozenite/redux-devtools-plugin` domain for listing stores/actions, dispatching actions, and driving history (jump/rollback/commit) — rather than exposing raw eval-based commands.
 
-Available tools:
-
-- `list-stores`
-- `get-store-state`
-- `list-actions`
-- `get-action-details`
-- `dispatch-action`
-- `jump-to-action`
-- `toggle-action`
-- `reset-history`
-- `rollback-state`
-- `commit-current-state`
-- `sweep-skipped-actions`
-- `set-recording-paused`
-- `set-locked`
-
-The agent API intentionally exposes curated store and history operations rather than raw eval-based Redux DevTools commands.
-
-#### Configuration Options
-
-To distinguish multiple stores, set a custom `name` per store:
-
-```ts
-const appStoreEnhancer = rozeniteDevToolsEnhancer({ name: 'app-store' });
-const sessionStoreEnhancer = rozeniteDevToolsEnhancer({
-  name: 'session-store',
-});
-```
-
-`maxAge` controls how many actions Redux DevTools keeps in history. The default is `50`.
-
-On React Native, state is serialized and sent to DevTools over the device bridge. Large stores combined with a high `maxAge` can use a lot of memory — on Android this may cause an out-of-memory crash when opening the Redux DevTools panel. If your store is large (for example, it includes RTK Query caches or big entity maps), keep `maxAge` low and use `stateSanitizer` or `actionSanitizer` to strip bulky slices before they are sent to DevTools.
-
-```ts
-rozeniteDevToolsEnhancer({
-  maxAge: 20,
-  stateSanitizer: (state, index) => ({
-    ...(state as Record<string, unknown>),
-    api: '[omitted]',
-  }),
-  actionSanitizer: (action, id) => ({
-    ...action,
-    payload: action.type === 'large/payload' ? '[omitted]' : action.payload,
-  }),
-});
-```
-
-Set `trace: true` to capture the dispatch stack for each action and enable the Trace tab. Rozenite attempts to symbolicate captured stacks through Metro so frames point to source files instead of generated bundle locations.
-
-```ts
-rozeniteDevToolsEnhancer({
-  trace: true,
-  traceLimit: 25,
-});
-```
-
-Use `traceSymbolication: false` if you want to keep raw stacks without calling Metro's `/symbolicate` endpoint.
-
-## Contributing
-
-The Redux DevTools plugin is open source and welcomes contributions! Check out the [Plugin Development Guide](../plugin-development/plugin-development.md) to learn how to contribute or create your own plugins.
-
-## Support
-
-If you encounter issues with the Redux DevTools plugin:
-
-1. **Check Documentation**: Review this guide for common solutions
-2. **Search Issues**: Look for similar issues in the repository
-3. **Create Issue**: Report bugs or request features
-4. **Community**: Reach out to the Rozenite community for help
-
----
-
-**Next**: Learn about [Plugin Development](../plugin-development/plugin-development.md) to create your own plugins, or explore other [Official Plugins](./overview.md).
+**Next**: Learn about [Plugin Development](../plugin-development/plugin-development.md), or explore other [Official Plugins](./overview.md).

--- a/website/src/docs/official-plugins/require-profiler.mdx
+++ b/website/src/docs/official-plugins/require-profiler.mdx
@@ -4,32 +4,15 @@ import { PackageManagerTabs } from '@rspress/core/theme';
 
 ![](/require-profiler-plugin.png)
 
-The Require Profiler plugin instruments `require()` calls during your React Native app's initial loading to track module initialization times, helping you identify which modules impact startup performance and optimize lazy evaluation through inlined require calls.
-
-## What is Require Profiler Plugin?
-
-The Require Profiler plugin is a performance analysis tool that helps you understand and optimize your app's initial loading performance in React Native by providing:
-
-- **Initial App Loading Profiling**: Automatically instruments `require()` calls during app startup to track initialization times
-- **Flame Graph Visualization**: Interactive flame graph showing the module dependency tree with timing information
-- **Startup Performance Insights**: Identify slow-loading modules that impact Time to Interactive (TTI)
-- **Conditional Require Optimization**: Discover modules that are good candidates for deferred loading via conditional require calls
-- **Dependency Analysis**: Visualize the complete module dependency graph loaded during initial app startup
-- **Real-time Metrics**: View total initialization time, module count, and per-module evaluation times
+The Require Profiler plugin tracks how long each `require()` call takes while your app starts up, and shows the result as a flame graph — so you can see exactly which modules are slowing down your app's Time to Interactive.
 
 ## Installation
 
 Make sure to go through the [Getting Started guide](/docs/getting-started) before installing the plugin.
 
-Install the Require Profiler plugin as a development dependency using your preferred package manager:
-
 <PackageManagerTabs command="install -D @rozenite/require-profiler-plugin" />
 
-## Configuration
-
-### Metro Configuration
-
-Add the require profiler instrumentation to your Metro configuration using the `enhanceMetroConfig` option in `withRozenite`:
+Enable the Metro instrumentation:
 
 ```javascript title="metro.config.js"
 const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
@@ -49,15 +32,12 @@ module.exports = withRozenite(
 );
 ```
 
-### React Native Integration
-
-Add the DevTools hook to your React Native app:
+Add the DevTools hook to your app:
 
 ```typescript title="App.tsx"
 import { useRequireProfilerDevTools } from '@rozenite/require-profiler-plugin';
 
 function App() {
-  // Enable Require Profiler DevTools
   useRequireProfilerDevTools();
 
   return <YourApp />;
@@ -66,88 +46,23 @@ function App() {
 
 ## Usage
 
-Once configured, the Require Profiler plugin will automatically appear in your React Native DevTools sidebar as "Metro Require Profiler". Click on it to access:
+Once configured, "Metro Require Profiler" appears in your React Native DevTools sidebar, showing a flame graph of every module loaded during startup.
 
-### Flame Graph Visualization
+- **Color** reflects timing: red modules took over 70% of the slowest module's time; blue modules were fast.
+- **Click** a module to zoom into that part of the tree, or open its detail panel for evaluation time, path, dependency count, and importing modules.
+- The header shows total initialization time, module count, and the entry point.
+- Use the filter (⚙️ in the header) to hide chains under a duration threshold — start around 100ms to focus on what actually matters for startup time.
 
-- **Interactive Visualization**: Navigate through your module dependency tree
-- **Color-coded Timing**: Red modules indicate slow initialization (>70% of max time), blue modules indicate fast initialization
-- **Zoom and Focus**: Click any module to zoom into specific parts of the dependency tree
-- **Module Details**: Hover over modules to see basic information, click for detailed sidebar view
+## What to look for
 
-### Module Details Panel
-
-When you click on a module in the flame graph, the sidebar shows:
-
-- **Evaluation Time**: How long the module took to initialize
-- **Module Path**: Full file path and name
-- **Dependencies Count**: Number of direct dependencies
-- **Parent Modules**: Which modules imported this module
-
-### Performance Metrics
-
-The header bar displays key performance indicators:
-
-- **Total Initialization Time**: Sum of all module initialization times
-- **Module Count**: Total number of modules loaded
-- **Entry Point**: The main module that started the loading chain
-
-### Filtering Options
-
-The Require Profiler provides filtering capabilities to help you focus on the most impactful performance issues:
-
-#### Minimum Duration Filter
-
-- **Skip chains shorter than (ms)**: Hide require chains with total duration below a specified threshold
-- **Purpose**: Filter out fast-loading modules to focus analysis on slow-loading chains that significantly impact startup performance
-- **Usage**: Access via the options button (⚙️) in the header bar
-- **Default**: 0ms (no filtering)
-- **Recommendation**: Start with 100ms to identify modules taking significant time during startup
-
-When filtering is active, only require chains meeting the duration threshold are displayed in the flame graph, allowing you to prioritize optimization efforts on the slowest-loading parts of your app.
-
-## Analyzing Performance
-
-### Identifying Slow Startup Modules
-
-The flame graph makes it easy to spot modules that take a long time to initialize during app startup. Look for:
-
-- **Red modules** (>70% of max time): These are your slowest modules impacting startup
-- **Wide modules**: Modules that take up a lot of horizontal space in the graph
-- **Deep dependency chains**: Modules that load many dependencies during initial load
-
-### Finding Conditional Require Candidates
-
-Modules that are good candidates for lazy evaluation typically:
-
-- Take significant time to initialize (>100ms) during startup
-- Are not needed immediately for the initial app experience
-- Have many dependencies that could be deferred via conditional require calls
-
-### Optimizing App Startup Performance
-
-By identifying and optimizing slow-loading modules, you can:
-
-- **Defer Heavy Modules**: Move non-critical modules to conditional require calls
-- **Improve Time to Interactive**: Prioritize critical modules and defer non-critical ones
-- **Optimize Dependency Chains**: Break up large dependency trees for faster startup
-- **Strategic Conditional Loading**: Identify natural boundaries for deferred module loading
-
-## Use Cases
-
-### Startup Performance Optimization
+Wide, red, or deeply nested modules are your best candidates for optimization. Once you've found one that isn't needed immediately, defer it with a conditional or lazy `require()`:
 
 ```typescript
-// Instead of loading heavy modules at startup:
+// Instead of loading it up front:
 const HeavyModule = require('./HeavyModule');
 
-// Consider lazy evaluation via conditional require calls:
+// Load it only when needed:
 let HeavyModule;
-if (condition) {
-  HeavyModule = require('./HeavyModule');
-}
-
-// Or defer loading until needed:
 const loadHeavyModule = () => {
   if (!HeavyModule) {
     HeavyModule = require('./HeavyModule');
@@ -156,33 +71,6 @@ const loadHeavyModule = () => {
 };
 ```
 
-### Initial Bundle Analysis
+Re-run the profiler after each change to confirm the improvement and catch regressions.
 
-Use the profiler to understand which parts of your codebase contribute most to initial loading time, helping you make informed decisions about:
-
-- Which modules to defer via conditional require calls
-- Which components to load lazily for better startup performance
-- Which utilities to load on-demand after initial app launch
-
-### Development Workflow
-
-- **Quick Feedback**: See immediate impact of require call changes on initial app loading
-- **Regression Detection**: Catch performance regressions in module initialization during startup
-- **Optimization Prioritization**: Focus optimization efforts on the slowest startup modules using duration filtering
-
-## Contributing
-
-The Require Profiler plugin is open source and welcomes contributions! Check out the [Plugin Development Guide](../plugin-development/plugin-development.md) to learn how to contribute or create your own plugins.
-
-## Support
-
-If you encounter issues with the Require Profiler plugin:
-
-1. **Check Documentation**: Review this guide for common solutions
-2. **Search Issues**: Look for similar issues in the repository
-3. **Create Issue**: Report bugs or request features
-4. **Community**: Reach out to the Rozenite community for help
-
----
-
-**Next**: Learn about [Plugin Development](../plugin-development/plugin-development.md) to create your own plugins, or explore other [Official Plugins](./overview.md).
+**Next**: Learn about [Plugin Development](../plugin-development/plugin-development.md), or explore other [Official Plugins](./overview.md).

--- a/website/src/docs/official-plugins/storage.mdx
+++ b/website/src/docs/official-plugins/storage.mdx
@@ -2,21 +2,19 @@ import { PackageManagerTabs } from '@rspress/core/theme';
 
 # Storage Plugin
 
-The Storage plugin provides a generic storage inspector for React Native DevTools. It supports multiple adapters and multiple storages per adapter, so you can inspect MMKV, AsyncStorage, and SecureStore in one panel.
+The Storage plugin is a single DevTools panel for MMKV, AsyncStorage, and Expo SecureStore. Register whichever adapters your app uses and inspect them all from one place.
 
 ## Installation
 
 Make sure to go through the [Getting Started guide](/docs/getting-started) before installing the plugin.
 
-Install the plugin:
-
 <PackageManagerTabs command="install -D @rozenite/storage-plugin" />
 
-Install adapter peer dependencies for the storages you use:
+Install the peer dependencies for the storages you use:
 
 <PackageManagerTabs command="install -D react-native-mmkv @react-native-async-storage/async-storage expo-secure-store" />
 
-## Base Setup
+## Setup
 
 ```ts title="App.tsx"
 import {
@@ -28,10 +26,7 @@ import {
 
 const storages = [
   createMMKVStorageAdapter({
-    storages: {
-      user: userStorage,
-      cache: cacheStorage,
-    },
+    storages: { user: userStorage, cache: cacheStorage },
   }),
   createAsyncStorageAdapter({
     storage: AsyncStorage,
@@ -50,53 +45,37 @@ function App() {
 
 ## Web (React Native for Web)
 
-With [Rozenite for Web](/docs/rozenite-for-web), this plugin is available when you debug your React Native web app.
+With [Rozenite for Web](/docs/rozenite-for-web), this plugin is also available when debugging your React Native web app — showing entries from whichever Async Storage / Expo Secure Store adapters you configure for the browser.
 
-On web, the inspector shows entries from Async Storage and Expo Secure Store adapters you configure for the browser.
+## Adapters
 
-## Adapter: MMKV
+### MMKV
 
 ```ts title="App.tsx"
 createMMKVStorageAdapter({
-  adapterId: 'mmkv',
-  adapterName: 'MMKV',
-  storages: {
-    'user-storage': userStorage,
-    'settings-storage': settingsStorage,
-  },
-  blacklist: {
-    'user-storage': /token|secret|password/,
-  },
+  storages: { 'user-storage': userStorage, 'settings-storage': settingsStorage },
+  blacklist: { 'user-storage': /token|secret|password/ },
 });
 ```
 
-### Limitations
+MMKV v4 arrays aren't supported — pass a record (`{ id: instance }`) instead.
 
-- MMKV v4 arrays are not supported because storage IDs are not readable from instances; pass a record (`{ id: instance }`) instead.
-- Buffer support depends on MMKV runtime behavior and value decoding heuristics.
-
-## Adapter: AsyncStorage
+### AsyncStorage
 
 ```ts title="App.tsx"
 // v2 style
-createAsyncStorageAdapter({
-  storage: AsyncStorage,
-});
+createAsyncStorageAdapter({ storage: AsyncStorage });
 
 // v3 style (instance-based)
 createAsyncStorageAdapter({
   storages: {
     auth: authStorageInstance,
-    cache: {
-      storage: cacheStorageInstance,
-      name: 'Cache Instance',
-      blacklist: /debug|temp/,
-    },
+    cache: { storage: cacheStorageInstance, name: 'Cache Instance', blacklist: /debug|temp/ },
   },
 });
 ```
 
-## Adapter: Expo SecureStore
+### Expo SecureStore
 
 ```ts title="App.tsx"
 createExpoSecureStorageAdapter({
@@ -106,186 +85,39 @@ createExpoSecureStorageAdapter({
 });
 ```
 
-### Limitations
+SecureStore doesn't support key enumeration, so you provide known keys via `keys`.
 
-- SecureStore does not provide key enumeration; you must provide known keys via `keys`.
+## Binary values
 
-## Binary entries (`buffer` type)
+MMKV storages that hold binary values render and edit them through a hex viewer with a Base64 mode for copy/paste. AsyncStorage and Expo SecureStore don't support binary values.
 
-Storages that support binary values — MMKV with its `getBuffer/set(ArrayBuffer)` APIs today — render and edit those values through a hex-first UI. The internal protocol is unchanged: a `buffer` is still a `number[]` of byte values; the new UI is purely a presentation and editing layer on top.
+## Hiding sensitive keys
 
-### Table view
-
-Buffer entries render as a short hex preview plus the total byte length:
-
-```text
-89 50 4E 47 0D 0A 1A 0A … 128 B
-```
-
-The first 8 bytes are shown. Smaller buffers omit the ellipsis.
-
-### Detail dialog
-
-Opening a `buffer` entry shows a standard hexdump with offsets, grouped hex bytes, and an ASCII column. The total byte length is shown above the dump.
-
-```text
-00000000  89 50 4E 47 0D 0A 1A 0A  00 00 00 0D 49 48 44 52  |.PNG........IHDR|
-00000010  00 00 00 20 00 00 00 20  08 06 00 00 00 73 7A 7A  |... ... .....szz|
-```
-
-ASCII bytes in the range `0x20–0x7E` render as themselves; everything else (control bytes, tabs, newlines, high bytes) renders as `.`.
-
-### Add / Edit dialogs
-
-The buffer editor opens in **Hex** mode by default. **Base64** is available as a secondary mode for copy/paste workflows. Bytes are the source of truth: switching modes converts the current input in place, or clears the editor if the input was incomplete.
-
-#### Hex mode
-
-A CodeMirror editor renders bytes in a canonical grouped-hex layout:
-
-```text
-89 50 4E 47 0D 0A 1A 0A  00 00 00 0D 49 48 44 52
-00 00 00 20 00 00 00 20  08 06 00 00 00 73 7A 7A
-```
-
-Rules:
-
-- 16 bytes per line; single spaces between bytes; an extra space between bytes 8 and 9.
-- Bytes are uppercase. Whitespace is not significant.
-- Typing leaves the surrounding text alone — single-byte edits do not reflow the document.
-- **Pasted content is normalized immediately.** The parser accepts:
-  - raw continuous hex (`deadbeef`)
-  - grouped hex with whitespace (`DE AD BE EF`)
-  - multiline grouped hex
-  - hexdump rows pasted from external tools — leading offsets and trailing `|ascii|` columns are stripped automatically
-  - optional `0x` prefixes per token
-- Incomplete intermediate input (e.g. a trailing single nibble) is allowed in the editor; save remains disabled until the value is valid.
-
-#### Base64 mode
-
-A plain editor accepting multiline base64. Surrounding and internal whitespace is trimmed before decoding.
-
-#### Validation messages
-
-Below the editor:
-
-- byte count
-- ASCII preview of the current bytes
-- the active error, if any
-
-Errors mirror what the parser surfaces:
-
-- `Enter at least one byte.`
-- `Hex input contains invalid characters.`
-- `Hex input must contain complete bytes.`
-- `Base64 input is invalid.`
-
-Save is disabled while the input is invalid.
-
-### Cross-adapter compatibility
-
-| Adapter          | Supports `buffer` |
-| ---------------- | :---------------: |
-| MMKV             |         ✓         |
-| AsyncStorage     |         —         |
-| Expo SecureStore |         —         |
-
-The dropdown's `Buffer (Array)` option is disabled in the Add Entry dialog for string-only storages.
-
-## Per-Storage Blacklist
-
-Blacklist is configured per storage and matched against the key in that storage.
+`blacklist` is configured per storage and matched against the key in that storage:
 
 ```ts title="App.tsx"
 createAsyncStorageAdapter({
   storages: {
-    cache: {
-      storage: cacheStorageInstance,
-      blacklist: /temp|debug|internal/,
-    },
+    cache: { storage: cacheStorageInstance, blacklist: /temp|debug|internal/ },
   },
 });
 ```
 
 ## Large storages
 
-The panel discovers configured storages without reading their entries. After
-you select a storage, it loads bounded, key-sorted pages containing value
-previews only. Search applies to keys on the device before pagination.
+The panel loads entries in bounded, key-sorted pages with value previews only — it doesn't read your whole storage up front. Search runs on the device before pagination. Open an entry to load its full value; closing it, switching storage, or refreshing discards that loaded value again.
 
-Open or edit an entry to load its complete value. Closing that interaction,
-switching storage, or using Refresh discards the loaded full value. The table
-keeps only a bounded working set of preview pages while scrolling.
+Storages with native subscriptions (like MMKV) update live. Others don't poll — use **Refresh** to pick up external changes.
 
-Storages with native subscriptions send key-only invalidations to keep the
-active view current. Storages without native subscriptions do not poll; use
-**Refresh** to see external changes.
+## Import / export
 
-## Import / Export
+Export the currently selected storage to a JSON snapshot, and import one back — handy for reproducing a bug from a captured state or sharing a scenario with a teammate.
 
-The panel can export the currently selected storage to a JSON snapshot and import a snapshot back. Use this to reproduce bugs from a captured state, share state between teammates, or seed known test scenarios without writing one-off app code.
+- Import and export always target the **currently selected storage** — switch the dropdown first to target a different one.
+- Import is an upsert: existing keys are overwritten, missing keys are created, keys not in the file are left alone. There's no "replace all".
+- The file is validated before anything is written. If validation fails, nothing changes.
+- Keys matching the target storage's `blacklist` are skipped, and the preview shows you which ones before you apply.
 
-### Behavior
-
-- **Scope**: Import and Export always operate on the **currently selected storage** only. Importing into a different storage requires switching the dropdown first; the file's metadata is never used to redirect the target.
-- **Upsert**: Import overwrites existing keys and creates missing ones. Keys not present in the file are left untouched. There is no "replace all" mode.
-- **Validate before write**: The file is fully parsed and validated before any entries are applied. If validation fails, nothing is written and the error points at the offending path (for example, `entries[3].value`).
-- **Stop on first error**: If a write fails mid-import (rare — most failures are caught up-front), the import stops and reports which key failed. Already-written entries stay; rerunning import is safe because writes are idempotent.
-- **Skipped keys**: Keys matching the target storage's `blacklist` are skipped during write. The preview shows the count and the keys before you apply.
-- **Live updates**: Completion invalidates the selected storage once, then the
-  table reloads authoritative preview pages. Progress events contain counts,
-  not imported values.
-
-### JSON snapshot schema
-
-Exports use a stable, versioned format:
-
-```json title="rozenite-storage-mmkv-user-20260511-104643.json"
-{
-  "version": 1,
-  "plugin": "@rozenite/storage-plugin",
-  "createdAt": "2026-05-11T10:46:43.000Z",
-  "storage": {
-    "adapterId": "mmkv",
-    "storageId": "user",
-    "adapterName": "MMKV",
-    "storageName": "user",
-    "capabilities": {
-      "supportedTypes": ["string", "number", "boolean", "buffer"]
-    }
-  },
-  "entries": [
-    { "key": "token", "type": "string", "value": "abc" },
-    { "key": "launchCount", "type": "number", "value": 3 },
-    { "key": "seenOnboarding", "type": "boolean", "value": true },
-    { "key": "blob", "type": "buffer", "value": [1, 2, 255] }
-  ]
-}
-```
-
-Fields:
-
-- `version` (number, required) — load-bearing. The current build accepts `1` only.
-- `plugin` (string, required) — informational. Always `@rozenite/storage-plugin` for files this plugin produces.
-- `createdAt` (string, required) — ISO-8601 timestamp of the export. Informational.
-- `storage` (object, required) — describes the source storage. Used for the preview's "imported from" label and the metadata-mismatch warning when the target storage differs. **Never used to redirect the import.**
-- `entries` (array, required) — typed entry list. Each entry has `key` (string), `type` (`"string" | "number" | "boolean" | "buffer"`), and `value` matching the type. Buffer values are `number[]` of integers in `0–255`. Empty arrays are allowed (a no-op import).
-- Unknown top-level fields are ignored for forward compatibility.
-
-### Cross-adapter compatibility
-
-The schema is portable across adapters, but each adapter only stores types it supports:
-
-| Adapter          | string | number | boolean | buffer |
-| ---------------- | :----: | :----: | :-----: | :----: |
-| MMKV             |   ✓    |   ✓    |    ✓    |   ✓    |
-| AsyncStorage     |   ✓    |   ✓    |    ✓    |   —    |
-| Expo SecureStore |   ✓    |   —    |    —    |   —    |
-
-If a file contains an entry whose `type` is not supported by the selected target, the preview disables **Apply** and lists the offending keys. Remove them from the file (or import into a more capable storage) and retry.
-
-### Versioning
-
-The current build accepts `version: 1` snapshots. Any other value is rejected with a clear error. Future schema bumps will either be backward-compatible additions or documented as breaking — but `version !== 1` is never silently coerced.
+Exports are versioned (`version: 1` today); a mismatched version is rejected rather than silently coerced.
 
 **Next**: See [MMKV](./mmkv.md), [Network Activity](./network-activity.md), and [Plugin Development](../plugin-development/plugin-development.md).

--- a/website/src/docs/official-plugins/tanstack-query.mdx
+++ b/website/src/docs/official-plugins/tanstack-query.mdx
@@ -4,30 +4,15 @@ import { PackageManagerTabs } from '@rspress/core/theme';
 
 ![](/tanstack-query-plugin.png)
 
-The TanStack Query plugin integrates [TanStack Query DevTools](https://tanstack.com/query/latest/docs/react/devtools) directly into your React Native DevTools, providing powerful query monitoring, cache management, and debugging capabilities for your React Native applications.
+The TanStack Query plugin brings [TanStack Query DevTools](https://tanstack.com/query/latest/docs/react/devtools) into React Native DevTools, so you can inspect and manage your queries and cache without leaving the DevTools window.
 
-This plugin was inspired by the excellent work of Austin Johnson and his [react-query-external-sync](https://github.com/LovesWorking/react-query-external-sync) library, which provided crucial insights into making TanStack Query work effectively in React Native environments.
-
-## What is TanStack Query?
-
-TanStack Query (formerly React Query) is a powerful data synchronization library for React and React Native that provides:
-
-- **Server State Management**: Efficiently manage, cache, and synchronize server state
-- **Automatic Background Updates**: Keep data fresh with automatic refetching
-- **Optimistic Updates**: Provide instant feedback with optimistic UI updates
-- **Error Handling**: Built-in error handling and retry mechanisms
-- **Caching**: Intelligent caching with configurable invalidation strategies
-- **DevTools**: Comprehensive debugging and monitoring tools
+It was inspired by Austin Johnson's [react-query-external-sync](https://github.com/LovesWorking/react-query-external-sync).
 
 ## Installation
 
-Make sure to go through the [Getting Started guide](/docs/getting-started) before installing the plugin,
-
-Install the TanStack Query plugin as a development dependency using your preferred package manager:
+Make sure to go through the [Getting Started guide](/docs/getting-started) before installing the plugin.
 
 <PackageManagerTabs command="install -D @rozenite/tanstack-query-plugin" />
-
-Add the DevTools hook to your React Native app to enable TanStack Query integration:
 
 ```typescript title="App.tsx"
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -43,7 +28,6 @@ const queryClient = new QueryClient({
 });
 
 function App() {
-  // Enable DevTools in development
   useTanStackQueryDevTools(queryClient);
 
   return (
@@ -56,25 +40,10 @@ function App() {
 
 ## Web (React Native for Web)
 
-With [Rozenite for Web](/docs/rozenite-for-web), this plugin is available when you debug your React Native web app.
+With [Rozenite for Web](/docs/rozenite-for-web), this plugin is also available when debugging your React Native web app.
 
 ## Usage
 
-Once configured, the TanStack Query plugin will automatically appear in your React Native DevTools sidebar as "TanStack Query".
+Once configured, "TanStack Query" appears in your React Native DevTools sidebar with the standard TanStack Query DevTools UI: live queries and mutations, cache inspection, and actions to refetch, invalidate, reset, or remove entries.
 
-## Contributing
-
-The TanStack Query plugin is open source and welcomes contributions! Check out the [Plugin Development Guide](../plugin-development/plugin-development.md) to learn how to contribute or create your own plugins.
-
-## Support
-
-If you encounter issues with the TanStack Query plugin:
-
-1. **Check Documentation**: Review this guide for common solutions
-2. **Search Issues**: Look for similar issues in the repository
-3. **Create Issue**: Report bugs or request features
-4. **Community**: Reach out to the Rozenite community for help
-
----
-
-**Next**: Learn about [Plugin Development](../plugin-development/plugin-development.md) to create your own plugins, or explore other [Official Plugins](./overview.md).
+**Next**: Learn about [Plugin Development](../plugin-development/plugin-development.md), or explore other [Official Plugins](./overview.md).

--- a/website/src/docs/plugin-development/overview.md
+++ b/website/src/docs/plugin-development/overview.md
@@ -1,40 +1,17 @@
 # Plugin Development Overview
 
-Plugins are the way to add new panels and functionalities to React Native DevTools through Rozenite. They allow you to extend the DevTools with custom debugging tools, performance monitors, and development utilities.
+Plugins add new panels to React Native DevTools through Rozenite — custom debugging tools, performance monitors, and development utilities tailored to your app.
 
-## What are Plugins?
+## How plugins work
 
-Plugins are packages that integrate seamlessly with Rozenite to add custom panels and functionality to React Native DevTools. They provide a powerful way to extend the development experience with tools tailored to your specific needs.
+A plugin has two parts that talk to each other over a type-safe, event-based bridge:
 
-### Key Characteristics
+1. **React Native side** — code that runs in your app.
+2. **DevTools side** — the panel UI shown in DevTools.
 
-- **Production Ready**: Tested and optimized for real-world use
-- **Type Safe**: Built with full TypeScript support
-- **Well Documented**: Comprehensive guides and examples
-- **Actively Maintained**: Regular updates and bug fixes
+Changes on either side are reflected on the other in real time, and both sides can send data or commands.
 
-## How Plugins Work
-
-### Architecture Overview
-
-Plugins consist of two main parts:
-
-1. **React Native Side**: Code that runs in your React Native app
-2. **DevTools Side**: UI components that appear in the DevTools interface
-
-### Communication Flow
-
-```
-React Native App ←→ Plugin Bridge ←→ DevTools Interface
-```
-
-- **Event-based Communication**: Plugins use a type-safe event system
-- **Real-time Updates**: Changes in your app are reflected immediately in DevTools
-- **Bidirectional**: Both sending data to DevTools and receiving commands from it
-
-### Plugin Structure
-
-A typical plugin has this structure:
+## Plugin structure
 
 ```
 my-plugin/
@@ -47,30 +24,16 @@ my-plugin/
 └── tsconfig.json          # TypeScript configuration
 ```
 
-## Plugin Capabilities
+## What you can build
 
-### What You Can Build
+Anything that benefits from a live view into your running app: custom debugging tools, performance monitors, state inspectors, network tools, storage inspectors, or development-time analytics.
 
-- **Custom Debugging Tools**: Create specialized debugging panels
-- **Performance Monitors**: Track app performance metrics
-- **State Inspectors**: Visualize and manipulate app state
-- **Network Tools**: Monitor and analyze network requests
-- **Storage Inspectors**: View and edit local storage
-- **Custom Analytics**: Build development-time analytics tools
+To develop without wiring up a playground app first, `rozenite dev` opens an in-browser dev host where you can preview panels, read the message log, and dispatch commands — see the [Plugin Development guide](./plugin-development.md#step-5-local-development-workflow). You can also define reusable presets and scripted dev flows in `rozenite.config.ts` to speed up local iteration.
 
-### Technical Features
+## Getting started
 
-- **React Native API Access**: Leverage React Native APIs and libraries
-- **Type Safety**: Full TypeScript support with compile-time checking
-- **Hot Reloading**: See changes instantly during development
-- **In-browser dev host**: `rozenite dev` opens a small test shell where you can preview panels, read the message log, and dispatch commands—without wiring up a playground app first (see the [Plugin Development guide](./plugin-development.md#step-5-local-development-workflow))
-- **Dev host presets and flows**: Define reusable commands and scripted dev routines in `rozenite.config.ts` to speed up local panel development
-- **Production Builds**: Optimized builds for distribution
-
-## Getting Started
-
-Ready to create your first plugin? Check out the [Plugin Development Guide](./plugin-development.md) for a complete walkthrough, or explore the [Official Plugins](../official-plugins/overview.md) to see examples of what's possible.
+Ready to build one? Follow the [Plugin Development Guide](./plugin-development.md) for a full walkthrough, or browse the [Official Plugins](../official-plugins/overview.md) for examples of what's possible.
 
 ## Contributing
 
-Want to contribute to the plugin ecosystem? We welcome contributions to both our maintained plugins and community plugins. Check out our [Plugin Development Guide](./plugin-development.md) to learn how to create plugins, or reach out to the community to discuss your ideas.
+We welcome contributions to both our maintained plugins and the community ecosystem. See the [Plugin Development Guide](./plugin-development.md) to get started, or reach out to the community to discuss an idea.

--- a/website/src/docs/plugin-development/plugin-development.md
+++ b/website/src/docs/plugin-development/plugin-development.md
@@ -6,8 +6,6 @@ This guide will walk you through the complete process of creating a React Native
 
 ## Quick Start
 
-Generate a new plugin in seconds:
-
 ```shell title="Terminal"
 npx rozenite generate
 cd my-awesome-plugin
@@ -51,11 +49,11 @@ my-plugin/
 
 ## Step 3: Creating Panels
 
-Panels are React components that appear in the DevTools interface. They're defined in your `rozenite.config.ts` file. **Plugin developers can leverage React Native APIs and libraries** to create powerful debugging tools that integrate deeply with the React Native runtime.
+Panels are React components that appear in the DevTools interface, defined in your `rozenite.config.ts` file. Your React Native side can use any React Native API or library, so a panel can integrate as deeply with the runtime as you need.
 
-### Type-Safe Plugin Development
+### Type-safe communication
 
-Rozenite provides full TypeScript support for plugin development. The `RozeniteDevToolsClient` uses an event-based API with full type safety:
+The `RozeniteDevToolsClient` uses an event-based API with full TypeScript support — compile-time checks and autocomplete for event names and payloads, and one client per plugin ID so events from different plugins never collide.
 
 #### Client API
 
@@ -70,14 +68,6 @@ client.send('event-name', payload); // Send typed event
 client.onMessage('event-name', callback); // Listen for typed event
 client.close(); // Clean up connection
 ```
-
-#### Type Safety Benefits
-
-- **Compile-time error checking** for event names and payloads
-- **IntelliSense support** for all event types and methods
-- **Type-safe event handling** between DevTools and React Native
-- **Automatic refactoring** when event interfaces change
-- **Plugin ID isolation** ensures events don't conflict between plugins
 
 ```typescript title="rozenite.config.ts"
 export default {

--- a/website/src/docs/rozenite-for-web.mdx
+++ b/website/src/docs/rozenite-for-web.mdx
@@ -6,39 +6,19 @@ import { PackageManagerTabs } from '@rspress/core/theme';
 Rozenite for Web is an experimental feature. The API and behavior may change in future releases.
 :::
 
-Rozenite for Web lets you debug your React Native web app from React Native DevTools.
+Rozenite for Web lets you debug your React Native web app from React Native DevTools — the same plugin panels you use on iOS and Android, in the browser.
 
-To use it, you need:
+You'll need a Chromium-based browser, the Rozenite browser extension, and the `@rozenite/web` package in your app. It works whether Metro bundles your web app directly, or you use Webpack Dev Server for web.
 
-- the Rozenite browser extension
-- the `@rozenite/web` package in your app
-
-**Browser support:** Chromium-based browsers only.
-
-## Prerequisites
-
-- A React Native project with web support
-- A Chromium-based browser with the Rozenite extension installed
-
-Rozenite for Web supports these setups:
-
-- **Metro-only web**: Metro bundles both mobile and web
-- **Webpack for web**: Webpack Dev Server bundles and serves the web app
-
-## Chrome extension setup
-
-Download the latest extension from the [GitHub releases](https://github.com/callstackincubator/rozenite/releases).
-
-### Installation
+## Install the Chrome extension
 
 1. Download the latest extension from the [releases page](https://github.com/callstackincubator/rozenite/releases).
-2. Open Chrome and go to `chrome://extensions`.
-3. Enable **Developer mode** (toggle in the top-right corner).
-4. Install the extension.
+2. Open Chrome, go to `chrome://extensions`, and enable **Developer mode** (top-right toggle).
+3. Install the extension.
 
-If you need help with manual installation, see the [Chrome extension loading guide](https://developer.chrome.com/docs/extensions/get-started/tutorial/hello-world#load-an-unpacked-extension).
+If you get stuck, see Chrome's [extension loading guide](https://developer.chrome.com/docs/extensions/get-started/tutorial/hello-world#load-an-unpacked-extension).
 
-## @rozenite/web package setup
+## Add @rozenite/web to your app
 
 ### Installation
 
@@ -59,18 +39,11 @@ module.exports = withRozeniteWeb(config);
 
 ### Entry point
 
-Add `require('@rozenite/web')` to your web entry point.
-
-The package gates its runtime setup internally, so you do not need to wrap the import with `__DEV__` yourself.
+Add `require('@rozenite/web')` to your web entry point — commonly `main.tsx` or your Expo Router root `_layout.tsx`. It already gates itself to development, so there's no need to wrap it in `__DEV__` yourself.
 
 ```javascript
 require('@rozenite/web');
 ```
-
-Common places:
-
-- `main.tsx`
-- Expo Router root `_layout.tsx`
 
 ### Webpack configuration
 


### PR DESCRIPTION
## Summary
- Rewrites `getting-started.mdx` to lead with the automatic `rozenite init` path and cuts the manual fallback to what's actually needed to enable Rozenite by hand.
- Trims all official plugin docs: removes the repeated Contributing/Support boilerplate footer, collapses duplicated "what is X" feature-bullet lists into the opening paragraph, and cuts implementation internals that don't affect what a user does (network-activity's hex-viewer/CSP mechanics, storage's byte-parsing rules, require-profiler's repeated sections).
- Light tightening pass on `plugin-development/overview.md` (cut generic marketing bullets + a redundant ASCII diagram) and `agent/skills.mdx` (cut maintainer-only rationale) and `rozenite-for-web.mdx`.
- Left `introduction.md`, `compatibility.mdx`, `feature-flags.mdx`, `sqlite.mdx`, `react-hook-form.mdx`, `plugin-development/rpc.md`, most of `agent/*`, and `prior-art.mdx` as-is — already concise or appropriately technical for their audience (plugin/agent-tool authors).

## Test plan
- [ ] Skim rendered pages in the website preview for broken formatting/links
- [ ] Confirm code snippets still match current package APIs