### PR TITLE
feat(ui): add seven design system primitives (Phase 1)

### DIFF
--- a/.changeset/ui-design-system-phase-1-primitives.md
+++ b/.changeset/ui-design-system-phase-1-primitives.md
@@ -1,0 +1,5 @@
+---
+'@rozenite/ui': minor
+---
+
+Add seven new `@rozenite/ui` primitives: `Text`/`Heading` for typography, `Row`/`Column` for flex layout (including the `fill`+`scroll` idiom for scrollable panes), `Icon` for rendering any icon component at a shared size scale plus a curated lucide re-export, `IconButton` for a labelled, tooltip-carrying icon-only button, `Menu` for dropdown actions, `Alert` for tone-aware inline status strips, and `Kbd` for keyboard shortcut hints. All additive — no existing component's behavior changes.

--- a/apps/ui-storybook/src/stories/Alert.stories.tsx
+++ b/apps/ui-storybook/src/stories/Alert.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Alert } from '@rozenite/ui';
+
+const meta = {
+  component: Alert,
+  title: 'Components/Alert',
+  parameters: {
+    docs: {
+      description: {
+        component: 'A tone-aware strip for surfacing status, warnings, or errors inline.',
+      },
+    },
+  },
+} satisfies Meta<typeof Alert>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Compare every tone.
+ * @summary Compare every alert tone.
+ */
+export const AllTones: Story = {
+  render: () => (
+    <div className="flex flex-col gap-2">
+      <Alert tone="neutral">
+        <Alert.Description>A neutral, informational note.</Alert.Description>
+      </Alert>
+      <Alert tone="info">
+        <Alert.Title>Heads up</Alert.Title>
+        <Alert.Description>New data is available.</Alert.Description>
+      </Alert>
+      <Alert tone="success">
+        <Alert.Title>Saved</Alert.Title>
+        <Alert.Description>Your changes were saved.</Alert.Description>
+      </Alert>
+      <Alert tone="warning">
+        <Alert.Title>Careful</Alert.Title>
+        <Alert.Description>This action may be slow on large datasets.</Alert.Description>
+      </Alert>
+      <Alert tone="danger">
+        <Alert.Title>Connection lost</Alert.Title>
+        <Alert.Description>Reconnect to resume streaming events.</Alert.Description>
+      </Alert>
+    </div>
+  ),
+};

--- a/apps/ui-storybook/src/stories/Column.stories.tsx
+++ b/apps/ui-storybook/src/stories/Column.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Column } from '@rozenite/ui';
+
+const meta = {
+  component: Column,
+  title: 'Components/Column',
+  parameters: {
+    docs: {
+      description: {
+        component: 'A vertical flex layout primitive with gap, alignment, wrap, fill and scroll.',
+      },
+    },
+  },
+} satisfies Meta<typeof Column>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Compare gap and alignment options for stacking items in a column.
+ * @summary Compare gap and alignment options.
+ */
+export const AllVariants: Story = {
+  render: () => (
+    <Column gap={2} className="w-48">
+      <div className="bg-primary/20 px-3 py-2 text-xs">A</div>
+      <div className="bg-primary/20 px-3 py-2 text-xs">B</div>
+      <div className="bg-primary/20 px-3 py-2 text-xs">C</div>
+    </Column>
+  ),
+};
+
+/**
+ * `fill` + `scroll` encodes the `min-h-0 flex-1 overflow-auto` idiom for a
+ * scrollable column that must not grow past its container — the pattern
+ * currently re-derived at 14 sites across 9 packages.
+ * @summary Constrain a column to its container and let it scroll.
+ */
+export const FillAndScroll: Story = {
+  render: () => (
+    <Column gap={1} scroll fill className="h-40 w-48 border border-border p-2">
+      {Array.from({ length: 20 }, (_, i) => (
+        <div key={i} className="shrink-0 bg-primary/20 px-3 py-2 text-xs">
+          Item {i}
+        </div>
+      ))}
+    </Column>
+  ),
+};

--- a/apps/ui-storybook/src/stories/Icon.stories.tsx
+++ b/apps/ui-storybook/src/stories/Icon.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Icon, Search, Settings, Trash2, CheckCircle2 } from '@rozenite/ui';
+
+const meta = {
+  component: Icon,
+  title: 'Components/Icon',
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Renders any icon component at a size from the shared Size scale. Also re-exports a curated lucide set.',
+      },
+    },
+  },
+} satisfies Meta<typeof Icon>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Compare the icon at every size step.
+ * @summary Compare icon sizes.
+ */
+export const AllSizes: Story = {
+  args: { icon: Search },
+  render: () => (
+    <div className="flex items-center gap-3">
+      <Icon icon={Search} size="sm" />
+      <Icon icon={Search} size="md" />
+      <Icon icon={Search} size="lg" />
+    </div>
+  ),
+};
+
+/**
+ * `icon` accepts any `ComponentType`, including the curated lucide re-exports.
+ * @summary Compare a few of the curated lucide icons.
+ */
+export const CuratedIcons: Story = {
+  args: { icon: Settings },
+  render: () => (
+    <div className="flex items-center gap-3">
+      <Icon icon={Settings} />
+      <Icon icon={Trash2} />
+      <Icon icon={CheckCircle2} />
+    </div>
+  ),
+};

