### PR TITLE
docs: update compatibility table with specific versions

### DIFF
--- a/website/src/docs/compatibility.mdx
+++ b/website/src/docs/compatibility.mdx
@@ -4,7 +4,7 @@
 
 | Rozenite | Expo SDK | React Native | Re.Pack |
 | -------- | -------- | ------------ | ------- |
-| 1.x      | 52+      | 0.76+        | 5.2+    |
+| 1.13.0, >= 2.0.0 | 52+      | 0.76+        | 5.2+    |
 
 Rozenite tracks Expo SDK releases as its primary compatibility baseline, since each
 Expo SDK pins a specific React Native version. If you're on bare React Native


### PR DESCRIPTION
Updated the compatibility table to show the latest v1 release (1.13.0) and explicitly indicate support for Rozenite 2.0.0+, since there are no breaking changes with expo/react-native between v1 and v2.