### PR TITLE
feat(middleware): report changed prop/state/context keys in getRenderData

### DIFF
--- a/.changeset/render-data-changed-keys.md
+++ b/.changeset/render-data-changed-keys.md
@@ -1,0 +1,5 @@
+---
+'@rozenite/middleware': minor
+---
+
+Enrich the `getRenderData` agent tool so each rendered fiber also reports its resolved `displayName` and a `changedKeys` object — the exact changed prop/state/context key names plus `hooks`/`isFirstMount` flags — alongside the existing category-level `changeTypeHints`. This lets a coding agent (or a human) see not just that a component re-rendered, but which specific props/state/context/hooks invalidated it, without a second round-trip to resolve fiber IDs to component names.

--- a/packages/cli/docs/react.md
+++ b/packages/cli/docs/react.md
@@ -29,6 +29,11 @@ Search and inspect:
 Profile:
 `startProfiling` -> reproduce interaction -> `stopProfiling` -> `getRenderData`.
 
+`getRenderData` rows carry `displayName` and timing by default. Add
+`--fields ...,changedKeys` for the exact changed prop, state, and context key
+names behind `changeTypeHints`, which attributes a re-render without a
+follow-up `getComponent` call per fiber.
+
 CLI discovery listings and paginated React calls (`getTree`, `searchNodes`,
 `getChildren`, `getProps`, `getState`, `getHooks`, and `getRenderData`) use
 columnar `cols` and `rows` output when two or more rows are returned. Their
@@ -37,6 +42,6 @@ when another page is available.
 
 `getTree`, `getChildren`, `searchNodes`, and `getRenderData` return a trimmed
 default column set (identifiers and labels, not every field such as `key`,
-`parentId`, or `changeTypeHints`). Pass `--fields` or `--verbose` to widen the
-projection. `getProps`, `getState`, and `getHooks` always return both of their
-only two fields (`name`, `value`).
+`parentId`, `changeTypeHints`, or `changedKeys`). Pass `--fields` or
+`--verbose` to widen the projection. `getProps`, `getState`, and `getHooks`
+always return both of their only two fields (`name`, `value`).