--- a/apps/ui-storybook/src/stories/IconButton.stories.tsx
+++ b/apps/ui-storybook/src/stories/IconButton.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { IconButton, Settings, Trash2 } from '@rozenite/ui';
+
+const meta = {
+  component: IconButton,
+  title: 'Components/IconButton',
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A square, icon-only button. `label` is required and doubles as the accessible name and the tooltip.',
+      },
+    },
+  },
+} satisfies Meta<typeof IconButton>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * `label` is required, so an unlabelled icon button is a type error. It is
+ * shown as the button's own tooltip on hover.
+ * @summary Every icon button is labelled and shows its own tooltip.
+ */
+export const AllVariants: Story = {
+  args: { label: 'Settings' },
+  render: () => (
+    <div className="flex items-center gap-2">
+      <IconButton label="Settings">
+        <Settings />
+      </IconButton>
+      <IconButton label="Delete" variant="destructive">
+        <Trash2 />
+      </IconButton>
+      <IconButton label="Settings" size="sm">
+        <Settings />
+      </IconButton>
+      <IconButton label="Settings" size="lg">
+        <Settings />
+      </IconButton>
+    </div>
+  ),
+};

--- a/apps/ui-storybook/src/stories/Kbd.stories.tsx
+++ b/apps/ui-storybook/src/stories/Kbd.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Kbd } from '@rozenite/ui';
+
+const meta = {
+  component: Kbd,
+  title: 'Components/Kbd',
+  parameters: {
+    docs: {
+      description: {
+        component: 'A styled keyboard key or shortcut hint.',
+      },
+    },
+  },
+} satisfies Meta<typeof Kbd>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Use to document a keyboard shortcut inline with other text.
+ * @summary Compose keys into a shortcut hint.
+ */
+export const Shortcut: Story = {
+  render: () => (
+    <div className="flex items-center gap-1 text-sm">
+      <span>Save with</span>
+      <Kbd>Ctrl</Kbd>
+      <span>+</span>
+      <Kbd>S</Kbd>
+    </div>
+  ),
+};

--- a/apps/ui-storybook/src/stories/Menu.stories.tsx
+++ b/apps/ui-storybook/src/stories/Menu.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Menu, Button } from '@rozenite/ui';
+
+const meta = {
+  component: Menu,
+  title: 'Components/Menu',
+  parameters: {
+    docs: {
+      description: {
+        component: 'A dropdown menu of actions, opened from a trigger.',
+      },
+    },
+  },
+} satisfies Meta<typeof Menu>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Use for a set of actions that do not warrant their own toolbar buttons.
+ * @summary Open a menu of actions from a trigger.
+ */
+export const Default: Story = {
+  render: () => (
+    <Menu>
+      <Menu.Trigger render={<Button variant="outline">Actions</Button>} />
+      <Menu.Content>
+        <Menu.Group>
+          <Menu.GroupLabel>Panel</Menu.GroupLabel>
+          <Menu.Item>Refresh</Menu.Item>
+          <Menu.Item>Export</Menu.Item>
+        </Menu.Group>
+        <Menu.Separator />
+        <Menu.Item>Clear all</Menu.Item>
+      </Menu.Content>
+    </Menu>
+  ),
+};

--- a/apps/ui-storybook/src/stories/Row.stories.tsx
+++ b/apps/ui-storybook/src/stories/Row.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Row } from '@rozenite/ui';
+
+const meta = {
+  component: Row,
+  title: 'Components/Row',
+  parameters: {
+    docs: {
+      description: {
+        component: 'A horizontal flex layout primitive with gap, alignment, wrap, fill and scroll.',
+      },
+    },
+  },
+} satisfies Meta<typeof Row>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Compare gap and alignment options for laying out items in a row.
+ * @summary Compare gap and alignment options.
+ */
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <Row gap={2}>
+        <div className="bg-primary/20 px-3 py-2 text-xs">A</div>
+        <div className="bg-primary/20 px-3 py-2 text-xs">B</div>
+        <div className="bg-primary/20 px-3 py-2 text-xs">C</div>
+      </Row>
+      <Row gap={4} justify="between" className="w-64">
+        <div className="bg-primary/20 px-3 py-2 text-xs">Left</div>
+        <div className="bg-primary/20 px-3 py-2 text-xs">Right</div>
+      </Row>
+    </div>
+  ),
+};
+
+/**
+ * `fill` + `scroll` encodes the `min-w-0 flex-1 overflow-auto` idiom for a
+ * row that must not grow past its container.
+ * @summary Constrain a row to its container and let it scroll.
+ */
+export const FillAndScroll: Story = {
+  render: () => (
+    <Row gap={2} scroll fill className="w-48 border border-border p-2">
+      {Array.from({ length: 20 }, (_, i) => (
+        <div key={i} className="shrink-0 bg-primary/20 px-3 py-2 text-xs">
+          Item {i}
+        </div>
+      ))}
+    </Row>
+  ),
+};

