### PR TITLE
perf(runtime): skip JSON.parse for non-rozenite binding traffic

### DIFF
--- a/.changeset/skip-parse-non-rozenite-bindings.md
+++ b/.changeset/skip-parse-non-rozenite-bindings.md
@@ -1,0 +1,9 @@
+---
+'@rozenite/runtime': patch
+---
+
+Reduce DevTools frontend overhead by skipping `JSON.parse` for binding
+messages that cannot be for the `rozenite` domain. Rozenite shares its
+binding with React Native's own React DevTools integration, so every React
+DevTools bridge message (which can carry full component trees) was
+previously parsed and discarded on every call.

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -37,7 +37,8 @@
   "scripts": {
     "build": "vite build",
     "typecheck": "tsc -p tsconfig.lib.json --noEmit",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "vitest --run --passWithNoTests"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/runtime/src/rn-devtools/__tests__/bindings-model.test.ts
+++ b/packages/runtime/src/rn-devtools/__tests__/bindings-model.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// `rn-devtools-frontend.ts` re-exports modules from the Chrome DevTools frontend
+// runtime (e.g. `/rozenite/core/sdk/sdk.js`), which only exist inside the actual
+// DevTools frontend environment. For unit testing `bindingCalled` in isolation we
+// stub it with a minimal `SDKModel` base class: `bindingCalled` never touches
+// `target()` or the DevTools-provided `dispatchEventToListeners`, so a bare-bones
+// stand-in is sufficient and avoids mocking 80% of an unrelated framework.
+vi.mock('../rn-devtools-frontend.js', () => {
+  class FakeSDKModel {
+    private readonly fakeTarget: unknown;
+
+    constructor(target: unknown) {
+      this.fakeTarget = target;
+    }
+
+    target(): unknown {
+      return this.fakeTarget;
+    }
+
+    dispatchEventToListeners(): void {
+      // no-op: not exercised by bindingCalled
+    }
+
+    static register(): void {
+      // no-op: registration is only meaningful inside the real DevTools frontend
+    }
+  }
+
+  return {
+    SDK: { SDKModel: { SDKModel: FakeSDKModel } },
+  };
+});
+
+const { RozeniteBindingsModel } = await import('../bindings-model.js');
+
+const BINDING_NAME = '__CHROME_DEVTOOLS_FRONTEND_BINDING__';
+
+// `bindingCalled` and the fields it reads are private, so a real intersection with the
+// class type collapses to `never`. This shape instead names just what the tests need,
+// keeping access typed instead of poking at an untyped `any`.
+type TestableModel = Pick<
+  InstanceType<typeof RozeniteBindingsModel>,
+  'subscribeToDomainMessages' | 'unsubscribeFromDomainMessages'
+> & {
+  messagingBindingName: string | null;
+  fuseboxDispatcherIsInitialized: boolean;
+  bindingCalled(event: { data: { name: string; payload: string } }): void;
+};
+
+describe('RozeniteBindingsModel bindingCalled', () => {
+  const createModel = (): TestableModel => {
+    const model = new RozeniteBindingsModel({} as never) as unknown as TestableModel;
+    model.messagingBindingName = BINDING_NAME;
+    model.fuseboxDispatcherIsInitialized = true;
+    return model;
+  };
+
+  it('dispatches a rozenite message to listeners', () => {
+    const model = createModel();
+    const listener = vi.fn();
+    model.subscribeToDomainMessages(listener);
+
+    const payload = JSON.stringify({ domain: 'rozenite', message: { hello: 'world' } });
+    model.bindingCalled({ data: { name: BINDING_NAME, payload } });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith({ hello: 'world' });
+  });
+
+  it('dispatches a rozenite message regardless of key order in the payload', () => {
+    const model = createModel();
+    const listener = vi.fn();
+    model.subscribeToDomainMessages(listener);
+
+    // The fast path must not assume `domain` comes before `message` (or anywhere in
+    // particular) -- it only checks for the substring anywhere in the raw string.
+    const payload = JSON.stringify({ message: { hello: 'world' }, domain: 'rozenite' });
+    model.bindingCalled({ data: { name: BINDING_NAME, payload } });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith({ hello: 'world' });
+  });
+
+  it('skips a large non-rozenite payload without parsing it', () => {
+    const parseSpy = vi.spyOn(JSON, 'parse');
+    const model = createModel();
+    const listener = vi.fn();
+    model.subscribeToDomainMessages(listener);
+
+    // Simulate a React DevTools bridge payload (e.g. a component subtree) that never
+    // mentions our domain name. The size here is illustrative of real-world React
+    // DevTools traffic; the assertion (JSON.parse not called) is size-independent.
+    const componentTree = Array.from({ length: 50 }, (_, i) => ({
+      id: i,
+      type: 'FunctionComponent',
+      displayName: `Component${i}`,
+    }));
+    const payload = JSON.stringify({ domain: 'react-devtools', message: componentTree });
+
+    model.bindingCalled({ data: { name: BINDING_NAME, payload } });
+
+    expect(parseSpy).not.toHaveBeenCalled();
+    expect(listener).not.toHaveBeenCalled();
+
+    parseSpy.mockRestore();
+  });
+
+  it('still correctly rejects a non-rozenite payload that happens to contain the substring "rozenite"', () => {
+    const model = createModel();
+    const listener = vi.fn();
+    model.subscribeToDomainMessages(listener);
+
+    // The substring appears in the message body, not the domain field, so the cheap
+    // pre-check cannot rule this out -- it must fall through to the real parse and
+    // domain comparison, which correctly rejects it.
+    const payload = JSON.stringify({
+      domain: 'react-devtools',
+      message: { note: 'unrelated mention of rozenite in the payload' },
+    });
+
+    expect(() => model.bindingCalled({ data: { name: BINDING_NAME, payload } })).not.toThrow();
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('throws when a rozenite-looking payload is malformed JSON', () => {
+    const model = createModel();
+
+    const payload = '{"domain": "rozenite", "message": invalid}';
+
+    expect(() => model.bindingCalled({ data: { name: BINDING_NAME, payload } })).toThrow(
+      'Failed to parse bindingCalled event payload',
+    );
+  });
+});

--- a/packages/runtime/src/rn-devtools/bindings-model.ts
+++ b/packages/runtime/src/rn-devtools/bindings-model.ts
@@ -48,6 +48,32 @@ export class RozeniteBindingsModel extends SDK.SDKModel.SDKModel {
     }
 
     const serializedMessage = event.data.payload;
+
+    // Rozenite piggybacks React Native's Fusebox dispatcher and shares the single
+    // `__CHROME_DEVTOOLS_FRONTEND_BINDING__` binding with React Native's own React
+    // DevTools integration. Because the binding name is shared, the `name` check above
+    // does not filter out React DevTools traffic, so this handler also receives every
+    // React DevTools bridge message (which can carry full component trees and be very
+    // large). Those messages are for the `react-devtools` domain, not ours, and would
+    // otherwise be JSON.parse'd here only to be discarded a few lines down once we see
+    // `parsedMessage.domain !== DOMAIN_NAME`.
+    //
+    // As a cheap pre-parse fast path, bail out without parsing if the raw string cannot
+    // possibly contain our domain marker. This is intentionally a conservative substring
+    // search, not a prefix/structure check: it must never rely on where `"rozenite"`
+    // appears in the payload (e.g. key ordering of `{domain, message}`), only on whether
+    // it appears at all. A message that happens to contain the substring elsewhere still
+    // falls through to the real parse + domain check below, which is authoritative -- so
+    // a false positive here is harmless. A false negative would require the payload to be
+    // serialized with the domain's ASCII letters escaped as JSON unicode escape sequences
+    // (i.e. spelling the domain name out as a run of `\uXXXX` codepoint escapes instead of
+    // the plain letters), which `JSON.stringify` -- used on the React Native side to build
+    // this payload -- never does. So in practice a message with domain "rozenite" always
+    // contains that literal substring in the raw payload.
+    if (!serializedMessage.includes(DOMAIN_NAME)) {
+      return;
+    }
+
     let parsedMessage = null;
 
     try {


### PR DESCRIPTION
## Description

`RozeniteBindingsModel.bindingCalled` now skips `JSON.parse` for binding messages that cannot possibly be for the `rozenite` domain, instead of parsing every message and discarding it a few lines later.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
No open issue was linked for this change.

## Context

Rozenite piggybacks React Native's Fusebox dispatcher, sharing the single `__CHROME_DEVTOOLS_FRONTEND_BINDING__` binding with React Native's own built-in React DevTools integration. Because the binding name is shared, the existing `name` check in `bindingCalled` does not filter out React DevTools traffic — every `Runtime.bindingCalled` event (including large React DevTools bridge messages carrying full component trees) was `JSON.parse`d and only then discarded once `parsedMessage.domain !== 'rozenite'` was found to be true.

The fix adds a cheap pre-parse fast path: if the raw payload string doesn't contain the substring `rozenite` anywhere, return early without parsing. This is deliberately a conservative substring search rather than a prefix or structural check (e.g. `startsWith` or key-position assumptions) — it must never assume anything about how upstream constructs the `{domain, message}` object, since that's outside Rozenite's control. A payload that happens to contain the substring `rozenite` elsewhere (a false positive for the fast path) still falls through to the existing parse-and-compare logic, which is unchanged and remains authoritative. The comment in `bindings-model.ts` spells out why a false negative can't happen in practice (`JSON.stringify`, which React Native uses to build this payload, never emits unicode-escaped ASCII letters).

`packages/middleware/src/agent/runtime/bindings.ts` (`parseRozeniteBindingPayload`) was intentionally left untouched: the Node agent side legitimately needs to parse both the `rozenite` and `react-devtools` domains (see `packages/middleware/src/agent/session.ts` around the `captureReactDevToolsMessage` branch), so it can't take the same shortcut.

## Testing

Automated:

- `pnpm --filter @rozenite/runtime test` — 5 tests passed (rozenite message dispatches; dispatch is independent of key order; a large non-rozenite payload is skipped without ever calling `JSON.parse`; a non-rozenite payload containing the substring `rozenite` still falls through and is correctly rejected by the domain check; malformed JSON for a rozenite-looking payload still throws)
- `pnpm --filter @rozenite/runtime typecheck`
- `pnpm --filter @rozenite/runtime lint`
- `pnpm --filter @rozenite/runtime build`
- `npx oxfmt --check` on the changed files
- `pnpm release:plan` — confirms the changeset is picked up

This change was also sent through an independent adversarial code review pass; findings (comment accuracy around JSON escaping, a missing key-order-independence test, and test-quality nits) were applied before opening this PR.