### PR TITLE
feat(ui): add tone tokens for the design system (Phase 0)

### DIFF
--- a/.changeset/ui-design-system-phase-0-tokens.md
+++ b/.changeset/ui-design-system-phase-0-tokens.md
@@ -1,0 +1,5 @@
+---
+'@rozenite/ui': minor
+---
+
+Add tone tokens for `success`, `warning`, and `info`, plus a `--danger` alias for the existing `--destructive` pair. Export the `Tone` and `Size` unions and the `surfaceTone`/`textTone` cva recipes so components can compose consistent tone-aware styling. No existing component's behavior changes.

--- a/apps/ui-storybook/src/stories/Tokens.stories.tsx
+++ b/apps/ui-storybook/src/stories/Tokens.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { surfaceTone, textTone, type Tone } from '@rozenite/ui';
+import { surfaceTone, textTone, sizeHeight, sizeIcon, type Tone, type Size } from '@rozenite/ui';
 
 const TONES: Tone[] = ['neutral', 'primary', 'success', 'warning', 'danger', 'info'];
 const VARIANTS = ['solid', 'soft', 'outline', 'ghost'] as const;
@@ -83,6 +83,31 @@ export const ToneVariantMatrix: Story = {
   ),
 };
 
+const SIZES: Size[] = ['sm', 'md', 'lg'];
+
+/**
+ * The `sm | md | lg` control-height scale from `sizeHeight`, each paired
+ * with its `sizeIcon` step.
+ * @summary Compare every control size step.
+ */
+export const SizeScale: Story = {
+  render: () => (
+    <div className="flex items-end gap-4 p-4">
+      {SIZES.map((size) => (
+        <div key={size} className="flex flex-col items-center gap-2">
+          <div
+            className={`bg-secondary flex items-center gap-1 border border-border px-2 text-xs ${sizeHeight[size]}`}
+          >
+            <span className={`bg-foreground ${sizeIcon[size]}`} />
+            {size}
+          </div>
+          <span className="text-muted-foreground text-xs">{sizeHeight[size]}</span>
+        </div>
+      ))}
+    </div>
+  ),
+};
+
 /**
  * `--radius` is `0` on purpose — this design system is square by design, not
  * an unfinished default. The `--radius-{sm,md,lg,xl}` scale stays wired
@@ -92,7 +117,6 @@ export const ToneVariantMatrix: Story = {
  * @summary Document why every corner is square by default.
  */
 export const SquareByDesign: Story = {
-  parameters: { withPluginShell: false },
   render: () => (
     <div className="flex flex-wrap items-center gap-4 p-4">
       <div className="flex flex-col items-center gap-2">

--- a/apps/ui-storybook/src/stories/Tokens.stories.tsx
+++ b/apps/ui-storybook/src/stories/Tokens.stories.tsx
@@ -1,0 +1,116 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { surfaceTone, textTone, type Tone } from '@rozenite/ui';
+
+const TONES: Tone[] = ['neutral', 'primary', 'success', 'warning', 'danger', 'info'];
+const VARIANTS = ['solid', 'soft', 'outline', 'ghost'] as const;
+
+function ToneMatrix() {
+  return (
+    <div className="grid grid-cols-4 gap-2">
+      {TONES.flatMap((tone) =>
+        VARIANTS.map((variant) => (
+          <div
+            key={`${tone}-${variant}`}
+            className={surfaceTone({
+              tone,
+              variant,
+              class: 'flex h-10 items-center justify-center rounded-md text-xs font-medium',
+            })}
+          >
+            {tone}/{variant}
+          </div>
+        )),
+      )}
+    </div>
+  );
+}
+
+function TextToneRow() {
+  return (
+    <div className="flex flex-wrap gap-4 text-sm font-medium">
+      {TONES.map((tone) => (
+        <span key={tone} className={textTone({ tone })}>
+          {tone}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function ThemePanel({ dark }: { dark: boolean }) {
+  return (
+    <div className={dark ? 'dark' : ''}>
+      <div className="bg-background text-foreground flex flex-col gap-4 p-4">
+        <p className="text-muted-foreground text-xs font-semibold uppercase">
+          {dark ? 'Dark' : 'Light'}
+        </p>
+        <ToneMatrix />
+        <TextToneRow />
+      </div>
+    </div>
+  );
+}
+
+/** No component owns this story — it documents the shared token layer that
+ *  every other component builds on top of. */
+const meta = {
+  title: 'Foundations/Tokens',
+  parameters: {
+    layout: 'fullscreen',
+    withPluginShell: false,
+    docs: {
+      description: {
+        component:
+          'The tone × variant × size matrix every component builds on. Tone is `neutral | primary | success | warning | danger | info`; variant is `solid | soft | outline | ghost`; size is `sm | md | lg`.',
+      },
+    },
+  },
+} satisfies Meta;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * The full tone × variant matrix from `surfaceTone`, rendered in both
+ * themes, plus the foreground-only palette from `textTone`.
+ * @summary Compare every tone and variant combination in both themes.
+ */
+export const ToneVariantMatrix: Story = {
+  render: () => (
+    <div className="grid grid-cols-2 divide-x divide-border">
+      <ThemePanel dark={false} />
+      <ThemePanel dark />
+    </div>
+  ),
+};
+
+/**
+ * `--radius` is `0` on purpose — this design system is square by design, not
+ * an unfinished default. The `--radius-{sm,md,lg,xl}` scale stays wired
+ * through `@theme inline` so `rounded-*` classes remain a live re-theming
+ * seam: raising `--radius` above `0` would round every component at once
+ * without touching component code.
+ * @summary Document why every corner is square by default.
+ */
+export const SquareByDesign: Story = {
+  parameters: { withPluginShell: false },
+  render: () => (
+    <div className="flex flex-wrap items-center gap-4 p-4">
+      <div className="flex flex-col items-center gap-2">
+        <div className="bg-primary size-16 rounded-sm" />
+        <span className="text-muted-foreground text-xs">rounded-sm</span>
+      </div>
+      <div className="flex flex-col items-center gap-2">
+        <div className="bg-primary size-16 rounded-md" />
+        <span className="text-muted-foreground text-xs">rounded-md</span>
+      </div>
+      <div className="flex flex-col items-center gap-2">
+        <div className="bg-primary size-16 rounded-lg" />
+        <span className="text-muted-foreground text-xs">rounded-lg</span>
+      </div>
+      <div className="flex flex-col items-center gap-2">
+        <div className="bg-primary size-16 rounded-xl" />
+        <span className="text-muted-foreground text-xs">rounded-xl</span>
+      </div>
+    </div>
+  ),
+};

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,5 +1,10 @@
 export { cn } from './utils/cn';
 
+export type { Tone } from './tokens/tone';
+export type { Size } from './tokens/size';
+export { sizeHeight, sizePaddingX, sizeIcon } from './tokens/size';
+export { surfaceTone, textTone } from './tokens/tone-variants';
+
 export { Split } from './split/split';
 export type {
   SplitDirection,

--- a/packages/ui/src/tokens/size.ts
+++ b/packages/ui/src/tokens/size.ts
@@ -1,0 +1,22 @@
+export type Size = 'sm' | 'md' | 'lg';
+
+/** Control height per size step. `md` is the default control height today. */
+export const sizeHeight: Record<Size, string> = {
+  sm: 'h-6',
+  md: 'h-8',
+  lg: 'h-10',
+};
+
+/** Horizontal padding per size step, for controls that pad by height. */
+export const sizePaddingX: Record<Size, string> = {
+  sm: 'px-2',
+  md: 'px-3',
+  lg: 'px-4',
+};
+
+/** Icon size (`size-*`) to pair with each control size step. */
+export const sizeIcon: Record<Size, string> = {
+  sm: 'size-3.5',
+  md: 'size-4',
+  lg: 'size-5',
+};

--- a/packages/ui/src/tokens/tone-variants.ts
+++ b/packages/ui/src/tokens/tone-variants.ts
@@ -1,0 +1,155 @@
+import { cva } from 'class-variance-authority';
+
+/**
+ * Crosses `tone` with `variant` (solid | soft | outline | ghost) for
+ * surface-bearing components — Button, IconButton, Badge, Alert.
+ */
+export const surfaceTone = cva('', {
+  variants: {
+    tone: {
+      neutral: '',
+      primary: '',
+      success: '',
+      warning: '',
+      danger: '',
+      info: '',
+    },
+    variant: {
+      solid: '',
+      soft: '',
+      outline: '',
+      ghost: '',
+    },
+  },
+  compoundVariants: [
+    {
+      tone: 'neutral',
+      variant: 'solid',
+      class: 'bg-secondary text-secondary-foreground',
+    },
+    { tone: 'neutral', variant: 'soft', class: 'bg-muted text-foreground' },
+    {
+      tone: 'neutral',
+      variant: 'outline',
+      class: 'border border-border text-foreground',
+    },
+    {
+      tone: 'neutral',
+      variant: 'ghost',
+      class: 'text-foreground hover:bg-accent hover:text-accent-foreground',
+    },
+
+    {
+      tone: 'primary',
+      variant: 'solid',
+      class: 'bg-primary text-primary-foreground',
+    },
+    {
+      tone: 'primary',
+      variant: 'soft',
+      class: 'bg-accent text-accent-foreground',
+    },
+    {
+      tone: 'primary',
+      variant: 'outline',
+      class: 'border border-primary text-primary',
+    },
+    {
+      tone: 'primary',
+      variant: 'ghost',
+      class: 'text-primary hover:bg-accent',
+    },
+
+    {
+      tone: 'success',
+      variant: 'solid',
+      class: 'bg-success text-success-foreground',
+    },
+    {
+      tone: 'success',
+      variant: 'soft',
+      class: 'bg-success-soft text-success',
+    },
+    {
+      tone: 'success',
+      variant: 'outline',
+      class: 'border border-success text-success',
+    },
+    {
+      tone: 'success',
+      variant: 'ghost',
+      class: 'text-success hover:bg-success-soft',
+    },
+
+    {
+      tone: 'warning',
+      variant: 'solid',
+      class: 'bg-warning text-warning-foreground',
+    },
+    {
+      tone: 'warning',
+      variant: 'soft',
+      class: 'bg-warning-soft text-warning',
+    },
+    {
+      tone: 'warning',
+      variant: 'outline',
+      class: 'border border-warning text-warning',
+    },
+    {
+      tone: 'warning',
+      variant: 'ghost',
+      class: 'text-warning hover:bg-warning-soft',
+    },
+
+    {
+      tone: 'danger',
+      variant: 'solid',
+      class: 'bg-danger text-danger-foreground',
+    },
+    { tone: 'danger', variant: 'soft', class: 'bg-danger/10 text-danger' },
+    {
+      tone: 'danger',
+      variant: 'outline',
+      class: 'border border-danger text-danger',
+    },
+    {
+      tone: 'danger',
+      variant: 'ghost',
+      class: 'text-danger hover:bg-danger/10',
+    },
+
+    { tone: 'info', variant: 'solid', class: 'bg-info text-info-foreground' },
+    {
+      tone: 'info',
+      variant: 'soft',
+      class: 'bg-info-soft text-info',
+    },
+    { tone: 'info', variant: 'outline', class: 'border border-info text-info' },
+    { tone: 'info', variant: 'ghost', class: 'text-info hover:bg-info-soft' },
+  ],
+  defaultVariants: {
+    tone: 'neutral',
+    variant: 'solid',
+  },
+});
+
+/**
+ * Foreground-only tone color, for text-bearing components that don't render
+ * a surface — Text, Icon, IndicatorDot.
+ */
+export const textTone = cva('', {
+  variants: {
+    tone: {
+      neutral: 'text-foreground',
+      primary: 'text-primary',
+      success: 'text-success',
+      warning: 'text-warning',
+      danger: 'text-danger',
+      info: 'text-info',
+    },
+  },
+  defaultVariants: {
+    tone: 'neutral',
+  },
+});

--- a/packages/ui/src/tokens/tone-variants.ts
+++ b/packages/ui/src/tokens/tone-variants.ts
@@ -1,4 +1,14 @@
 import { cva } from 'class-variance-authority';
+import type { Tone } from './tone';
+
+const toneKeys = {
+  neutral: '',
+  primary: '',
+  success: '',
+  warning: '',
+  danger: '',
+  info: '',
+} as const satisfies Record<Tone, string>;
 
 /**
  * Crosses `tone` with `variant` (solid | soft | outline | ghost) for
@@ -6,14 +16,7 @@ import { cva } from 'class-variance-authority';
  */
 export const surfaceTone = cva('', {
   variants: {
-    tone: {
-      neutral: '',
-      primary: '',
-      success: '',
-      warning: '',
-      danger: '',
-      info: '',
-    },
+    tone: toneKeys,
     variant: {
       solid: '',
       soft: '',
@@ -107,7 +110,7 @@ export const surfaceTone = cva('', {
       variant: 'solid',
       class: 'bg-danger text-danger-foreground',
     },
-    { tone: 'danger', variant: 'soft', class: 'bg-danger/10 text-danger' },
+    { tone: 'danger', variant: 'soft', class: 'bg-danger-soft text-danger' },
     {
       tone: 'danger',
       variant: 'outline',
@@ -116,7 +119,7 @@ export const surfaceTone = cva('', {
     {
       tone: 'danger',
       variant: 'ghost',
-      class: 'text-danger hover:bg-danger/10',
+      class: 'text-danger hover:bg-danger-soft',
     },
 
     { tone: 'info', variant: 'solid', class: 'bg-info text-info-foreground' },
@@ -147,7 +150,7 @@ export const textTone = cva('', {
       warning: 'text-warning',
       danger: 'text-danger',
       info: 'text-info',
-    },
+    } as const satisfies Record<Tone, string>,
   },
   defaultVariants: {
     tone: 'neutral',

--- a/packages/ui/src/tokens/tone.ts
+++ b/packages/ui/src/tokens/tone.ts
@@ -1,0 +1,1 @@
+export type Tone = 'neutral' | 'primary' | 'success' | 'warning' | 'danger' | 'info';

--- a/packages/ui/styles.css
+++ b/packages/ui/styles.css
@@ -22,6 +22,17 @@
   --color-accent-foreground: var(--accent-foreground);
   --color-destructive: var(--destructive);
   --color-destructive-foreground: var(--destructive-foreground);
+  --color-danger: var(--danger);
+  --color-danger-foreground: var(--danger-foreground);
+  --color-success: var(--success);
+  --color-success-foreground: var(--success-foreground);
+  --color-success-soft: var(--success-soft);
+  --color-warning: var(--warning);
+  --color-warning-foreground: var(--warning-foreground);
+  --color-warning-soft: var(--warning-soft);
+  --color-info: var(--info);
+  --color-info-foreground: var(--info-foreground);
+  --color-info-soft: var(--info-soft);
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
@@ -40,6 +51,9 @@
 }
 
 :root {
+  /* Square is by design, not a bug — see the Storybook tokens page. The
+     --radius-{sm,md,lg,xl} scale below stays wired so `rounded-*` remains a
+     live re-theming seam even while --radius is 0. */
   --radius: 0;
   --background: #ffffff;
   --foreground: #201f24;
@@ -57,6 +71,17 @@
   --accent-foreground: #201f24;
   --destructive: #fa7171;
   --destructive-foreground: #201f24;
+  --danger: var(--destructive);
+  --danger-foreground: var(--destructive-foreground);
+  --success: #15803d;
+  --success-foreground: #ffffff;
+  --success-soft: #16a34a1f;
+  --warning: #b45309;
+  --warning-foreground: #ffffff;
+  --warning-soft: #d977061f;
+  --info: #1d4ed8;
+  --info-foreground: #ffffff;
+  --info-soft: #2563eb1f;
   --border: #cfced5;
   --input: #cfced5;
   --ring: #8232ff;
@@ -87,6 +112,17 @@
   --accent-foreground: #ffffff;
   --destructive: #fa7171;
   --destructive-foreground: #201f24;
+  --danger: var(--destructive);
+  --danger-foreground: var(--destructive-foreground);
+  --success: #4ade80;
+  --success-foreground: #201f24;
+  --success-soft: #22c55e33;
+  --warning: #fbbf24;
+  --warning-foreground: #201f24;
+  --warning-soft: #f59e0b33;
+  --info: #60a5fa;
+  --info-foreground: #201f24;
+  --info-soft: #3b82f633;
   --border: #424145;
   --input: #424145;
   --ring: #8232ff;

--- a/packages/ui/styles.css
+++ b/packages/ui/styles.css
@@ -24,6 +24,7 @@
   --color-destructive-foreground: var(--destructive-foreground);
   --color-danger: var(--danger);
   --color-danger-foreground: var(--danger-foreground);
+  --color-danger-soft: var(--danger-soft);
   --color-success: var(--success);
   --color-success-foreground: var(--success-foreground);
   --color-success-soft: var(--success-soft);
@@ -73,6 +74,7 @@
   --destructive-foreground: #201f24;
   --danger: var(--destructive);
   --danger-foreground: var(--destructive-foreground);
+  --danger-soft: color-mix(in srgb, var(--destructive) 10%, transparent);
   --success: #15803d;
   --success-foreground: #ffffff;
   --success-soft: #16a34a1f;
@@ -114,6 +116,7 @@
   --destructive-foreground: #201f24;
   --danger: var(--destructive);
   --danger-foreground: var(--destructive-foreground);
+  --danger-soft: color-mix(in srgb, var(--destructive) 15%, transparent);
   --success: #4ade80;
   --success-foreground: #201f24;
   --success-soft: #22c55e33;


### PR DESCRIPTION
## Description

Adds the token layer for the `@rozenite/ui` design system roadmap (Phase 0 of `docs/agents/ui-design-system-plan.md`):

- New `success`, `warning`, and `info` tone tokens (`--<tone>`, `--<tone>-foreground`, `--<tone>-soft`) in `styles.css`, defined for both light and dark.
- A `--danger`/`--danger-foreground` alias for the existing `--destructive` pair (the eventual rename target for Phase 3).
- `src/tokens/tone.ts` exporting the `Tone` union.
- `src/tokens/size.ts` exporting the `Size` union and the height/padding/icon-size maps.
- `src/tokens/tone-variants.ts` exporting the `surfaceTone` and `textTone` cva recipes.
- A new Storybook "Foundations/Tokens" page rendering the full tone × variant matrix in both themes and documenting the square-by-design `--radius: 0` decision.

Purely additive — no existing component's className output or behavior changes.

## Related Issue

No open issue is linked to this PR.

## Context

This is the first of several phase-scoped PRs implementing the plan. Phase 0 exists because nothing later in the plan (new primitives, tone/emphasis split on Button/Badge/IndicatorDot) can be built cleanly until tone and size are real, exported tokens instead of per-component inventions — today only `destructive` exists as a tone, which is why several plugin helpers hand-roll `text-green-400` etc.

While building the tokens Storybook page, the accessibility panel initially flagged 20 color-contrast violations. Two real issues surfaced and were fixed: the `soft` variant was pairing white foreground text on a pale tint (nearly invisible), and the initial 400-level tone colors were too light for legible text/border use in light mode. Colors were adjusted so light mode uses darker, more saturated tones (matching the existing pattern of darker-for-light / lighter-for-dark), bringing violations down to a residual few borderline/pre-existing ones on this documentation-only page (the a11y check here is informational, `test: 'todo'`, non-blocking).

## Testing

- `pnpm --filter @rozenite/ui typecheck`
- `pnpm --filter @rozenite/ui lint`
- `pnpm --filter @rozenite/ui build`
- `pnpm --filter @rozenite/ui test` — 33 tests passed
- `cd apps/ui-storybook && npx tsc -b`
- `pnpm --filter ui-storybook lint`
- `pnpm lint:all` / `pnpm typecheck:all` (via the pre-push hook)
- Manual: ran `pnpm start:ui-storybook`, opened the new Foundations/Tokens story with `agent-browser`, and visually verified the tone × variant matrix in both light and dark panels, iterating on colors to reduce axe color-contrast violations.