### PR TITLE
fix(tools): format chrome-extension manifest.json after version sync

### DIFF
--- a/scripts/release/release.mjs
+++ b/scripts/release/release.mjs
@@ -100,6 +100,7 @@ function syncChromeExtensionManifestVersion() {
 
   manifest.version = manifestVersion;
   writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  run('pnpm', ['exec', 'oxfmt', '--write', manifestPath]);
 }
 
 function publishChromeExtensionRelease(tag) {


### PR DESCRIPTION
## Description

Fixes the release automation added in #394: after `syncChromeExtensionManifestVersion()` rewrites `packages/chrome-extension/manifest.json`'s `version` field via `JSON.stringify(manifest, null, 2)`, the file's short arrays (`permissions`, `resources`, `matches`) get expanded onto multiple lines, which doesn't match oxfmt's formatting (it collapses arrays that fit on one line). Since `commitVersionChanges()` runs a normal `git commit`, lefthook's `pre-commit` hook runs `oxfmt --check` on the staged file and fails, aborting the release commit.

See the failed run: https://github.com/callstackincubator/rozenite/actions/runs/31677909005/job/94376470953

## Related Issue

N/A — no existing issue for this change.

## Context

Rather than hand-matching oxfmt's array-collapsing rules in the manual `JSON.stringify` output, `syncChromeExtensionManifestVersion()` now runs `oxfmt --write` on the file immediately after writing it, so the staged file is already correctly formatted regardless of future oxfmt config changes.

## Testing

- Simulated a version bump against the current `manifest.json` and confirmed the pre-existing `JSON.stringify` output fails `oxfmt --check` (arrays expand to multi-line) while the fixed code (`oxfmt --write` after writing) passes.
- `pnpm exec oxfmt --check scripts/release/release.mjs`
- `pnpm exec eslint scripts/release/release.mjs` — pre-existing unrelated `no-undef` errors for `console`/`Buffer` confirmed present before this change too.