### PR TITLE
ci: deploy website automatically as part of the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,3 +56,10 @@ jobs:
 
       - name: Run release
         run: pnpm release:run
+
+  deploy-website:
+    name: Deploy website
+    needs: release
+    if: github.event.inputs.mode != 'canary'
+    uses: ./.github/workflows/website-release-deploy.yml
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,15 @@ jobs:
   deploy-website:
     name: Deploy website
     needs: release
-    if: github.event.inputs.mode != 'canary'
+    # Only stable releases deploy production docs. Canary pushes no tag, and rc
+    # runs from a release/v* branch, which must not become the production site.
+    if: github.event.inputs.mode == 'stable'
     uses: ./.github/workflows/website-release-deploy.yml
-    secrets: inherit
+    # Do not inherit id-token: write from this workflow — the deploy job must not
+    # be able to mint an npm trusted-publishing token.
+    permissions:
+      contents: read
+    secrets:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/.github/workflows/website-release-deploy.yml
+++ b/.github/workflows/website-release-deploy.yml
@@ -6,6 +6,16 @@ on:
       - 'v*'
   workflow_dispatch:
   workflow_call:
+    secrets:
+      VERCEL_TOKEN:
+        required: true
+      VERCEL_ORG_ID:
+        required: true
+      VERCEL_PROJECT_ID:
+        required: true
+
+permissions:
+  contents: read
 
 concurrency:
   group: website-deploy-${{ github.ref }}
@@ -35,7 +45,9 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install Vercel CLI
-        run: pnpm install --global vercel@latest
+        # Pinned deliberately: this job runs unattended on every stable release
+        # with the Vercel deploy token in scope, so the CLI must not float.
+        run: pnpm install --global vercel@59.1.3
 
       - name: Pull Vercel environment information
         run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/website-release-deploy.yml
+++ b/.github/workflows/website-release-deploy.yml
@@ -5,6 +5,7 @@ on:
     tags:
       - 'v*'
   workflow_dispatch:
+  workflow_call:
 
 concurrency:
   group: website-deploy-${{ github.ref }}


### PR DESCRIPTION
## Description

The website deploy workflow previously only triggered on a `v*` tag push or manual dispatch. Release automation (`release.yml`) pushes that tag using the default `GITHUB_TOKEN`, and GitHub Actions does not fire other workflows for pushes made with that token — so the tag push never actually kicked off the website deploy, and it had to be triggered by hand after every release.

This adds a `workflow_call` trigger to `website-release-deploy.yml` and calls it as a job from `release.yml` once the release job succeeds, for `stable` and `rc` modes (canary releases don't push a tag, so there's nothing new to deploy). The existing `push: tags: v*` and `workflow_dispatch` triggers are left in place, so the workflow can still be run by hand if needed.

## Related Issue

N/A — CI/workflow fix, no issue.

## Context

Chose calling it as a reusable workflow (`uses: ./.github/workflows/website-release-deploy.yml` with `secrets: inherit`) from `release.yml` rather than relying on the tag-push trigger, since that trigger is a no-op when the tag is pushed by a workflow using `GITHUB_TOKEN`.

## Testing

- `actionlint .github/workflows/release.yml .github/workflows/website-release-deploy.yml` — no issues
- Pre-push hooks (`lint:all`, `typecheck:all`) passed