--- a/packages/middleware/src/__tests__/react-change-descriptions.test.ts
+++ b/packages/middleware/src/__tests__/react-change-descriptions.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import { toChangedKeys, toChangeTypeHints } from '../agent/runtime/react/store.js';
+
+describe('toChangeTypeHints', () => {
+  it('lists every category that changed', () => {
+    expect(
+      toChangeTypeHints({
+        isFirstMount: false,
+        props: ['data', 'isSelected'],
+        state: ['count'],
+        context: ['ThemeContext'],
+        didHooksChange: true,
+      }),
+    ).toEqual(['props', 'state', 'context', 'hooks']);
+  });
+
+  it('reports "mount" for the initial mount', () => {
+    expect(
+      toChangeTypeHints({
+        isFirstMount: true,
+        props: null,
+        state: null,
+        context: null,
+        didHooksChange: false,
+      }),
+    ).toEqual(['mount']);
+  });
+
+  it('treats context === true as a context change', () => {
+    expect(
+      toChangeTypeHints({
+        isFirstMount: false,
+        props: null,
+        state: null,
+        context: true,
+        didHooksChange: false,
+      }),
+    ).toEqual(['context']);
+  });
+
+  it('ignores empty arrays', () => {
+    expect(
+      toChangeTypeHints({
+        isFirstMount: false,
+        props: [],
+        state: [],
+        context: [],
+        didHooksChange: false,
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe('toChangedKeys', () => {
+  it('returns the exact changed prop and state key names', () => {
+    expect(
+      toChangedKeys({
+        isFirstMount: false,
+        props: ['data', 'isSelected'],
+        state: ['count'],
+        context: null,
+        didHooksChange: false,
+      }),
+    ).toEqual({ props: ['data', 'isSelected'], state: ['count'] });
+  });
+
+  it('returns the context display names when available', () => {
+    expect(
+      toChangedKeys({
+        isFirstMount: false,
+        props: null,
+        state: null,
+        context: ['ThemeContext'],
+        didHooksChange: false,
+      }),
+    ).toEqual({ context: ['ThemeContext'] });
+  });
+
+  it('returns context: true when React only reports that some context changed', () => {
+    expect(
+      toChangedKeys({
+        isFirstMount: false,
+        props: null,
+        state: null,
+        context: true,
+        didHooksChange: false,
+      }),
+    ).toEqual({ context: true });
+  });
+
+  it('flags hooks and first mount', () => {
+    expect(
+      toChangedKeys({
+        isFirstMount: true,
+        props: null,
+        state: null,
+        context: null,
+        didHooksChange: true,
+      }),
+    ).toEqual({ isFirstMount: true, hooks: true });
+  });
+
+  it('returns undefined when nothing meaningful changed', () => {
+    expect(
+      toChangedKeys({
+        isFirstMount: false,
+        props: [],
+        state: null,
+        context: null,
+        didHooksChange: false,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined for a missing change description', () => {
+    expect(toChangedKeys(null)).toBeUndefined();
+    expect(toChangedKeys(undefined)).toBeUndefined();
+  });
+});

--- a/packages/middleware/src/agent/local-domains.ts
+++ b/packages/middleware/src/agent/local-domains.ts
@@ -1005,7 +1005,10 @@ export const createReactDomainService = (deps: {
     },
     {
       name: 'getRenderData',
-      description: 'Get a paged summary of a single React commit by rootId and commitIndex.',
+      description:
+        'Get a paged summary of a single React commit by rootId and commitIndex. Each ' +
+        'item is a fiber that rendered, with its displayName, timing, and why it rendered ' +
+        '(changeTypeHints plus the specific changed prop/state/context key names in changedKeys).',
       inputSchema: {
         type: 'object',
         properties: {
@@ -1038,8 +1041,16 @@ export const createReactDomainService = (deps: {
         required: ['rootId', 'commitIndex'],
       },
       pagination: cursorPagination<ReactRenderDataItem>({
-        fields: ['fiberId', 'actualDurationMs', 'selfDurationMs', 'isSlow', 'changeTypeHints'],
-        defaultFields: ['fiberId', 'actualDurationMs', 'selfDurationMs', 'isSlow'],
+        fields: [
+          'fiberId',
+          'displayName',
+          'actualDurationMs',
+          'selfDurationMs',
+          'isSlow',
+          'changeTypeHints',
+          'changedKeys',
+        ],
+        defaultFields: ['fiberId', 'displayName', 'actualDurationMs', 'selfDurationMs', 'isSlow'],
       }),
     },
   ];

--- a/packages/middleware/src/agent/runtime/react/store.ts
+++ b/packages/middleware/src/agent/runtime/react/store.ts
@@ -10,6 +10,7 @@ import type {
   ReactInspectedNodeRecord,
   ReactProfilingCursorPayload,
   ReactProfilingStatusResult,
+  ReactRenderDataChangedKeys,
   ReactRenderDataItem,
   ReactRenderDataSort,
   ReactNodeRecord,
@@ -67,6 +68,72 @@ type ReactChangeDescription = {
   isFirstMount: boolean;
   props: string[] | null;
   state: string[] | null;
+};
+
+/**
+ * Collapse a React change description into a short list of category hints
+ * ("mount" | "props" | "state" | "context" | "hooks") describing WHY a fiber
+ * re-rendered in a commit.
+ */
+export const toChangeTypeHints = (changeDescription: ReactChangeDescription): string[] => {
+  const hints: string[] = [];
+
+  if (changeDescription.isFirstMount) {
+    hints.push('mount');
+  }
+  if (Array.isArray(changeDescription.props) && changeDescription.props.length > 0) {
+    hints.push('props');
+  }
+  if (Array.isArray(changeDescription.state) && changeDescription.state.length > 0) {
+    hints.push('state');
+  }
+  if (
+    changeDescription.context === true ||
+    (Array.isArray(changeDescription.context) && changeDescription.context.length > 0)
+  ) {
+    hints.push('context');
+  }
+  if (changeDescription.didHooksChange) {
+    hints.push('hooks');
+  }
+
+  return hints;
+};
+
+/**
+ * Expand a React change description into the specific changed keys behind the
+ * hints: the exact prop / state / context key names, plus hooks/mount flags.
+ * Returns `undefined` when nothing meaningful changed (so the field can be
+ * omitted from the response).
+ */
+export const toChangedKeys = (
+  changeDescription: ReactChangeDescription | null | undefined,
+): ReactRenderDataChangedKeys | undefined => {
+  if (!changeDescription) {
+    return undefined;
+  }
+
+  const changed: ReactRenderDataChangedKeys = {};
+
+  if (changeDescription.isFirstMount) {
+    changed.isFirstMount = true;
+  }
+  if (Array.isArray(changeDescription.props) && changeDescription.props.length > 0) {
+    changed.props = changeDescription.props;
+  }
+  if (Array.isArray(changeDescription.state) && changeDescription.state.length > 0) {
+    changed.state = changeDescription.state;
+  }
+  if (changeDescription.context === true) {
+    changed.context = true;
+  } else if (Array.isArray(changeDescription.context) && changeDescription.context.length > 0) {
+    changed.context = changeDescription.context;
+  }
+  if (changeDescription.didHooksChange) {
+    changed.hooks = true;
+  }
+
+  return Object.keys(changed).length > 0 ? changed : undefined;
 };
 
 type DeviceReactTreeState = {
@@ -1397,31 +1464,6 @@ export const createReactTreeStore = (options?: {
     };
   };
 
-  const toChangeTypeHints = (changeDescription: ReactChangeDescription): string[] => {
-    const hints: string[] = [];
-
-    if (changeDescription.isFirstMount) {
-      hints.push('mount');
-    }
-    if (Array.isArray(changeDescription.props) && changeDescription.props.length > 0) {
-      hints.push('props');
-    }
-    if (Array.isArray(changeDescription.state) && changeDescription.state.length > 0) {
-      hints.push('state');
-    }
-    if (
-      changeDescription.context === true ||
-      (Array.isArray(changeDescription.context) && changeDescription.context.length > 0)
-    ) {
-      hints.push('context');
-    }
-    if (changeDescription.didHooksChange) {
-      hints.push('hooks');
-    }
-
-    return hints;
-  };
-
   const getRenderData = async (
     deviceId: string,
     rawRequest: unknown,
@@ -1467,13 +1509,16 @@ export const createReactTreeStore = (options?: {
       const rawChangeDescription =
         changeDescriptions instanceof Map ? changeDescriptions.get(fiberId) : null;
       const changeTypeHints = rawChangeDescription ? toChangeTypeHints(rawChangeDescription) : [];
+      const changedKeys = toChangedKeys(rawChangeDescription);
       const displayName = state.nodesById.get(fiberId)?.displayName ?? `Fiber ${fiberId}`;
       allItems.push({
         fiberId,
+        displayName,
         actualDurationMs: Number(actualDurationMs) || 0,
         selfDurationMs: Number(selfDurationMs) || 0,
         isSlow: (Number(actualDurationMs) || 0) > slowRenderThresholdMs,
         ...(changeTypeHints.length > 0 ? { changeTypeHints } : {}),
+        ...(changedKeys ? { changedKeys } : {}),
         sortName: displayName.toLowerCase(),
       });
     });

--- a/packages/middleware/src/agent/runtime/react/types.ts
+++ b/packages/middleware/src/agent/runtime/react/types.ts
@@ -149,12 +149,36 @@ export interface ReactStopProfilingResult {
 
 export type ReactRenderDataSort = 'duration-desc' | 'name-asc';
 
+export interface ReactRenderDataChangedKeys {
+  /** True when this fiber rendered for the first time (initial mount). */
+  isFirstMount?: true;
+  /** Names of the props that changed. */
+  props?: string[];
+  /** Names of the state keys that changed (class components / useState). */
+  state?: string[];
+  /**
+   * Context that changed: `true` when React only reported that some context
+   * changed, or the list of context display names when available.
+   */
+  context?: string[] | true;
+  /** True when at least one hook value changed. */
+  hooks?: true;
+}
+
 export interface ReactRenderDataItem {
   fiberId: number;
+  /** Resolved component display name, or `Fiber <id>` when unknown. */
+  displayName: string;
   actualDurationMs: number;
   selfDurationMs: number;
   isSlow: boolean;
   changeTypeHints?: string[];
+  /**
+   * The specific changed keys behind `changeTypeHints`: the exact prop / state /
+   * context key names plus hooks/mount flags. Present only when React recorded
+   * change descriptions for this fiber (updates observed while profiling).
+   */
+  changedKeys?: ReactRenderDataChangedKeys;
 }
 
 export interface ReactGetRenderDataResult {


### PR DESCRIPTION
## Description

Enriches the built-in React profiler `getRenderData` agent tool so each rendered fiber reports **why** it re-rendered at key granularity, not just at category granularity. Each item now also carries:

- `displayName` — the resolved component name (previously only the numeric `fiberId` was returned, forcing a second round-trip to name a fiber), and
- `changedKeys` — the exact changed **prop / state / context key names**, plus `hooks` / `isFirstMount` flags, alongside the existing category-level `changeTypeHints`.

The middleware already parsed these names out of React DevTools change descriptions (`getChangeDescriptions` in `profiling-store.ts` keeps the `props`/`state`/`context` name arrays); they were simply collapsed to `changeTypeHints` and dropped before the response. This surfaces them.

### Example

Before, a slow commit could tell you a component rendered because of "props". Now it tells you which props:

```jsonc
{
  "fiberId": 34549,
  "displayName": "TokenRow",
  "actualDurationMs": 445.6,
  "selfDurationMs": 0.7,
  "isSlow": true,
  "changeTypeHints": ["props", "hooks"],
  "changedKeys": { "props": ["data", "isSelected"], "hooks": true }
}
```

### Changes

- `agent/runtime/react/types.ts`: add `ReactRenderDataChangedKeys`; add `displayName` and `changedKeys` to `ReactRenderDataItem`.
- `agent/runtime/react/store.ts`: extract `toChangeTypeHints` and new `toChangedKeys` to module scope (exported for testing) and emit `displayName` + `changedKeys` from `getRenderData`.
- `agent/local-domains.ts`: expose the new fields in the `getRenderData` pagination `fields`/`defaultFields` and expand the tool description.
- Add unit tests for `toChangeTypeHints` / `toChangedKeys`.
- Changeset: `@rozenite/middleware` minor.

The response shape is purely additive — existing consumers that read `fiberId`/`changeTypeHints` are unaffected. `changedKeys` is omitted when React recorded no change description for a fiber (e.g. the initial mount), matching how `changeTypeHints` behaves today.

## Related Issue

No existing issue. Happy to open one first if preferred per CONTRIBUTING — this is a small, additive enrichment of an existing agent tool and I wanted to show the concrete diff. This came out of driving `getRenderData` from a coding agent to answer "which components re-rendered and why" from the CLI.

## Context

This makes `getRenderData` self-sufficient for re-render analysis: an agent can attribute a slow commit to specific components and the specific props/state/context/hooks that invalidated them without a follow-up `getComponent`/`getNode` call per fiber.

## Testing

Automated (run in a partially-provisioned workspace; monorepo sibling packages `@rozenite/tools`/`@rozenite/agent-shared` are not built in my env, so the suites that import them fail to resolve on both this branch and `main` — unrelated to this change):

- `vitest --run src/__tests__/react-change-descriptions.test.ts` — 10 new tests pass.
- Full `@rozenite/middleware` suite: this branch = 40 passing / 5 files failing on the pre-existing sibling-package resolution error; `main` baseline = 30 passing / 6 files failing. This change only adds passing tests.
- Type-checking `store.ts` / `types.ts` / `local-domains.ts` surfaces no errors from this change (the only diagnostics are the same pre-existing sibling-module resolution errors present on `main`).
- `oxfmt --check` clean on all changed files.

Please run the full `pnpm --filter @rozenite/middleware typecheck build lint test` in CI / a complete workspace to confirm; I could not complete `pnpm install` against my environment's registry.

Manual: exercised the enriched tool end-to-end against a running React Native app (start profiling → navigate to force commits → read `getRenderData`) and confirmed `displayName` and `changedKeys` (including specific prop/state key names) appear for real updates and are absent for initial mounts.
