### PR TITLE
fix(runtime,middleware): stop dropping host-to-device messages with astral-plane characters

### DIFF
--- a/.changeset/fix-host-to-device-message-encoding.md
+++ b/.changeset/fix-host-to-device-message-encoding.md
@@ -1,0 +1,15 @@
+---
+'@rozenite/runtime': patch
+'@rozenite/middleware': patch
+---
+
+Fix host-to-device messages being silently dropped when their payload
+contained a character outside the Basic Multilingual Plane (for example an
+emoji). Messages were sent by interpolating a JSON string into a JS source
+string that the device's JS engine had to recompile, which cannot represent
+such characters and failed the recompilation without surfacing an error —
+losing the message. Sends now go through `Runtime.callFunctionOn` with the
+payload passed as a value argument instead, and a failed send is now reported
+instead of being silently swallowed. Sends also no longer wait for the device
+to acknowledge the round trip, since delivery order is already guaranteed by
+the underlying protocol.

--- a/packages/middleware/src/__tests__/agent-session.test.ts
+++ b/packages/middleware/src/__tests__/agent-session.test.ts
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => {
   const loggerInfo = vi.fn();
   const loggerWarn = vi.fn();
   const loggerDebug = vi.fn();
+  const loggerError = vi.fn();
   const handler = {
     connectDevice: vi.fn(),
     disconnectDevice: vi.fn(),
@@ -38,6 +39,10 @@ const mocks = vi.hoisted(() => {
   const wsInstances: MockWebSocket[] = [];
   let bindingName = 'rozenite-binding';
   let stalledRuntimeExpression: string | null = null;
+  let stalledCallFunctionOn = false;
+  let forcedCallFunctionOnExceptionText: string | null = null;
+  let forcedCallFunctionOnProtocolError: string | null = null;
+  let forcedCallFunctionOnMessageError: string | null = null;
 
   class MockWebSocket {
     static readonly CONNECTING = 0;
@@ -95,6 +100,12 @@ const mocks = vi.hoisted(() => {
         method: payload.method,
         params: payload.params,
       });
+
+      if (payload.method === 'Runtime.callFunctionOn' && forcedCallFunctionOnProtocolError) {
+        callback?.(new Error(forcedCallFunctionOnProtocolError));
+        return;
+      }
+
       callback?.();
 
       if (
@@ -105,7 +116,25 @@ const mocks = vi.hoisted(() => {
         return;
       }
 
+      if (payload.method === 'Runtime.callFunctionOn' && stalledCallFunctionOn) {
+        return;
+      }
+
       queueMicrotask(() => {
+        if (payload.method === 'Runtime.callFunctionOn' && forcedCallFunctionOnMessageError) {
+          // A genuine CDP protocol-level error response
+          // (`{"id": ..., "error": {...}}`), as opposed to a socket-write failure
+          // or a successful response carrying `exceptionDetails`.
+          this.emit(
+            'message',
+            JSON.stringify({
+              id: payload.id,
+              error: { message: forcedCallFunctionOnMessageError, code: -32000 },
+            }),
+          );
+          return;
+        }
+
         this.emit(
           'message',
           JSON.stringify({
@@ -128,6 +157,13 @@ const mocks = vi.hoisted(() => {
   }
 
   const getCommandResult = (method: string, params?: Record<string, unknown>) => {
+    if (method === 'Runtime.callFunctionOn' && forcedCallFunctionOnExceptionText) {
+      return {
+        result: {},
+        exceptionDetails: { text: forcedCallFunctionOnExceptionText },
+      };
+    }
+
     if (method !== 'Runtime.evaluate') {
       return {};
     }
@@ -158,6 +194,7 @@ const mocks = vi.hoisted(() => {
     loggerInfo,
     loggerWarn,
     loggerDebug,
+    loggerError,
     MockWebSocket,
     handler,
     createAgentMessageHandler: vi.fn(() => handler),
@@ -174,11 +211,28 @@ const mocks = vi.hoisted(() => {
     stallRuntimeEvaluationContaining: (expression: string) => {
       stalledRuntimeExpression = expression;
     },
+    stallCallFunctionOn: () => {
+      stalledCallFunctionOn = true;
+    },
+    forceCallFunctionOnException: (text: string | null) => {
+      forcedCallFunctionOnExceptionText = text;
+    },
+    forceCallFunctionOnProtocolError: (message: string | null) => {
+      forcedCallFunctionOnProtocolError = message;
+    },
+    forceCallFunctionOnMessageError: (message: string | null) => {
+      forcedCallFunctionOnMessageError = message;
+    },
     reset: () => {
       commandLog.length = 0;
       loggerInfo.mockReset();
       loggerWarn.mockReset();
       loggerDebug.mockReset();
+      loggerError.mockReset();
+      stalledCallFunctionOn = false;
+      forcedCallFunctionOnExceptionText = null;
+      forcedCallFunctionOnProtocolError = null;
+      forcedCallFunctionOnMessageError = null;
       handler.connectDevice.mockReset();
       handler.disconnectDevice.mockReset();
       handler.handleDeviceMessage.mockReset();
@@ -232,6 +286,7 @@ vi.mock('../logger.js', () => ({
     info: mocks.loggerInfo,
     warn: mocks.loggerWarn,
     debug: mocks.loggerDebug,
+    error: mocks.loggerError,
   },
 }));
 
@@ -493,6 +548,238 @@ describe('agent session', () => {
     );
 
     expect(readyExpressions).toHaveLength(2);
+  });
+
+  it('sends domain messages via Runtime.callFunctionOn with a single-stringified by-value argument once a main execution context id is known', async () => {
+    const { socket } = await bootstrapSession();
+
+    // Re-capture the main execution context id, as would happen on reload.
+    socket.emit(
+      'message',
+      JSON.stringify({
+        method: 'Runtime.executionContextCreated',
+        params: { context: { name: 'main', id: 42 } },
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(500);
+    await flushMicrotasks();
+
+    const callFunctionOnCommands = mocks.commandLog.filter(
+      (command) => command.method === 'Runtime.callFunctionOn',
+    );
+    const readyCommand = callFunctionOnCommands.find((command) => {
+      const args = command.params?.arguments as Array<{ value: unknown }> | undefined;
+      return typeof args?.[0]?.value === 'string' && args[0].value.includes('agent-session-ready');
+    });
+
+    expect(readyCommand).toBeDefined();
+    expect(readyCommand?.params?.executionContextId).toBe(42);
+    expect(readyCommand?.params?.functionDeclaration).toContain('sendMessage("rozenite", m)');
+
+    // The by-value argument must be the JSON string of the message -- a single
+    // stringify, not the "stringify the stringified string" that `Runtime.evaluate`
+    // needed to embed the payload into JS source text.
+    const argValue = (readyCommand?.params?.arguments as Array<{ value: unknown }>)[0].value;
+    expect(typeof argValue).toBe('string');
+    const parsed = JSON.parse(argValue as string);
+    expect(typeof parsed).toBe('object');
+    expect(parsed).toMatchObject({ type: 'agent-session-ready' });
+
+    // No more Runtime.evaluate-based sends for this domain once the context id
+    // is known -- the legacy double-stringify path is no longer used.
+    const readyExpressions = getExpressions().filter(
+      (expression) =>
+        expression.includes('sendMessage("rozenite"') && expression.includes('agent-session-ready'),
+    );
+    expect(readyExpressions).toHaveLength(1); // only the first send, before the id was known
+  });
+
+  it('reports a failed send instead of swallowing it, both for a runtime exception and a rejected command', async () => {
+    const { socket } = await bootstrapSession();
+
+    socket.emit(
+      'message',
+      JSON.stringify({
+        method: 'Runtime.executionContextCreated',
+        params: { context: { name: 'main', id: 7 } },
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(500);
+    await flushMicrotasks();
+    mocks.loggerError.mockClear();
+
+    // Case 1: the command succeeds at the protocol level but the evaluated
+    // function throws (surfaced as `exceptionDetails`, exactly what `sendMessage`
+    // silently ignored before this fix).
+    mocks.forceCallFunctionOnException('stale execution context');
+
+    socket.emit(
+      'message',
+      JSON.stringify({
+        method: 'Runtime.executionContextCreated',
+        params: { context: { name: 'main', id: 7 } },
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(500);
+    await flushMicrotasks();
+
+    expect(mocks.loggerError).toHaveBeenCalledWith(
+      expect.stringContaining('stale execution context'),
+    );
+
+    // Case 2: the underlying socket write itself fails outright (distinct from
+    // case 3 below: this is `ws.send`'s own callback reporting an error, before
+    // any CDP response is ever received).
+    mocks.loggerError.mockClear();
+    mocks.forceCallFunctionOnException(null); // clear case-1 forcing via exceptionDetails
+    mocks.forceCallFunctionOnProtocolError('Cannot find context with specified id');
+
+    socket.emit(
+      'message',
+      JSON.stringify({
+        method: 'Runtime.executionContextCreated',
+        params: { context: { name: 'main', id: 7 } },
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(500);
+    await flushMicrotasks();
+
+    expect(mocks.loggerError).toHaveBeenCalledWith(
+      expect.stringContaining('Cannot find context with specified id'),
+    );
+
+    // Case 3: the device replies with a genuine CDP protocol-level error
+    // (`{"id": ..., "error": {...}}`) -- e.g. a stale execution context id the
+    // device no longer recognizes after a reload. This is the path
+    // `handleSocketMessage`'s `message.error` branch handles, distinct from both
+    // cases above.
+    mocks.loggerError.mockClear();
+    mocks.forceCallFunctionOnProtocolError(null);
+    mocks.forceCallFunctionOnMessageError('Cannot find context with specified id');
+
+    socket.emit(
+      'message',
+      JSON.stringify({
+        method: 'Runtime.executionContextCreated',
+        params: { context: { name: 'main', id: 7 } },
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(500);
+    await flushMicrotasks();
+
+    expect(mocks.loggerError).toHaveBeenCalledWith(
+      expect.stringContaining('Cannot find context with specified id'),
+    );
+  });
+
+  it('retries bootstrap when the agent-session-ready send fails', async () => {
+    // `sendDomainMessage` no longer blocks the caller on the CDP round trip, but
+    // `sendAgentSessionReady` still `await`s it -- a failed send must still
+    // propagate so `bootstrap()`'s own retry logic (its `catch` calling
+    // `scheduleBootstrap()`) keeps working, exactly as it did when this call was
+    // fully awaited.
+    const { socket } = await bootstrapSession();
+
+    socket.emit(
+      'message',
+      JSON.stringify({
+        method: 'Runtime.executionContextCreated',
+        params: { context: { name: 'main', id: 7 } },
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(500);
+    await flushMicrotasks();
+
+    const readySendsBefore = mocks.commandLog.filter(
+      (command) =>
+        command.method === 'Runtime.callFunctionOn' &&
+        JSON.stringify(
+          (command.params?.arguments as Array<{ value: unknown }> | undefined)?.[0]?.value,
+        ).includes('agent-session-ready'),
+    ).length;
+
+    mocks.forceCallFunctionOnMessageError('Cannot find context with specified id');
+    socket.emit(
+      'message',
+      JSON.stringify({
+        method: 'Runtime.executionContextCreated',
+        params: { context: { name: 'main', id: 7 } },
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(500);
+    await flushMicrotasks();
+
+    // Stop forcing the failure and let the retried bootstrap succeed.
+    mocks.forceCallFunctionOnMessageError(null);
+    await vi.advanceTimersByTimeAsync(500);
+    await flushMicrotasks();
+
+    const readySendsAfter = mocks.commandLog.filter(
+      (command) =>
+        command.method === 'Runtime.callFunctionOn' &&
+        JSON.stringify(
+          (command.params?.arguments as Array<{ value: unknown }> | undefined)?.[0]?.value,
+        ).includes('agent-session-ready'),
+    ).length;
+
+    // More than one additional attempt: the failed send (which did not itself
+    // reach the device) plus at least one retry that succeeded.
+    expect(readySendsAfter).toBeGreaterThan(readySendsBefore + 1);
+  });
+
+  it('times out a pending CDP command instead of hanging forever', async () => {
+    const { socket } = await bootstrapSession();
+    mocks.stallCallFunctionOn();
+
+    socket.emit(
+      'message',
+      JSON.stringify({
+        method: 'Runtime.executionContextCreated',
+        params: { context: { name: 'main', id: 7 } },
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(500);
+    await flushMicrotasks();
+
+    const callFunctionOnCommand = mocks.commandLog.find(
+      (command) => command.method === 'Runtime.callFunctionOn',
+    );
+    expect(callFunctionOnCommand).toBeDefined();
+    mocks.loggerError.mockClear();
+
+    // The command was sent but the device never responds -- without the pending
+    // command timeout this would hang forever.
+    await vi.advanceTimersByTimeAsync(10_000);
+    await flushMicrotasks();
+
+    expect(mocks.loggerError).toHaveBeenCalledWith(expect.stringContaining('timed out'));
+  });
+
+  it('does not time out CDP commands outside the message-send path', async () => {
+    // The pending-command timeout exists specifically to bound the message-send
+    // path (see the previous test) -- it must not apply to `sendCommand` in
+    // general, or legitimately long-running commands (e.g.
+    // `HeapProfiler.takeHeapSnapshot`, large `Network.getResponseBody` calls)
+    // issued by the local domain services would be cut off after 10s.
+    const { socket } = await bootstrapSession();
+
+    // Stall an ordinary (non-message-send) `Runtime.evaluate` call -- the
+    // dispatcher-liveness check bootstrap issues on every rerun -- standing in
+    // for a slow, unrelated CDP command that must be allowed to run past the
+    // send-path's timeout window without being rejected.
+    mocks.stallRuntimeEvaluationContaining(`globalThis.${RUNTIME_GLOBAL}`);
+    mocks.loggerError.mockClear();
+
+    socket.emit('message', JSON.stringify({ method: 'Runtime.executionContextsCleared' }));
+    await vi.advanceTimersByTimeAsync(500);
+    await flushMicrotasks();
+
+    // Advance well past COMMAND_TIMEOUT_MS (10s): a scoped timeout would have
+    // fired and rejected this pending command by now.
+    await vi.advanceTimersByTimeAsync(15_000);
+    await flushMicrotasks();
+
+    expect(mocks.loggerError).not.toHaveBeenCalledWith(expect.stringContaining('timed out'));
   });
 
   it('heals a relaunched app with the same device id and a new page id', async () => {

--- a/packages/middleware/src/__tests__/sanitize-unpaired-surrogates.test.ts
+++ b/packages/middleware/src/__tests__/sanitize-unpaired-surrogates.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeUnpairedSurrogates } from '../agent/session.js';
+
+// `sanitizeUnpairedSurrogates` operates on the *output* of `JSON.stringify`, not
+// on a raw JS string. Modern (ES2019+ "well-formed") `JSON.stringify` never emits
+// a lone surrogate as a raw UTF-16 code unit -- it always escapes it to a literal
+// six-character `\uXXXX` sequence. So the function has to look for that escape
+// sequence text, not for raw surrogate code units (which, for a lone surrogate,
+// will never appear post-stringify). These tests build inputs the way the real
+// call sites do: `JSON.stringify(...)` first, then sanitize the result.
+
+describe('sanitizeUnpairedSurrogates', () => {
+  it('leaves ordinary ASCII/BMP text untouched', () => {
+    const input = JSON.stringify('He said "hi"\nnewline\ttab \\backslash');
+    expect(sanitizeUnpairedSurrogates(input)).toBe(input);
+  });
+
+  it('preserves valid surrogate pairs (e.g. emoji), which JSON.stringify never escapes', () => {
+    const input = JSON.stringify('party 🎉 time 👋🏽 done');
+    // Emoji survive JSON.stringify as raw UTF-16 code units, not `\u` escapes --
+    // confirm the fixture actually exercises that (otherwise this test would
+    // pass trivially even if the sanitizer corrupted emoji).
+    expect(input).not.toMatch(/\\u[dD][89a-fA-F]/);
+    expect(sanitizeUnpairedSurrogates(input)).toBe(input);
+  });
+
+  it('does not mangle U+2028 or U+2029 (JSON.stringify does not escape them either)', () => {
+    const input = JSON.stringify('line  separator and paragraph  separator');
+    expect(sanitizeUnpairedSurrogates(input)).toBe(input);
+  });
+
+  it('replaces an unpaired high-surrogate escape sequence produced by JSON.stringify', () => {
+    const input = JSON.stringify('broken \uD800 surrogate');
+    expect(input).toContain('\\ud800');
+    const result = sanitizeUnpairedSurrogates(input);
+    expect(result).not.toContain('\\ud800');
+    expect(result).toBe(JSON.stringify('broken � surrogate'));
+  });
+
+  it('replaces an unpaired low-surrogate escape sequence produced by JSON.stringify', () => {
+    const input = JSON.stringify('broken \uDC00 surrogate');
+    expect(input).toContain('\\udc00');
+    const result = sanitizeUnpairedSurrogates(input);
+    expect(result).not.toContain('\\udc00');
+    expect(result).toBe(JSON.stringify('broken � surrogate'));
+  });
+
+  it('replaces two consecutive unpaired high-surrogate escape sequences independently', () => {
+    const input = JSON.stringify('\uD800\uD800');
+    const result = sanitizeUnpairedSurrogates(input);
+    expect(result).toBe(JSON.stringify('��'));
+  });
+
+  it('replaces an unpaired high-surrogate escape sequence at the end of the string', () => {
+    const input = JSON.stringify('trailing \uD800');
+    const result = sanitizeUnpairedSurrogates(input);
+    expect(result).toBe(JSON.stringify('trailing �'));
+  });
+
+  it('leaves a valid surrogate pair escape sequence untouched (should one ever appear)', () => {
+    // JSON.stringify does not normally escape a *paired* surrogate -- it only
+    // escapes an unpaired half -- but the sanitizer must not corrupt a valid pair
+    // if it ever encounters one already in escape-sequence form.
+    const input = '"before \\ud83c\\udf89 after"';
+    expect(sanitizeUnpairedSurrogates(input)).toBe(input);
+  });
+
+  it('reproduces the real device failure and confirms the fix: makes JSON.stringify output safe for a strict receiver', () => {
+    // Empirically, a downstream JSON parser (the CDP relay / device) rejects an
+    // unpaired `\uXXXX` surrogate escape even though it is syntactically valid
+    // JSON text -- reproduced against a real device during development of this
+    // fix ("json parse error ... expected another unicode escape for second half
+    // of surrogate pair"). After sanitizing, no such escape sequence remains.
+    const message = { pluginId: 'p', payload: { value: 'before-\uD800-after' } };
+    const serialized = JSON.stringify(message);
+    expect(serialized).toMatch(/\\u[dD]8/);
+
+    const sanitized = sanitizeUnpairedSurrogates(serialized);
+    expect(sanitized).not.toMatch(/\\u[dD][89a-fA-F][0-9a-fA-F]{2}\\u[dD][c-fC-F]/);
+    expect(sanitized).not.toContain('\\ud800');
+    expect(() => JSON.parse(sanitized)).not.toThrow();
+    expect(JSON.parse(sanitized).payload.value).toBe('before-�-after');
+  });
+
+  it('preserves a message containing both a valid emoji and an unpaired surrogate, mangling only the latter', () => {
+    const input = JSON.stringify('ok 🎉 but also \uD800 broken');
+    const result = sanitizeUnpairedSurrogates(input);
+    expect(result).toBe(JSON.stringify('ok 🎉 but also � broken'));
+  });
+
+  it('is a no-op (returns the identical reference-equal-in-value input) when there is nothing to sanitize', () => {
+    const input = JSON.stringify({ ok: true, emoji: '🎉' });
+    expect(sanitizeUnpairedSurrogates(input)).toBe(input);
+  });
+});

--- a/packages/middleware/src/agent/session.ts
+++ b/packages/middleware/src/agent/session.ts
@@ -31,6 +31,11 @@ const PLUGIN_READINESS_QUIET_WINDOW_MS = 50;
 const PLUGIN_READINESS_MAX_WAIT_MS = 250;
 const RECOVERY_RETRY_DELAY_MS = 500;
 const RECOVERY_MAX_ATTEMPTS = 16;
+// A malformed outgoing frame (e.g. one containing an unpaired UTF-16 surrogate,
+// see `sanitizeUnpairedSurrogates`) can come back from the device with `"id": null`,
+// which cannot be correlated to the pending command that caused it. Without a
+// timeout, that command's entry in `pendingCommands` would never resolve.
+const COMMAND_TIMEOUT_MS = 10_000;
 
 const RECOVERABLE_CLOSE_REASONS = new Set([
   '[RECREATING_DEVICE]',
@@ -49,9 +54,51 @@ const getDebuggerWebSocketOrigin = (webSocketDebuggerUrl: string): string => {
   return `${protocol}//${url.host}`;
 };
 
+// Matches a `\uXXXX` escape sequence for either half of a surrogate pair
+// (D800-DFFF), capturing a *pair* of such escapes (high immediately followed
+// by low) before falling back to matching a single one.
+const SURROGATE_ESCAPE_SEQUENCE =
+  /\\u[dD][89a-fA-F][0-9a-fA-F]{2}\\u[dD][c-fC-F][0-9a-fA-F]{2}|\\u[dD][89a-fA-F][0-9a-fA-F]{2}/g;
+
+// Replaces an unpaired UTF-16 surrogate half with U+FFFD.
+//
+// Verified against a real device: modern `JSON.stringify` (ES2019+
+// "well-formed" `JSON.stringify`) never emits a lone surrogate as a raw code
+// unit -- it always escapes it to a literal six-character `\uXXXX` sequence,
+// so a real lone surrogate in `message` is already gone as a raw code unit by
+// the time `JSON.stringify(message)` returns. The device's own JSON parser is
+// stricter than the JSON grammar and rejects that escape sequence outright
+// (`"json parse error ... expected another unicode escape for second half of
+// surrogate pair"`), which comes back as an error response with `"id": null"`
+// -- uncorrelatable to the request that caused it. This function operates on
+// the *already-stringified* text, replacing an unpaired `\uXXXX` escape
+// sequence (not a raw code unit -- there won't be one).
+//
+// A raw surrogate *pair* (e.g. ordinary emoji) is not affected by any of
+// this: `JSON.stringify` does not escape it at all, so it survives as two
+// ordinary UTF-16 code units in the string and this function never matches
+// it. U+2028/U+2029 are likewise untouched (not surrogates, and
+// `JSON.stringify` does not escape them either).
+export const sanitizeUnpairedSurrogates = (jsonText: string): string => {
+  let mutated = false;
+
+  const sanitized = jsonText.replace(SURROGATE_ESCAPE_SEQUENCE, (match) => {
+    if (match.length === 12) {
+      // A high escape immediately followed by a low escape -- a valid pair.
+      return match;
+    }
+
+    mutated = true;
+    return '\uFFFD';
+  });
+
+  return mutated ? sanitized : jsonText;
+};
+
 type PendingCommand = {
   resolve: (value: Record<string, unknown>) => void;
   reject: (error: Error) => void;
+  timeout: NodeJS.Timeout | null;
 };
 
 type StartReadiness = {
@@ -115,6 +162,7 @@ export const createAgentSession = (options: {
   let nextCommandId = 1;
   let bootstrapTimer: NodeJS.Timeout | null = null;
   let bindingName: string | null = null;
+  let mainExecutionContextId: number | null = null;
   let bootstrapped = false;
   let terminationNotified = false;
   let disconnectLogged = false;
@@ -295,6 +343,7 @@ export const createAgentSession = (options: {
   const sendCommand = (
     method: string,
     params?: Record<string, unknown>,
+    options?: { timeoutMs?: number },
   ): Promise<Record<string, unknown>> => {
     if (!ws || ws.readyState !== WebSocket.OPEN) {
       return markPromiseAsHandled(Promise.reject(new Error('CDP websocket is not connected')));
@@ -305,13 +354,36 @@ export const createAgentSession = (options: {
     touch();
 
     const promise = new Promise<Record<string, unknown>>((resolve, reject) => {
-      pendingCommands.set(commandId, { resolve, reject });
+      // A malformed outgoing frame can come back as an error keyed by `"id":
+      // null` (see `sanitizeUnpairedSurrogates`), which `handleSocketMessage`
+      // cannot match back to this command. Without a timeout, such a command
+      // would stay pending forever. This is opt-in (via `options.timeoutMs`)
+      // rather than applied to every command: some CDP commands (e.g.
+      // `HeapProfiler.takeHeapSnapshot`, `Network.getResponseBody` for large
+      // bodies) are legitimately long-running and must not be cut off.
+      let timeout: NodeJS.Timeout | null = null;
+      if (options?.timeoutMs !== undefined) {
+        timeout = setTimeout(() => {
+          if (pendingCommands.delete(commandId)) {
+            reject(new Error(`CDP command "${method}" timed out after ${options.timeoutMs}ms`));
+          }
+        }, options.timeoutMs);
+        timeout.unref?.();
+      }
+
+      pendingCommands.set(commandId, { resolve, reject, timeout });
       ws!.send(payload, (error) => {
         if (!error) {
           return;
         }
 
-        pendingCommands.delete(commandId);
+        const pending = pendingCommands.get(commandId);
+        if (pending) {
+          if (pending.timeout) {
+            clearTimeout(pending.timeout);
+          }
+          pendingCommands.delete(commandId);
+        }
         reject(error);
       });
     });
@@ -365,12 +437,82 @@ export const createAgentSession = (options: {
   };
 
   const sendDomainMessage = (domain: string, message: unknown): Promise<void> => {
-    const serializedMessage = JSON.stringify(message);
-    const escapedMessage = JSON.stringify(serializedMessage);
+    // `Runtime.evaluate` requires interpolating the payload into a JS source string
+    // that Hermes has to recompile. A single stringify + string-literal interpolation
+    // is not reversible for arbitrary strings -- it silently drops messages
+    // containing astral-plane characters, since Hermes' source parser can't accept a
+    // lone UTF-16 surrogate half in source text. `Runtime.callFunctionOn` with a
+    // by-value argument instead ships the string through CDP's own (correct) value
+    // serialization, so it round-trips byte-for-byte.
+    const serializedMessage = sanitizeUnpairedSurrogates(JSON.stringify(message));
+
+    // Scoped to this send path, not every CDP command (see `sendCommand`'s own
+    // comment): a malformed frame can come back uncorrelatably as `"id": null"`,
+    // which only this path is at risk of after `sanitizeUnpairedSurrogates`.
+    const commandPromise =
+      mainExecutionContextId !== null
+        ? sendCommand(
+            'Runtime.callFunctionOn',
+            {
+              executionContextId: mainExecutionContextId,
+              functionDeclaration: `function(m) { ${RUNTIME_GLOBAL}.sendMessage(${JSON.stringify(
+                domain,
+              )}, m) }`,
+              arguments: [{ value: serializedMessage }],
+            },
+            { timeoutMs: COMMAND_TIMEOUT_MS },
+          )
+        : // No main execution context captured yet (e.g. sent before the first
+          // `Runtime.executionContextCreated` event arrived). Fall back to the
+          // legacy path rather than dropping the message outright; this is a rare
+          // startup race, not the steady-state path.
+          sendCommand(
+            'Runtime.evaluate',
+            {
+              expression: `${RUNTIME_GLOBAL}.sendMessage(${JSON.stringify(domain)}, ${JSON.stringify(
+                serializedMessage,
+              )})`,
+            },
+            { timeoutMs: COMMAND_TIMEOUT_MS },
+          );
+
+    // We deliberately do not block the *caller* on the round trip -- CDP requests
+    // are ordered and execute in order on the device's JS thread, so message
+    // ordering is preserved regardless of whether anyone awaits this promise.
+    // Fire-and-forget call sites (`void sendDomainMessage(...)`) therefore pay no
+    // latency cost. But this function still returns the real promise chain (rather
+    // than an already-resolved one) so that the one call site that legitimately
+    // needs to know about failure -- `sendAgentSessionReady`, awaited from
+    // `bootstrap()` so a failed send retries the whole bootstrap sequence -- keeps
+    // working. `markPromiseAsHandled` prevents that same rejection from surfacing
+    // as an unhandled rejection for the `void`-calling sites.
+    const reported = commandPromise.then((response) => {
+      const exceptionText = (response as CDPEvaluateResponse).exceptionDetails?.text;
+      if (exceptionText) {
+        // Logged uniformly with the protocol-rejection case below, rather than
+        // here, so there is exactly one log line per failed send.
+        throw new Error(exceptionText);
+      }
+    });
+
     return markPromiseAsHandled(
-      sendCommand('Runtime.evaluate', {
-        expression: `${RUNTIME_GLOBAL}.sendMessage(${JSON.stringify(domain)}, ${escapedMessage})`,
-      }).then(() => undefined),
+      reported.catch((error: unknown) => {
+        const message = error instanceof Error ? error.message : String(error);
+        // A send racing an intentional teardown (reload, recovery, session stop)
+        // is expected operational churn, not an actionable failure -- downgrade it
+        // so it doesn't read as a real fault. Everything else (a stale execution
+        // context, a malformed-frame timeout, an actual runtime exception surfaced
+        // above) is logged at error level.
+        if (
+          message.includes('CDP connection closed') ||
+          message.includes('CDP websocket is not connected')
+        ) {
+          logger.warn(`Failed to send message to domain "${domain}": ${message}`);
+        } else {
+          logger.error(`Failed to send message to domain "${domain}": ${message}`);
+        }
+        throw error;
+      }),
     );
   };
 
@@ -558,6 +700,7 @@ export const createAgentSession = (options: {
 
   const teardownConnection = (): void => {
     bindingName = null;
+    mainExecutionContextId = null;
     bootstrapped = false;
     connectedAt = undefined;
     rejectStartReadiness(new Error('CDP connection closed before bootstrap completed'));
@@ -567,6 +710,9 @@ export const createAgentSession = (options: {
     }
     for (const [commandId, pending] of pendingCommands.entries()) {
       pendingCommands.delete(commandId);
+      if (pending.timeout) {
+        clearTimeout(pending.timeout);
+      }
       pending.reject(new Error('CDP connection closed'));
     }
     clearBootstrapTimer();
@@ -658,6 +804,7 @@ export const createAgentSession = (options: {
     }
     logDisconnected();
     bindingName = null;
+    mainExecutionContextId = null;
     bootstrapped = false;
     connectedAt = undefined;
     rejectStartReadiness(new Error('CDP connection closed before bootstrap completed'));
@@ -673,6 +820,9 @@ export const createAgentSession = (options: {
 
     for (const [commandId, pending] of pendingCommands.entries()) {
       pendingCommands.delete(commandId);
+      if (pending.timeout) {
+        clearTimeout(pending.timeout);
+      }
       pending.reject(new Error('CDP connection closed'));
     }
 
@@ -728,6 +878,9 @@ export const createAgentSession = (options: {
       }
 
       pendingCommands.delete(message.id);
+      if (pending.timeout) {
+        clearTimeout(pending.timeout);
+      }
       if (message.error) {
         pending.reject(new Error(JSON.stringify(message.error)));
         return;
@@ -745,16 +898,28 @@ export const createAgentSession = (options: {
       emitCDPEvent(message.method, (message.params as Record<string, unknown> | undefined) || {});
     }
 
-    if (
-      message.method === 'Runtime.executionContextCreated' &&
-      (message.params as { context?: { name?: string } } | undefined)?.context?.name ===
-        MAIN_EXECUTION_CONTEXT_NAME
-    ) {
-      bootstrapped = false;
-      scheduleBootstrap();
+    if (message.method === 'Runtime.executionContextCreated') {
+      const context = (message.params as { context?: { name?: string; id?: number } } | undefined)
+        ?.context;
+      if (context?.name === MAIN_EXECUTION_CONTEXT_NAME) {
+        if (typeof context.id === 'number') {
+          mainExecutionContextId = context.id;
+        }
+        bootstrapped = false;
+        scheduleBootstrap();
+      }
+    }
+
+    if (message.method === 'Runtime.executionContextDestroyed') {
+      const destroyedId = (message.params as { executionContextId?: number } | undefined)
+        ?.executionContextId;
+      if (destroyedId !== undefined && destroyedId === mainExecutionContextId) {
+        mainExecutionContextId = null;
+      }
     }
 
     if (message.method === 'Runtime.executionContextsCleared') {
+      mainExecutionContextId = null;
       bootstrapped = false;
       scheduleBootstrap();
     }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -37,12 +37,15 @@
   "scripts": {
     "build": "vite build",
     "typecheck": "tsc -p tsconfig.lib.json --noEmit",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "vitest --run --passWithNoTests"
   },
   "dependencies": {
     "tslib": "^2.3.0"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "vitest": "^4.0.18"
+  },
   "engines": {
     "node": ">=20"
   }

--- a/packages/runtime/src/rn-devtools/__tests__/bindings-model-send-message.test.ts
+++ b/packages/runtime/src/rn-devtools/__tests__/bindings-model-send-message.test.ts
@@ -1,0 +1,305 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// `rn-devtools-frontend.ts` re-exports modules from the Chrome DevTools frontend
+// runtime (e.g. `/rozenite/core/sdk/sdk.js`), which only exist inside the actual
+// DevTools frontend environment. This mirrors the stub used for the
+// `bindingCalled` unit tests in the neighboring `bindings-model.test.ts` file: a
+// minimal `SDKModel` base class plus a `RuntimeModel` token used only for
+// identity comparison in `target().model(SDK.RuntimeModel.RuntimeModel)`.
+vi.mock('../rn-devtools-frontend.js', () => {
+  class FakeSDKModel {
+    private readonly fakeTarget: unknown;
+
+    constructor(target: unknown) {
+      this.fakeTarget = target;
+    }
+
+    target(): unknown {
+      return this.fakeTarget;
+    }
+
+    dispatchEventToListeners(): void {
+      // no-op: not exercised by these tests
+    }
+
+    static register(): void {
+      // no-op: registration is only meaningful inside the real DevTools frontend
+    }
+  }
+
+  class RuntimeModelToken {}
+
+  return {
+    SDK: {
+      SDKModel: { SDKModel: FakeSDKModel },
+      RuntimeModel: { RuntimeModel: RuntimeModelToken },
+    },
+  };
+});
+
+const { SDK } = await import('../rn-devtools-frontend.js');
+const { RozeniteBindingsModel, sanitizeUnpairedSurrogates } = await import('../bindings-model.js');
+
+// The real `RuntimeAgent`'s generated `invoke_*` methods never reject -- a
+// protocol-level failure resolves with `getError()` set instead (verified
+// directly against the vendored `@react-native/debugger-frontend` bundle's
+// `protocol_client.js`). `getError: () => undefined` is the "no error" case a
+// real successful response always carries, so every fake response below
+// includes it -- a response missing it would not be representative of the
+// real agent.
+const okResponse = (extra: Record<string, unknown> = {}) => ({
+  getError: () => undefined,
+  ...extra,
+});
+
+type FakeAgent = {
+  invoke_evaluate: ReturnType<typeof vi.fn>;
+  invoke_addBinding: ReturnType<typeof vi.fn>;
+  invoke_callFunctionOn: ReturnType<typeof vi.fn>;
+};
+
+type FakeRuntimeModel = {
+  agent: FakeAgent;
+  addEventListener: ReturnType<typeof vi.fn>;
+  removeEventListener: ReturnType<typeof vi.fn>;
+  executionContexts: ReturnType<typeof vi.fn>;
+};
+
+// `sendMessage`, `mainExecutionContextId`, and the execution-context listener
+// methods are private; this shape names just what the tests need instead of
+// poking at an untyped `any`, matching the pattern used by the neighboring
+// `bindingCalled` test file.
+type TestableModel = Pick<InstanceType<typeof RozeniteBindingsModel>, 'sendMessage'> & {
+  fuseboxDispatcherIsInitialized: boolean;
+  mainExecutionContextId: number | null;
+  initializeExecutionContextListeners(): void;
+  onExecutionContextCreated(event: { data: { name: string; id: number } }): void;
+  onExecutionContextDestroyed(event: { data: { name: string; id: number } }): void;
+};
+
+const flushMicrotasks = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('RozeniteBindingsModel sendMessage', () => {
+  let runtimeModel: FakeRuntimeModel;
+  let existingContexts: Array<{ id: number; name: string }>;
+
+  beforeEach(() => {
+    existingContexts = [];
+    runtimeModel = {
+      agent: {
+        invoke_evaluate: vi.fn(async () => okResponse({ result: { value: true } })),
+        invoke_addBinding: vi.fn(async () => okResponse()),
+        invoke_callFunctionOn: vi.fn(async () => okResponse({ result: {} })),
+      },
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      executionContexts: vi.fn(() => existingContexts),
+    };
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const createModel = (): TestableModel => {
+    const fakeTarget = {
+      model: (token: unknown) => (token === SDK.RuntimeModel.RuntimeModel ? runtimeModel : null),
+    };
+    const model = new RozeniteBindingsModel(fakeTarget as never) as unknown as TestableModel;
+    model.fuseboxDispatcherIsInitialized = true;
+    return model;
+  };
+
+  it('does nothing (and does not throw) when the dispatcher is not initialized', async () => {
+    const model = createModel();
+    model.fuseboxDispatcherIsInitialized = false;
+    model.mainExecutionContextId = 5;
+
+    await model.sendMessage({ hello: 'world' });
+
+    expect(runtimeModel.agent.invoke_callFunctionOn).not.toHaveBeenCalled();
+  });
+
+  it('falls back to Runtime.evaluate when no main execution context is known yet, instead of dropping the message', async () => {
+    const model = createModel();
+    model.mainExecutionContextId = null;
+
+    const message = { pluginId: 'p', type: 'ping' };
+    await model.sendMessage(message);
+
+    expect(runtimeModel.agent.invoke_callFunctionOn).not.toHaveBeenCalled();
+    expect(runtimeModel.agent.invoke_evaluate).toHaveBeenCalledTimes(1);
+    const call = runtimeModel.agent.invoke_evaluate.mock.calls[0][0];
+    expect(call.expression).toContain('sendMessage("rozenite"');
+
+    // Only the message payload is double-stringified in this legacy fallback --
+    // that's inherent to needing a JS string *literal* in `Runtime.evaluate`'s
+    // source text, unlike the callFunctionOn path above. Evaluating the exact
+    // expression must reproduce the original message.
+    const sent = new Function(
+      `let sent; globalThis.__FUSEBOX_REACT_DEVTOOLS_DISPATCHER__ = { sendMessage: (_domain, m) => { sent = m; } }; ${call.expression}; return sent;`,
+    )();
+    expect(JSON.parse(sent)).toEqual(message);
+  });
+
+  it('sends via Runtime.callFunctionOn with a single-stringified by-value argument', async () => {
+    const model = createModel();
+    model.mainExecutionContextId = 11;
+
+    const message = { pluginId: 'p', type: 'ping', payload: { n: 1 } };
+    await model.sendMessage(message);
+
+    expect(runtimeModel.agent.invoke_callFunctionOn).toHaveBeenCalledTimes(1);
+    const call = runtimeModel.agent.invoke_callFunctionOn.mock.calls[0][0];
+
+    expect(call.executionContextId).toBe(11);
+    expect(call.functionDeclaration).toContain('sendMessage("rozenite", m)');
+    expect(call.arguments).toHaveLength(1);
+
+    const argValue = call.arguments[0].value;
+    // A single stringify only: parsing it once yields the plain object, not a
+    // JSON string that would need parsing a second time (the double-stringify
+    // this path replaced).
+    expect(typeof argValue).toBe('string');
+    const parsed = JSON.parse(argValue);
+    expect(parsed).toEqual(message);
+  });
+
+  it('does not await the round trip but reports a runtime exception (exceptionDetails) instead of swallowing it', async () => {
+    const model = createModel();
+    model.mainExecutionContextId = 1;
+    let resolveSend!: (value: ReturnType<typeof okResponse>) => void;
+    runtimeModel.agent.invoke_callFunctionOn.mockReturnValue(
+      new Promise((resolve) => {
+        resolveSend = resolve;
+      }),
+    );
+
+    const sendPromise = model.sendMessage({ hello: 'world' });
+
+    // `sendMessage` must resolve without waiting for the CDP round trip: the
+    // `invoke_callFunctionOn` promise above is still pending (`resolveSend` has
+    // not been called yet), yet `sendPromise` already settles.
+    await expect(sendPromise).resolves.toBeUndefined();
+
+    resolveSend(okResponse({ exceptionDetails: { text: 'boom' } }));
+    await flushMicrotasks();
+
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('boom'));
+  });
+
+  it('reports a protocol-level failure (getError(), not exceptionDetails) instead of swallowing it', async () => {
+    // The real agent's `invoke_*` methods never reject -- a protocol error (e.g.
+    // a stale execution context id after a reload, the scenario this exercises)
+    // resolves with `getError()` set rather than throwing. A prior version of
+    // this send path only checked `exceptionDetails` and had a dead `.catch()`,
+    // which meant this exact failure mode was silently dropped.
+    const model = createModel();
+    model.mainExecutionContextId = 1;
+    runtimeModel.agent.invoke_callFunctionOn.mockResolvedValue(
+      okResponse({ getError: () => 'Cannot find context with specified id', result: {} }),
+    );
+
+    await model.sendMessage({ hello: 'world' });
+    await flushMicrotasks();
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('Cannot find context with specified id'),
+    );
+  });
+
+  it('resolves an existing main execution context when listeners are attached (initial-context race)', () => {
+    existingContexts = [
+      { id: 3, name: 'other' },
+      { id: 42, name: 'main' },
+    ];
+    const model = createModel();
+
+    model.initializeExecutionContextListeners();
+
+    expect(model.mainExecutionContextId).toBe(42);
+  });
+
+  it('re-captures the execution context id on reload (create -> destroy -> create)', () => {
+    const model = createModel();
+    model.initializeExecutionContextListeners();
+    expect(model.mainExecutionContextId).toBeNull();
+
+    model.onExecutionContextCreated({ data: { name: 'main', id: 1 } });
+    expect(model.mainExecutionContextId).toBe(1);
+
+    model.onExecutionContextDestroyed({ data: { name: 'main', id: 1 } });
+    expect(model.mainExecutionContextId).toBeNull();
+
+    model.onExecutionContextCreated({ data: { name: 'main', id: 2 } });
+    expect(model.mainExecutionContextId).toBe(2);
+  });
+
+  it('does not clear the execution context id when a non-matching context is destroyed', () => {
+    const model = createModel();
+    model.initializeExecutionContextListeners();
+
+    model.onExecutionContextCreated({ data: { name: 'main', id: 1 } });
+    // A stale destroy event for a previous, already-replaced context id must
+    // not clobber the currently active one.
+    model.onExecutionContextDestroyed({ data: { name: 'main', id: 999 } });
+
+    expect(model.mainExecutionContextId).toBe(1);
+  });
+
+  it('ignores execution contexts that are not the main context', () => {
+    const model = createModel();
+    model.initializeExecutionContextListeners();
+
+    model.onExecutionContextCreated({ data: { name: 'worker', id: 1 } });
+
+    expect(model.mainExecutionContextId).toBeNull();
+  });
+});
+
+// `sanitizeUnpairedSurrogates` operates on the *output* of `JSON.stringify`, not
+// on a raw JS string. Modern (ES2019+ "well-formed") `JSON.stringify` never
+// emits a lone surrogate as a raw UTF-16 code unit -- it always escapes it to a
+// literal six-character `\uXXXX` sequence. So the function has to look for that
+// escape sequence text, not for raw surrogate code units (which, for a lone
+// surrogate, will never appear post-stringify).
+describe('sanitizeUnpairedSurrogates', () => {
+  it('leaves ordinary text untouched', () => {
+    const input = JSON.stringify('He said "hi"\nnewline\ttab \\backslash');
+    expect(sanitizeUnpairedSurrogates(input)).toBe(input);
+  });
+
+  it('preserves valid surrogate pairs (emoji), which JSON.stringify never escapes', () => {
+    const input = JSON.stringify('party 🎉 time');
+    expect(input).not.toMatch(/\\u[dD][89a-fA-F]/);
+    expect(sanitizeUnpairedSurrogates(input)).toBe(input);
+  });
+
+  it('does not mangle U+2028 or U+2029', () => {
+    const input = JSON.stringify('line  sep and para  sep');
+    expect(sanitizeUnpairedSurrogates(input)).toBe(input);
+  });
+
+  it('replaces an unpaired high-surrogate escape sequence produced by JSON.stringify', () => {
+    const input = JSON.stringify('broken \uD800 surrogate');
+    expect(input).toContain('\\ud800');
+    expect(sanitizeUnpairedSurrogates(input)).toBe(JSON.stringify('broken � surrogate'));
+  });
+
+  it('replaces an unpaired low-surrogate escape sequence produced by JSON.stringify', () => {
+    const input = JSON.stringify('broken \uDC00 surrogate');
+    expect(sanitizeUnpairedSurrogates(input)).toBe(JSON.stringify('broken � surrogate'));
+  });
+
+  it('makes a real device-rejected payload safe: no unpaired escape sequence survives', () => {
+    // Verified against a real device: a lone surrogate escape (properly escaped
+    // by JSON.stringify, syntactically valid JSON) is still rejected by the
+    // device's stricter JSON parser with "expected another unicode escape for
+    // second half of surrogate pair", surfacing as an uncorrelatable `id: null`.
+    const serialized = JSON.stringify({ payload: { value: 'before-\uD800-after' } });
+    const sanitized = sanitizeUnpairedSurrogates(serialized);
+    expect(sanitized).not.toMatch(/\\u[dD][89a-fA-F][0-9a-fA-F]{2}/);
+    expect(() => JSON.parse(sanitized)).not.toThrow();
+  });
+});

--- a/packages/runtime/src/rn-devtools/bindings-model.ts
+++ b/packages/runtime/src/rn-devtools/bindings-model.ts
@@ -17,15 +17,58 @@ const DOMAIN_NAME = 'rozenite';
 const MAIN_EXECUTION_CONTEXT_NAME = 'main';
 const RUNTIME_GLOBAL = '__FUSEBOX_REACT_DEVTOOLS_DISPATCHER__';
 
+// Matches a `\uXXXX` escape sequence for either half of a surrogate pair
+// (D800-DFFF), capturing a *pair* of such escapes (high immediately followed
+// by low) before falling back to matching a single one.
+const SURROGATE_ESCAPE_SEQUENCE =
+  /\\u[dD][89a-fA-F][0-9a-fA-F]{2}\\u[dD][c-fC-F][0-9a-fA-F]{2}|\\u[dD][89a-fA-F][0-9a-fA-F]{2}/g;
+
+// Replaces an unpaired UTF-16 surrogate half with U+FFFD.
+//
+// Verified against a real device: modern `JSON.stringify` (ES2019+
+// "well-formed" `JSON.stringify`) never emits a lone surrogate as a raw code
+// unit -- it always escapes it to a literal six-character `\uXXXX` sequence,
+// so a real lone surrogate in `message` is already gone as a raw code unit by
+// the time `JSON.stringify(message)` returns. The device's own JSON parser is
+// stricter than the JSON grammar and rejects that escape sequence outright
+// (`"json parse error ... expected another unicode escape for second half of
+// surrogate pair"`), which the frontend cannot correlate back to the request
+// that caused it -- the error response comes back with `"id": null"`. This
+// function operates on the *already-stringified* text, replacing an unpaired
+// `\uXXXX` escape sequence (not a raw code unit -- there won't be one).
+//
+// A raw surrogate *pair* (e.g. ordinary emoji) is not affected by any of
+// this: `JSON.stringify` does not escape it at all, so it survives as two
+// ordinary UTF-16 code units in the string and this function never matches
+// it. U+2028/U+2029 are likewise untouched (not surrogates, and
+// `JSON.stringify` does not escape them either).
+export const sanitizeUnpairedSurrogates = (jsonText: string): string => {
+  let mutated = false;
+
+  const sanitized = jsonText.replace(SURROGATE_ESCAPE_SEQUENCE, (match) => {
+    if (match.length === 12) {
+      // A high escape immediately followed by a low escape -- a valid pair.
+      return match;
+    }
+
+    mutated = true;
+    return '\uFFFD';
+  });
+
+  return mutated ? sanitized : jsonText;
+};
+
 export class RozeniteBindingsModel extends SDK.SDKModel.SDKModel {
   private messagingBindingName: string | null = null;
   private enabled = false;
   private fuseboxDispatcherIsInitialized = false;
   private messageQueue: JSONValue[] = [];
   private messageListeners: Set<DomainMessageListener> = new Set();
+  private mainExecutionContextId: number | null = null;
 
   override dispose(): void {
     this.messageQueue = [];
+    this.mainExecutionContextId = null;
 
     const runtimeModel = this.target().model(SDK.RuntimeModel.RuntimeModel);
     runtimeModel?.removeEventListener('BindingCalled', this.bindingCalled, this);
@@ -151,13 +194,77 @@ export class RozeniteBindingsModel extends SDK.SDKModel.SDKModel {
       );
     }
 
-    const serializedMessage = JSON.stringify(message);
-    const escapedMessage = JSON.stringify(serializedMessage);
+    // `Runtime.evaluate` requires interpolating the payload into a JS source string
+    // that Hermes has to recompile. A single stringify + string-literal interpolation
+    // is not reversible for arbitrary strings (e.g. it silently drops messages
+    // containing astral-plane characters, since Hermes' source parser can't accept a
+    // lone UTF-16 surrogate half in source text). `Runtime.callFunctionOn` with a
+    // by-value argument instead ships the string through CDP's own (correct) value
+    // serialization, so it round-trips byte-for-byte -- see the emoji round-trip
+    // check in this package's send-path tests.
+    const serializedMessage = sanitizeUnpairedSurrogates(JSON.stringify(message));
+    const functionDeclaration = `function(m) { ${RUNTIME_GLOBAL}.sendMessage(${JSON.stringify(
+      DOMAIN_NAME,
+    )}, m) }`;
 
-    // Note: Double quote must be used in case we get a string with a nested JSON object.
-    await runtimeModel.agent.invoke_evaluate({
-      expression: `${RUNTIME_GLOBAL}.sendMessage('${DOMAIN_NAME}', ${escapedMessage})`,
-    });
+    const executionContextId = this.mainExecutionContextId;
+
+    // We deliberately do not await the round trip: CDP requests are ordered and
+    // execute in order on the runtime's JS thread, so message ordering is preserved
+    // without blocking the caller on the response. We still inspect the response so
+    // a failed send is reported instead of silently dropped, which is the whole
+    // reason this path stopped using `Runtime.evaluate` in the first place.
+    //
+    // `invoke_*` methods on this agent never reject -- a protocol-level failure
+    // (e.g. a stale execution context id after a reload) resolves with `getError()`
+    // set rather than throwing, so that has to be checked explicitly alongside
+    // `exceptionDetails` (a JS-level exception during the evaluated function, a
+    // different failure mode -- both are checked below).
+    const reportFailure = (response: {
+      exceptionDetails?: { text: string };
+      getError: () => string | undefined;
+    }): void => {
+      const protocolError = response.getError();
+      if (protocolError) {
+        console.error('Failed to send message from RozeniteBindingsModel: ' + protocolError);
+        return;
+      }
+      if (response.exceptionDetails) {
+        console.error(
+          'Failed to send message from RozeniteBindingsModel: ' + response.exceptionDetails.text,
+        );
+      }
+    };
+
+    if (executionContextId === null) {
+      // No main execution context id captured yet (e.g. sent before the first
+      // `ExecutionContextCreated` event arrived, or before `enable()`'s initial
+      // lookup ran). Fall back to `Runtime.evaluate` rather than dropping the
+      // message outright -- this is a rare startup race, not the steady-state path,
+      // and the fallback is no worse than this path's previous behavior.
+      const escapedMessage = JSON.stringify(serializedMessage);
+      void runtimeModel.agent
+        .invoke_evaluate({
+          expression: `${RUNTIME_GLOBAL}.sendMessage(${JSON.stringify(DOMAIN_NAME)}, ${escapedMessage})`,
+        })
+        .then((response) => {
+          if (response.exceptionDetails) {
+            console.error(
+              'Failed to send message from RozeniteBindingsModel: ' +
+                response.exceptionDetails.text,
+            );
+          }
+        });
+      return;
+    }
+
+    void runtimeModel.agent
+      .invoke_callFunctionOn({
+        executionContextId,
+        functionDeclaration,
+        arguments: [{ value: serializedMessage }],
+      })
+      .then(reportFailure);
   }
 
   async enable(): Promise<void> {
@@ -234,14 +341,29 @@ export class RozeniteBindingsModel extends SDK.SDKModel.SDKModel {
       this.onExecutionContextDestroyed,
       this,
     );
+
+    // These listeners can be attached after the main execution context already
+    // exists (e.g. the app was already running when the DevTools panel opened),
+    // in which case its `ExecutionContextCreated` event was dispatched before we
+    // were listening and we'd never see it. Resolve it directly from the model's
+    // current state so `sendMessage` has a valid execution context id right away,
+    // not only after the first reload.
+    const existingMainContext = runtimeModel
+      .executionContexts()
+      .find((context) => context.name === MAIN_EXECUTION_CONTEXT_NAME);
+    if (existingMainContext) {
+      this.mainExecutionContextId = existingMainContext.id;
+    }
   }
 
   private onExecutionContextCreated({
     data: executionContext,
-  }: RuntimeEvent<{ name: string }>): void {
+  }: RuntimeEvent<{ name: string; id: number }>): void {
     if (executionContext.name !== MAIN_EXECUTION_CONTEXT_NAME) {
       return;
     }
+
+    this.mainExecutionContextId = executionContext.id;
 
     void this.waitForFuseboxDispatcherToBeInitialized()
       .then(() => {
@@ -255,9 +377,13 @@ export class RozeniteBindingsModel extends SDK.SDKModel.SDKModel {
 
   private onExecutionContextDestroyed({
     data: executionContext,
-  }: RuntimeEvent<{ name: string }>): void {
+  }: RuntimeEvent<{ name: string; id: number }>): void {
     if (executionContext.name !== MAIN_EXECUTION_CONTEXT_NAME) {
       return;
+    }
+
+    if (this.mainExecutionContextId === executionContext.id) {
+      this.mainExecutionContextId = null;
     }
 
     this.fuseboxDispatcherIsInitialized = false;

--- a/packages/runtime/src/rn-devtools/rn-devtools-frontend-api.d.ts
+++ b/packages/runtime/src/rn-devtools/rn-devtools-frontend-api.d.ts
@@ -186,6 +186,11 @@ declare module '/rozenite/models/react_native/react_native.js' {
       };
     };
 
+    export interface ExecutionContext {
+      id: number;
+      name: string;
+    }
+
     export class RuntimeModel extends SDKModel.SDKModel {
       addEventListener<T>(
         event: string,
@@ -197,6 +202,10 @@ declare module '/rozenite/models/react_native/react_native.js' {
         callback: (message: RuntimeEvent<T>) => void,
         thisArg: unknown,
       ): void;
+      // Returns the execution contexts currently known to the frontend. Used to
+      // resolve the "main" context id at binding-model enable time, in case its
+      // creation event was dispatched before our listeners were attached.
+      executionContexts(): ExecutionContext[];
       agent: {
         invoke_evaluate: (params: {
           expression: string;
@@ -205,6 +214,27 @@ declare module '/rozenite/models/react_native/react_native.js' {
         invoke_addBinding: (params: {
           name: string;
         }) => Promise<RuntimeModel.ProtocolResponseWithError>;
+        // Same underlying CDP `Runtime.callFunctionOn` command as `invoke_evaluate`
+        // wraps `Runtime.evaluate`; verified present on the RuntimeAgent served by
+        // `@react-native/debugger-frontend` (core/sdk/sdk.js registers
+        // "Runtime.callFunctionOn" via protocol_client.js, and the module's
+        // RemoteObject helpers already call `agent.invoke_callFunctionOn(...)`).
+        //
+        // Every generated `invoke_*` method (verified directly in the vendored
+        // `protocol_client.js`) resolves -- it never rejects -- and always carries
+        // `getError()`, the same as `invoke_addBinding` below: a protocol-level
+        // failure (e.g. a stale `executionContextId` after a reload) surfaces only
+        // through `getError()`, not through `exceptionDetails` (which is specific
+        // to a JS-level exception thrown *during* the evaluated function, a
+        // different failure mode). Both must be checked.
+        invoke_callFunctionOn: (params: {
+          functionDeclaration: string;
+          executionContextId?: number;
+          objectId?: string;
+          arguments?: Array<{ value?: unknown }>;
+          returnByValue?: boolean;
+          silent?: boolean;
+        }) => Promise<RuntimeModel.EvaluateResponse & RuntimeModel.ProtocolResponseWithError>;
       };
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1380,6 +1380,10 @@ importers:
       tslib:
         specifier: ^2.3.0
         version: 2.8.1
+    devDependencies:
+      vitest:
+        specifier: ^4.0.18
+        version: 4.1.0(@types/node@18.16.9)(@vitest/ui@3.2.4(vitest@3.2.4))(jiti@2.4.2)(jsdom@22.1.0(supports-color@8.1.1))(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.8.1)
 
   packages/shell:
     dependencies:
@@ -23669,12 +23673,6 @@ snapshots:
     dependencies:
       sc-errors: 3.0.0
 
-  agent-base@6.0.2(supports-color@5.5.0):
-    dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
-    transitivePeerDependencies:
-      - supports-color
-
   agent-base@6.0.2(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
@@ -26990,11 +26988,11 @@ snapshots:
 
   http-parser-js@0.5.10: {}
 
-  http-proxy-agent@5.0.0(supports-color@5.5.0):
+  http-proxy-agent@5.0.0(supports-color@8.1.1):
     dependencies:
       '@tootallnate/once': 2.0.0
-      agent-base: 6.0.2(supports-color@5.5.0)
-      debug: 4.4.3(supports-color@5.5.0)
+      agent-base: 6.0.2(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -27034,7 +27032,7 @@ snapshots:
   https-proxy-agent@5.0.1(supports-color@8.1.1):
     dependencies:
       agent-base: 6.0.2(supports-color@8.1.1)
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -27606,7 +27604,7 @@ snapshots:
       domexception: 4.0.0
       form-data: 4.0.3
       html-encoding-sniffer: 3.0.0
-      http-proxy-agent: 5.0.0(supports-color@5.5.0)
+      http-proxy-agent: 5.0.0(supports-color@8.1.1)
       https-proxy-agent: 5.0.1(supports-color@8.1.1)
       is-potential-custom-element-name: 1.0.1
       nwsapi: 2.2.22
@@ -27620,7 +27618,7 @@ snapshots:
       whatwg-encoding: 2.0.0
       whatwg-mimetype: 3.0.0
       whatwg-url: 12.0.1
-      ws: 8.18.3
+      ws: 8.21.2
       xml-name-validator: 4.0.0
     transitivePeerDependencies:
       - bufferutil


### PR DESCRIPTION
## Description

Host-to-device messages (plugin domain messages, the agent-session-ready handshake, `set-entry` writes for storage/mmkv/sqlite plugins, etc.) were sent by double-JSON-stringifying the payload and interpolating the result into a `Runtime.evaluate` JS source-string expression, which the device's JS engine (Hermes) then recompiles.

A payload containing a character outside the Basic Multilingual Plane (for example an emoji, a UTF-16 surrogate pair) fails that recompilation with `Invalid UTF-8 code point`, and the message is silently lost — neither call site checked the response for `exceptionDetails`, so the failure was invisible.

This switches the send path to `Runtime.callFunctionOn` with the payload passed as a single-stringified by-value argument (in both `packages/runtime/src/rn-devtools/bindings-model.ts`, the DevTools-frontend model, and `packages/middleware/src/agent/session.ts`, the middleware's raw-CDP agent session), and stops silently swallowing failures.

## Related Issue

Closes #407

## Context

**Why `Runtime.callFunctionOn`, and did the frontend wrapper actually expose it?** The CDP protocol supports `callFunctionOn`, but the DevTools-frontend's hand-written `RuntimeAgent` ambient declaration (`rn-devtools-frontend-api.d.ts`) only declared `invoke_evaluate`/`invoke_addBinding`. Verified directly against the installed `@react-native/debugger-frontend@0.86.2` bundle: `core/sdk/sdk.js` both registers `Runtime.callFunctionOn` (via `protocol_client.js`'s command registration) and already calls `agent.invoke_callFunctionOn(...)` internally (in `RemoteObject`'s property-mutation helpers) — so it's exposed, and both `bindings-model.ts` and `session.ts` implement the switch.

**Correctness findings surfaced during an adversarial review (opus) of the first pass, all fixed:**
- The real `RuntimeAgent`'s generated `invoke_*` methods never reject — a protocol-level failure (e.g. a stale execution context id after a reload) resolves with `getError()` set rather than throwing. The first pass only checked `exceptionDetails` (a *different* failure mode: a JS-level exception during the evaluated function) and had a dead `.catch()`. Both are now checked.
- The pending-command timeout (added because a malformed frame can come back as an uncorrelatable `"id": null"` response) was initially applied to every CDP command, which would have cut off legitimately long-running commands (`HeapProfiler.takeHeapSnapshot`, large `Network.getResponseBody`/`getRequestPostData` calls). It's now opt-in per command and only applied to the send path.
- `sendDomainMessage` initially always returned an already-resolved promise once the round trip was no longer awaited, which silently broke `bootstrap()`'s existing retry-on-failure logic for the `agent-session-ready` handshake. It now returns the real (still-rejectable) promise chain, so `void`-calling sites stay non-blocking while the one `await`-ing call site keeps its retry behavior.
- The unpaired-surrogate sanitizer initially scanned for raw UTF-16 surrogate code units, but by the time it ran (on `JSON.stringify(message)`'s output) a lone surrogate is already represented as a literal `\uXXXX` *escape sequence* (`JSON.stringify` is well-formed since ES2019 and never emits a raw lone surrogate) — so the original sanitizer never matched anything. It now matches the escape-sequence text instead, verified against a real device: the device's own JSON parser rejects an unpaired `\uXXXX` escape sequence with `"expected another unicode escape for second half of surrogate pair"`, even though it's syntactically valid JSON.

**Honest framing:** this is not a meaningful throughput/perf win. Median added latency from the extra `Runtime.callFunctionOn` framing vs `Runtime.evaluate` is 0–1ms for typical (sub-8KB) structured payloads on a localhost simulator connection; with unstructured (quote-free) payloads the new framing is marginally *larger* on the wire. The actual win is removing the round-trip await from the hot send path (CDP requests are ordered and execute in order regardless of whether the caller awaits the response) and, primarily, fixing the data loss.

**⚠️ Known overlap with #405 (`perf/skip-json-parse-non-rozenite-bindings`), both open off `main`:** both PRs independently add the same line to `packages/runtime/package.json`'s `scripts`:
```
"test": "vitest --run --passWithNoTests"
```
Git will conflict on that hunk for whichever merges second. The two PRs also disagree on convention: #405 adds the script *without* declaring `vitest` as a devDependency, on the assumption that packages here don't declare it directly. That assumption doesn't hold — `packages/middleware`, `shell`, `metro`, `tools`, `expo-atlas-plugin`, `file-system-plugin`, and `sqlite-plugin` all declare `vitest` in `devDependencies`. This PR follows that majority convention (adds `"vitest": "^4.0.18"` to `packages/runtime`'s `devDependencies`, with the corresponding minimal `pnpm-lock.yaml` update). Whoever merges second should rebase onto the other and drop the duplicate script line; if #405 lands first, this PR should additionally pick up its devDependency declaration rather than the reverse.

## Testing

Automated:
- `pnpm --filter @rozenite/runtime typecheck / lint / test` — 15 tests passed
- `pnpm --filter @rozenite/middleware typecheck / lint / test` — 107 tests passed
- `pnpm --filter @rozenite/metro test` (CJS-load smoke test over the built `@rozenite/runtime`/`@rozenite/middleware` bundles) — 2 tests passed
- `pnpm release:plan` — changeset present and valid
- `pnpm build:all`, root `lint`/`typecheck` (also run automatically by the repo's pre-push hook) — all green

Manual, against a real device (RN 0.86 / Hermes, iPhone 17 Pro simulator, connected over the raw CDP `Runtime` domain with `Origin: http://127.0.0.1:8081`):
- Emoji-bearing payload via the new `Runtime.callFunctionOn` shape: delivered byte-for-byte (round-trip identical). The same payload via the old `Runtime.evaluate` double-stringify path: `Compiling JS failed: ... Invalid UTF-8 code point 0xd83c` (reproduces the bug for comparison in the same session).
- A message containing an unpaired UTF-16 surrogate, sanitized: delivered successfully with no `exceptionDetails`/error and a byte-identical round trip.