--- a/apps/ui-storybook/src/stories/Text.stories.tsx
+++ b/apps/ui-storybook/src/stories/Text.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Text, Heading } from '@rozenite/ui';
+
+const meta = {
+  component: Text,
+  title: 'Components/Text',
+  parameters: {
+    docs: {
+      description: {
+        component: 'Use Text for typography that is not a page or section heading.',
+      },
+    },
+  },
+} satisfies Meta<typeof Text>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Compare every type variant, plus `Heading` for semantic h1-h6 elements.
+ * @summary Compare every typography variant.
+ */
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex flex-col gap-2">
+      <Heading level={2}>Heading (h2)</Heading>
+      <Text variant="title">Title</Text>
+      <Text variant="heading">Heading</Text>
+      <Text variant="body">Body</Text>
+      <Text variant="caption">Caption</Text>
+      <Text variant="code">const x = 1;</Text>
+      <Text variant="numeric">1,024.50</Text>
+    </div>
+  ),
+};

--- a/packages/ui/src/alert/alert.tsx
+++ b/packages/ui/src/alert/alert.tsx
@@ -1,0 +1,45 @@
+import type { ComponentProps } from 'react';
+import { cn } from '../utils/cn';
+import { surfaceTone } from '../tokens/tone-variants';
+import type { Tone } from '../tokens/tone';
+
+export type AlertProps = ComponentProps<'div'> & {
+  /** @default 'neutral' */
+  tone?: Tone;
+};
+
+function AlertRoot({ tone = 'neutral', className, ...props }: AlertProps) {
+  return (
+    <div
+      role="alert"
+      data-slot="alert"
+      className={cn(
+        surfaceTone({
+          tone,
+          variant: 'soft',
+          class: 'flex items-start gap-2 rounded-md border border-current/15 p-3 text-sm',
+        }),
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export type AlertTitleProps = ComponentProps<'div'>;
+
+function AlertTitle({ className, ...props }: AlertTitleProps) {
+  return <div data-slot="alert-title" className={cn('font-medium', className)} {...props} />;
+}
+
+export type AlertDescriptionProps = ComponentProps<'div'>;
+
+function AlertDescription({ className, ...props }: AlertDescriptionProps) {
+  return <div data-slot="alert-description" className={cn('opacity-80', className)} {...props} />;
+}
+
+/** A tone-aware strip for surfacing status, warnings, or errors inline. */
+export const Alert = Object.assign(AlertRoot, {
+  Title: AlertTitle,
+  Description: AlertDescription,
+});

--- a/packages/ui/src/alert/alert.tsx
+++ b/packages/ui/src/alert/alert.tsx
@@ -11,13 +11,15 @@ export type AlertProps = ComponentProps<'div'> & {
 function AlertRoot({ tone = 'neutral', className, ...props }: AlertProps) {
   return (
     <div
-      role="alert"
+      // `danger` interrupts and needs an assertive announcement; other tones
+      // are informational and should announce politely, like `role="status"`.
+      role={tone === 'danger' ? 'alert' : 'status'}
       data-slot="alert"
       className={cn(
         surfaceTone({
           tone,
           variant: 'soft',
-          class: 'flex items-start gap-2 rounded-md border border-current/15 p-3 text-sm',
+          class: 'flex flex-col gap-1 rounded-md border border-current/15 p-3 text-sm',
         }),
         className,
       )}

--- a/packages/ui/src/column/column.tsx
+++ b/packages/ui/src/column/column.tsx
@@ -1,0 +1,53 @@
+import type { ComponentProps } from 'react';
+import { cn } from '../utils/cn';
+import {
+  flexAlignClass,
+  flexGapClass,
+  flexJustifyClass,
+  type FlexAlign,
+  type FlexGap,
+  type FlexJustify,
+} from '../utils/flex';
+
+export type ColumnProps = ComponentProps<'div'> & {
+  gap?: FlexGap;
+  align?: FlexAlign;
+  justify?: FlexJustify;
+  wrap?: boolean;
+  /** `min-h-0 flex-1` — take the remaining height without overflowing a flex column. */
+  fill?: boolean;
+  /** `overflow-auto`, typically paired with `fill`. */
+  scroll?: boolean;
+};
+
+/** A vertical flex layout primitive. */
+export function Column({
+  className,
+  gap,
+  align,
+  justify,
+  wrap,
+  fill,
+  scroll,
+  tabIndex,
+  ...props
+}: ColumnProps) {
+  return (
+    <div
+      data-slot="column"
+      // Keyboard-focusable when scrollable, so it's reachable without a mouse.
+      tabIndex={scroll ? (tabIndex ?? 0) : tabIndex}
+      className={cn(
+        'flex flex-col',
+        gap !== undefined && flexGapClass[gap],
+        align && flexAlignClass[align],
+        justify && flexJustifyClass[justify],
+        wrap && 'flex-wrap',
+        fill && 'min-h-0 flex-1',
+        scroll && 'overflow-auto',
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/packages/ui/src/column/column.tsx
+++ b/packages/ui/src/column/column.tsx
@@ -44,7 +44,7 @@ export function Column({
         justify && flexJustifyClass[justify],
         wrap && 'flex-wrap',
         fill && 'min-h-0 flex-1',
-        scroll && 'overflow-auto',
+        scroll && 'overflow-auto outline-none focus-visible:ring-2 focus-visible:ring-ring',
         className,
       )}
       {...props}

--- a/packages/ui/src/icon-button/icon-button.tsx
+++ b/packages/ui/src/icon-button/icon-button.tsx
@@ -3,17 +3,18 @@ import type { VariantProps } from 'class-variance-authority';
 import { buttonVariants } from '../button/button';
 import { cn } from '../utils/cn';
 import { Tooltip } from '../tooltip/tooltip';
+import type { Size } from '../tokens/size';
 
 const iconButtonSize = {
-  sm: 'size-6',
-  md: 'size-8',
-  lg: 'size-10',
-} as const;
+  sm: 'size-6 [&_svg]:size-3.5',
+  md: 'size-8 [&_svg]:size-4',
+  lg: 'size-10 [&_svg]:size-5',
+} as const satisfies Record<Size, string>;
 
 export type IconButtonProps = ComponentProps<'button'> &
   Pick<VariantProps<typeof buttonVariants>, 'variant'> & {
     /** @default 'md' */
-    size?: keyof typeof iconButtonSize;
+    size?: Size;
     /** Accessible name, also shown as the button's tooltip. An unlabelled icon button is a type error. */
     label: string;
   };

--- a/packages/ui/src/icon-button/icon-button.tsx
+++ b/packages/ui/src/icon-button/icon-button.tsx
@@ -1,0 +1,54 @@
+import type { ComponentProps } from 'react';
+import type { VariantProps } from 'class-variance-authority';
+import { buttonVariants } from '../button/button';
+import { cn } from '../utils/cn';
+import { Tooltip } from '../tooltip/tooltip';
+
+const iconButtonSize = {
+  sm: 'size-6',
+  md: 'size-8',
+  lg: 'size-10',
+} as const;
+
+export type IconButtonProps = ComponentProps<'button'> &
+  Pick<VariantProps<typeof buttonVariants>, 'variant'> & {
+    /** @default 'md' */
+    size?: keyof typeof iconButtonSize;
+    /** Accessible name, also shown as the button's tooltip. An unlabelled icon button is a type error. */
+    label: string;
+  };
+
+/** A square, icon-only button. Always labelled — `label` doubles as the
+ *  accessible name and the tooltip text. */
+export function IconButton({
+  className,
+  variant,
+  size = 'md',
+  label,
+  type = 'button',
+  children,
+  ...props
+}: IconButtonProps) {
+  return (
+    <Tooltip>
+      <Tooltip.Trigger
+        render={
+          <button
+            type={type}
+            aria-label={label}
+            data-slot="icon-button"
+            className={cn(
+              buttonVariants({ variant, size: 'icon' }),
+              iconButtonSize[size],
+              className,
+            )}
+            {...props}
+          >
+            {children}
+          </button>
+        }
+      />
+      <Tooltip.Content>{label}</Tooltip.Content>
+    </Tooltip>
+  );
+}

--- a/packages/ui/src/icon/icon.tsx
+++ b/packages/ui/src/icon/icon.tsx
@@ -1,20 +1,33 @@
 import type { ComponentType, SVGProps } from 'react';
 import { cn } from '../utils/cn';
 import { sizeIcon, type Size } from '../tokens/size';
+import { textTone } from '../tokens/tone-variants';
+import type { Tone } from '../tokens/tone';
 
 export type IconProps = SVGProps<SVGSVGElement> & {
   /** Any icon component, e.g. a curated re-export from this module or a one-off glyph. */
   icon: ComponentType<SVGProps<SVGSVGElement>>;
   /** @default 'md' */
   size?: Size;
+  /** Overrides the icon's inherited color. */
+  tone?: Tone;
 };
 
-/** Renders any icon component at a size from the shared `Size` scale. */
-export function Icon({ icon: IconComponent, size = 'md', className, ...props }: IconProps) {
+/** Renders any icon component at a size from the shared `Size` scale. Decorative
+ *  by default (`aria-hidden`) — set `aria-label` to make it accessible on its own. */
+export function Icon({
+  icon: IconComponent,
+  size = 'md',
+  tone,
+  className,
+  'aria-hidden': ariaHidden,
+  ...props
+}: IconProps) {
   return (
     <IconComponent
       data-slot="icon"
-      className={cn(sizeIcon[size], 'shrink-0', className)}
+      aria-hidden={ariaHidden ?? (props['aria-label'] ? undefined : true)}
+      className={cn(sizeIcon[size], 'shrink-0', tone && textTone({ tone }), className)}
       {...props}
     />
   );

--- a/packages/ui/src/icon/icon.tsx
+++ b/packages/ui/src/icon/icon.tsx
@@ -1,0 +1,45 @@
+import type { ComponentType, SVGProps } from 'react';
+import { cn } from '../utils/cn';
+import { sizeIcon, type Size } from '../tokens/size';
+
+export type IconProps = SVGProps<SVGSVGElement> & {
+  /** Any icon component, e.g. a curated re-export from this module or a one-off glyph. */
+  icon: ComponentType<SVGProps<SVGSVGElement>>;
+  /** @default 'md' */
+  size?: Size;
+};
+
+/** Renders any icon component at a size from the shared `Size` scale. */
+export function Icon({ icon: IconComponent, size = 'md', className, ...props }: IconProps) {
+  return (
+    <IconComponent
+      data-slot="icon"
+      className={cn(sizeIcon[size], 'shrink-0', className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  AlertTriangle,
+  ArrowLeft,
+  ArrowRight,
+  Check,
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  ChevronsUpDown,
+  Copy,
+  ExternalLink,
+  Info,
+  Minus,
+  MoreHorizontal,
+  MoreVertical,
+  Plus,
+  RefreshCw,
+  Search,
+  Settings,
+  Trash2,
+  X,
+  XCircle,
+} from 'lucide-react';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -5,6 +5,62 @@ export type { Size } from './tokens/size';
 export { sizeHeight, sizePaddingX, sizeIcon } from './tokens/size';
 export { surfaceTone, textTone } from './tokens/tone-variants';
 
+export { Text, Heading, textVariants } from './text/text';
+export type { TextProps, HeadingProps } from './text/text';
+
+export { Row } from './row/row';
+export type { RowProps } from './row/row';
+
+export { Column } from './column/column';
+export type { ColumnProps } from './column/column';
+
+export { Icon } from './icon/icon';
+export type { IconProps } from './icon/icon';
+export {
+  AlertTriangle,
+  ArrowLeft,
+  ArrowRight,
+  Check,
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  ChevronsUpDown,
+  Copy,
+  ExternalLink,
+  Info,
+  Minus,
+  MoreHorizontal,
+  MoreVertical,
+  Plus,
+  RefreshCw,
+  Search,
+  Settings,
+  Trash2,
+  X,
+  XCircle,
+} from './icon/icon';
+
+export { IconButton } from './icon-button/icon-button';
+export type { IconButtonProps } from './icon-button/icon-button';
+
+export { Menu } from './menu/menu';
+export type {
+  MenuProps,
+  MenuTriggerProps,
+  MenuContentProps,
+  MenuItemProps,
+  MenuCheckboxItemProps,
+  MenuSeparatorProps,
+  MenuGroupProps,
+  MenuGroupLabelProps,
+} from './menu/menu';
+
+export { Alert } from './alert/alert';
+export type { AlertProps, AlertTitleProps, AlertDescriptionProps } from './alert/alert';
+
+export { Kbd } from './kbd/kbd';
+export type { KbdProps } from './kbd/kbd';
+
 export { Split } from './split/split';
 export type {
   SplitDirection,

--- a/packages/ui/src/kbd/kbd.tsx
+++ b/packages/ui/src/kbd/kbd.tsx
@@ -1,0 +1,18 @@
+import type { ComponentProps } from 'react';
+import { cn } from '../utils/cn';
+
+export type KbdProps = ComponentProps<'kbd'>;
+
+/** A styled keyboard key or shortcut hint. */
+export function Kbd({ className, ...props }: KbdProps) {
+  return (
+    <kbd
+      data-slot="kbd"
+      className={cn(
+        'inline-flex h-5 min-w-5 items-center justify-center rounded-sm border border-border bg-muted px-1 font-mono text-[10px] font-medium text-muted-foreground',
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/packages/ui/src/kbd/kbd.tsx
+++ b/packages/ui/src/kbd/kbd.tsx
@@ -9,7 +9,7 @@ export function Kbd({ className, ...props }: KbdProps) {
     <kbd
       data-slot="kbd"
       className={cn(
-        'inline-flex h-5 min-w-5 items-center justify-center rounded-sm border border-border bg-muted px-1 font-mono text-[10px] font-medium text-muted-foreground',
+        'inline-flex h-5 min-w-5 items-center justify-center rounded-sm border border-border bg-muted px-1 font-mono text-xs font-medium text-muted-foreground',
         className,
       )}
       {...props}

--- a/packages/ui/src/menu/menu.tsx
+++ b/packages/ui/src/menu/menu.tsx
@@ -1,0 +1,128 @@
+import { Menu as MenuPrimitive } from '@base-ui/react/menu';
+import { Check } from 'lucide-react';
+import { cn } from '../utils/cn';
+import { usePluginPortalContainer } from '../theme/theme-context';
+
+export type MenuProps = MenuPrimitive.Root.Props;
+
+function MenuRoot(props: MenuProps) {
+  return <MenuPrimitive.Root {...props} />;
+}
+
+export type MenuTriggerProps = MenuPrimitive.Trigger.Props;
+
+function MenuTrigger(props: MenuTriggerProps) {
+  return <MenuPrimitive.Trigger data-slot="menu-trigger" {...props} />;
+}
+
+export type MenuContentProps = MenuPrimitive.Popup.Props &
+  Pick<MenuPrimitive.Positioner.Props, 'side' | 'sideOffset' | 'align'>;
+
+function MenuContent({
+  className,
+  side = 'bottom',
+  sideOffset = 4,
+  align = 'start',
+  children,
+  ...props
+}: MenuContentProps) {
+  const container = usePluginPortalContainer();
+
+  return (
+    <MenuPrimitive.Portal container={container}>
+      <MenuPrimitive.Positioner side={side} sideOffset={sideOffset} align={align} className="z-50">
+        <MenuPrimitive.Popup
+          data-slot="menu-content"
+          className={cn(
+            'min-w-40 overflow-y-auto rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md',
+            'origin-(--transform-origin) transition-[transform,scale,opacity] data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0',
+            className,
+          )}
+          {...props}
+        >
+          {children}
+        </MenuPrimitive.Popup>
+      </MenuPrimitive.Positioner>
+    </MenuPrimitive.Portal>
+  );
+}
+
+export type MenuItemProps = MenuPrimitive.Item.Props;
+
+function MenuItem({ className, ...props }: MenuItemProps) {
+  return (
+    <MenuPrimitive.Item
+      data-slot="menu-item"
+      className={cn(
+        'flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-foreground select-none',
+        'data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground',
+        'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export type MenuCheckboxItemProps = MenuPrimitive.CheckboxItem.Props;
+
+function MenuCheckboxItem({ className, children, ...props }: MenuCheckboxItemProps) {
+  return (
+    <MenuPrimitive.CheckboxItem
+      data-slot="menu-checkbox-item"
+      className={cn(
+        'flex cursor-default items-center justify-between gap-2 rounded-sm px-2 py-1.5 text-sm text-foreground select-none',
+        'data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground',
+        'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <MenuPrimitive.CheckboxItemIndicator>
+        <Check className="size-3.5" />
+      </MenuPrimitive.CheckboxItemIndicator>
+    </MenuPrimitive.CheckboxItem>
+  );
+}
+
+export type MenuSeparatorProps = MenuPrimitive.Separator.Props;
+
+function MenuSeparator({ className, ...props }: MenuSeparatorProps) {
+  return (
+    <MenuPrimitive.Separator
+      data-slot="menu-separator"
+      className={cn('-mx-1 my-1 h-px bg-border', className)}
+      {...props}
+    />
+  );
+}
+
+export type MenuGroupProps = MenuPrimitive.Group.Props;
+
+function MenuGroup(props: MenuGroupProps) {
+  return <MenuPrimitive.Group data-slot="menu-group" {...props} />;
+}
+
+export type MenuGroupLabelProps = MenuPrimitive.GroupLabel.Props;
+
+function MenuGroupLabel({ className, ...props }: MenuGroupLabelProps) {
+  return (
+    <MenuPrimitive.GroupLabel
+      data-slot="menu-group-label"
+      className={cn('px-2 py-1.5 text-xs font-medium text-muted-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+/** A dropdown menu of actions, opened from a trigger. */
+export const Menu = Object.assign(MenuRoot, {
+  Trigger: MenuTrigger,
+  Content: MenuContent,
+  Item: MenuItem,
+  CheckboxItem: MenuCheckboxItem,
+  Separator: MenuSeparator,
+  Group: MenuGroup,
+  GroupLabel: MenuGroupLabel,
+});

--- a/packages/ui/src/menu/menu.tsx
+++ b/packages/ui/src/menu/menu.tsx
@@ -6,7 +6,7 @@ import { usePluginPortalContainer } from '../theme/theme-context';
 export type MenuProps = MenuPrimitive.Root.Props;
 
 function MenuRoot(props: MenuProps) {
-  return <MenuPrimitive.Root {...props} />;
+  return <MenuPrimitive.Root data-slot="menu" {...props} />;
 }
 
 export type MenuTriggerProps = MenuPrimitive.Trigger.Props;
@@ -16,13 +16,14 @@ function MenuTrigger(props: MenuTriggerProps) {
 }
 
 export type MenuContentProps = MenuPrimitive.Popup.Props &
-  Pick<MenuPrimitive.Positioner.Props, 'side' | 'sideOffset' | 'align'>;
+  Pick<MenuPrimitive.Positioner.Props, 'side' | 'sideOffset' | 'align' | 'alignOffset'>;
 
 function MenuContent({
   className,
   side = 'bottom',
   sideOffset = 4,
   align = 'start',
+  alignOffset = 0,
   children,
   ...props
 }: MenuContentProps) {
@@ -30,11 +31,17 @@ function MenuContent({
 
   return (
     <MenuPrimitive.Portal container={container}>
-      <MenuPrimitive.Positioner side={side} sideOffset={sideOffset} align={align} className="z-50">
+      <MenuPrimitive.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        alignOffset={alignOffset}
+        className="z-50"
+      >
         <MenuPrimitive.Popup
           data-slot="menu-content"
           className={cn(
-            'min-w-40 overflow-y-auto rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md',
+            'max-h-(--available-height) min-w-40 overflow-y-auto rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md',
             'origin-(--transform-origin) transition-[transform,scale,opacity] data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0',
             className,
           )}

--- a/packages/ui/src/row/row.tsx
+++ b/packages/ui/src/row/row.tsx
@@ -44,7 +44,7 @@ export function Row({
         justify && flexJustifyClass[justify],
         wrap && 'flex-wrap',
         fill && 'min-w-0 flex-1',
-        scroll && 'overflow-auto',
+        scroll && 'overflow-auto outline-none focus-visible:ring-2 focus-visible:ring-ring',
         className,
       )}
       {...props}

--- a/packages/ui/src/row/row.tsx
+++ b/packages/ui/src/row/row.tsx
@@ -1,0 +1,53 @@
+import type { ComponentProps } from 'react';
+import { cn } from '../utils/cn';
+import {
+  flexAlignClass,
+  flexGapClass,
+  flexJustifyClass,
+  type FlexAlign,
+  type FlexGap,
+  type FlexJustify,
+} from '../utils/flex';
+
+export type RowProps = ComponentProps<'div'> & {
+  gap?: FlexGap;
+  align?: FlexAlign;
+  justify?: FlexJustify;
+  wrap?: boolean;
+  /** `min-w-0 flex-1` — take the remaining width without overflowing a flex row. */
+  fill?: boolean;
+  /** `overflow-auto`, typically paired with `fill`. */
+  scroll?: boolean;
+};
+
+/** A horizontal flex layout primitive. */
+export function Row({
+  className,
+  gap,
+  align,
+  justify,
+  wrap,
+  fill,
+  scroll,
+  tabIndex,
+  ...props
+}: RowProps) {
+  return (
+    <div
+      data-slot="row"
+      // Keyboard-focusable when scrollable, so it's reachable without a mouse.
+      tabIndex={scroll ? (tabIndex ?? 0) : tabIndex}
+      className={cn(
+        'flex flex-row',
+        gap !== undefined && flexGapClass[gap],
+        align && flexAlignClass[align],
+        justify && flexJustifyClass[justify],
+        wrap && 'flex-wrap',
+        fill && 'min-w-0 flex-1',
+        scroll && 'overflow-auto',
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/packages/ui/src/text/text.tsx
+++ b/packages/ui/src/text/text.tsx
@@ -1,6 +1,8 @@
 import type { ComponentProps, ElementType } from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '../utils/cn';
+import { textTone } from '../tokens/tone-variants';
+import type { Tone } from '../tokens/tone';
 
 export const textVariants = cva('text-foreground', {
   variants: {
@@ -18,11 +20,21 @@ export const textVariants = cva('text-foreground', {
   },
 });
 
-export type TextProps = ComponentProps<'span'> & VariantProps<typeof textVariants>;
+export type TextProps = ComponentProps<'span'> &
+  VariantProps<typeof textVariants> & {
+    /** Overrides the variant's default color. */
+    tone?: Tone;
+  };
 
 /** Typography for everything that isn't a page or section heading. */
-export function Text({ className, variant, ...props }: TextProps) {
-  return <span data-slot="text" className={cn(textVariants({ variant }), className)} {...props} />;
+export function Text({ className, variant, tone, ...props }: TextProps) {
+  return (
+    <span
+      data-slot="text"
+      className={cn(textVariants({ variant }), tone && textTone({ tone }), className)}
+      {...props}
+    />
+  );
 }
 
 const headingLevelTag = {
@@ -34,20 +46,37 @@ const headingLevelTag = {
   6: 'h6',
 } as const satisfies Record<number, ElementType>;
 
+const headingLevelClass = {
+  1: 'text-lg font-bold',
+  2: 'text-base font-semibold',
+  3: 'text-sm font-semibold',
+  4: 'text-sm font-medium',
+  5: 'text-xs font-semibold',
+  6: 'text-xs font-medium',
+} as const satisfies Record<1 | 2 | 3 | 4 | 5 | 6, string>;
+
 export type HeadingProps = ComponentProps<'h1'> & {
-  /** Which heading element to render.
+  /** Which heading element to render, and its type size.
    * @default 2 */
   level?: 1 | 2 | 3 | 4 | 5 | 6;
+  /** Overrides the default foreground color. */
+  tone?: Tone;
 };
 
-/** A semantic page or section heading, styled with the `title` type scale. */
-export function Heading({ level = 2, className, ...props }: HeadingProps) {
+/** A semantic page or section heading. `level` controls both the rendered
+ *  element (`h1`-`h6`) and its type size. */
+export function Heading({ level = 2, tone, className, ...props }: HeadingProps) {
   const Tag = headingLevelTag[level];
 
   return (
     <Tag
       data-slot="heading"
-      className={cn(textVariants({ variant: 'title' }), className)}
+      className={cn(
+        textVariants({ variant: 'title' }),
+        headingLevelClass[level],
+        tone && textTone({ tone }),
+        className,
+      )}
       {...props}
     />
   );

--- a/packages/ui/src/text/text.tsx
+++ b/packages/ui/src/text/text.tsx
@@ -1,0 +1,54 @@
+import type { ComponentProps, ElementType } from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '../utils/cn';
+
+export const textVariants = cva('text-foreground', {
+  variants: {
+    variant: {
+      title: 'text-base font-semibold',
+      heading: 'text-sm font-semibold',
+      body: 'text-sm font-normal',
+      caption: 'text-xs text-muted-foreground',
+      code: 'font-mono text-xs',
+      numeric: 'font-mono text-xs tabular-nums',
+    },
+  },
+  defaultVariants: {
+    variant: 'body',
+  },
+});
+
+export type TextProps = ComponentProps<'span'> & VariantProps<typeof textVariants>;
+
+/** Typography for everything that isn't a page or section heading. */
+export function Text({ className, variant, ...props }: TextProps) {
+  return <span data-slot="text" className={cn(textVariants({ variant }), className)} {...props} />;
+}
+
+const headingLevelTag = {
+  1: 'h1',
+  2: 'h2',
+  3: 'h3',
+  4: 'h4',
+  5: 'h5',
+  6: 'h6',
+} as const satisfies Record<number, ElementType>;
+
+export type HeadingProps = ComponentProps<'h1'> & {
+  /** Which heading element to render.
+   * @default 2 */
+  level?: 1 | 2 | 3 | 4 | 5 | 6;
+};
+
+/** A semantic page or section heading, styled with the `title` type scale. */
+export function Heading({ level = 2, className, ...props }: HeadingProps) {
+  const Tag = headingLevelTag[level];
+
+  return (
+    <Tag
+      data-slot="heading"
+      className={cn(textVariants({ variant: 'title' }), className)}
+      {...props}
+    />
+  );
+}

--- a/packages/ui/src/utils/flex.ts
+++ b/packages/ui/src/utils/flex.ts
@@ -1,0 +1,30 @@
+export const flexGapClass = {
+  0: 'gap-0',
+  1: 'gap-1',
+  2: 'gap-2',
+  3: 'gap-3',
+  4: 'gap-4',
+  6: 'gap-6',
+  8: 'gap-8',
+} as const;
+
+export const flexAlignClass = {
+  start: 'items-start',
+  center: 'items-center',
+  end: 'items-end',
+  stretch: 'items-stretch',
+  baseline: 'items-baseline',
+} as const;
+
+export const flexJustifyClass = {
+  start: 'justify-start',
+  center: 'justify-center',
+  end: 'justify-end',
+  between: 'justify-between',
+  around: 'justify-around',
+  evenly: 'justify-evenly',
+} as const;
+
+export type FlexGap = keyof typeof flexGapClass;
+export type FlexAlign = keyof typeof flexAlignClass;
+export type FlexJustify = keyof typeof flexJustifyClass;


### PR DESCRIPTION
## Description

Stacked on #419 (Phase 0 tokens). Adds Phase 1 of `docs/agents/ui-design-system-plan.md`: seven new `@rozenite/ui` primitives, each in its own name-matched folder with a Storybook story.

- `Text` + `Heading` — collapses ad-hoc typography strings into `title` / `heading` / `body` / `caption` / `code` / `numeric` variants; `Heading` renders semantic `h1`-`h6`.
- `Row` / `Column` — flex layout primitives with `gap`, `align`, `justify`, `wrap`, and the `fill`+`scroll` idiom (`min-{w,h}-0 flex-1 overflow-auto`) for scrollable panes, currently re-derived at 14 sites across 9 packages.
- `Icon` — renders any icon component at a size from the shared `Size` scale, plus a curated `lucide-react` re-export.
- `IconButton` — a square, icon-only button with a **required** `label` prop (an unlabelled icon button is a type error) that doubles as the accessible name and its own tooltip.
- `Menu` — built on Base UI's `Menu` primitive; a genuine gap today (`network-activity` reaches for raw Radix + `@floating-ui/react` because nothing exists).
- `Alert` — a tone-aware strip built on `surfaceTone` from Phase 0, replacing ad-hoc rose-toned strips.
- `Kbd` — a styled keyboard key/shortcut hint.

All additive — no existing component's behavior changes.

## Related Issue

No open issue is linked to this PR.

## Context

Building each primitive in Storybook and testing interactively with `agent-browser` surfaced two real bugs, both fixed here:

- The `Menu` story initially placed `Menu.GroupLabel` as a sibling of `Menu.Group` instead of nested inside it, which Base UI rejects at runtime (`MenuGroupContext is missing`) — fixed by nesting it correctly, which is also the only valid usage, so this only affected the story, not the component.
- `Row`/`Column` with `scroll` rendered a `div` with `overflow-auto` but no way to reach it by keyboard, tripping axe's `scrollable-region-focusable` rule. Fixed by giving the scrollable variant `tabIndex={0}` by default (still overridable via an explicit `tabIndex` prop).

## Testing

- `pnpm --filter @rozenite/ui typecheck`
- `pnpm --filter @rozenite/ui lint`
- `pnpm --filter @rozenite/ui build`
- `pnpm --filter @rozenite/ui test` — 33 tests passed
- `cd apps/ui-storybook && npx tsc -b`
- `pnpm --filter ui-storybook lint`
- `pnpm lint:all` / `pnpm typecheck:all` (via the pre-push hook)
- Manual: ran `pnpm start:ui-storybook` and drove each new story with `agent-browser` — opened the `Menu` dropdown, hovered an `IconButton` to confirm its tooltip and accessible name, checked `Alert` tones render with sufficient contrast in the ambient plugin theme, and confirmed the `Column`/`Row` `FillAndScroll` stories go from 1 accessibility violation to 0 after the `tabIndex` fix.