### PR TITLE
feat(ui): add useConfirmDialog and migrate plugin panels to it

### DIFF
--- a/.changeset/imperative-confirm-dialog.md
+++ b/.changeset/imperative-confirm-dialog.md
@@ -1,0 +1,10 @@
+---
+'@rozenite/feature-flags-plugin': minor
+'@rozenite/storage-plugin': minor
+'@rozenite/rhf-plugin': minor
+'@rozenite/ui': minor
+---
+
+Add `useConfirmDialog()` to `@rozenite/ui`: an imperative alternative to `ConfirmDialog` that resolves a promise with the user's choice instead of driving `open` from local state. `PluginShell` now mounts `Toast` and `ConfirmDialog.Provider` automatically, so plugin panels no longer need to wrap themselves in `<Toast.Provider>` to use `useToast()`.
+
+Migrate the feature-flags, storage, and React Hook Form DevTools panels to `useConfirmDialog()`, replacing their declarative confirm/alert dialogs.

--- a/apps/ui-storybook/src/stories/ConfirmDialog.stories.tsx
+++ b/apps/ui-storybook/src/stories/ConfirmDialog.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Button } from '@rozenite/ui';
+import { useState } from 'react';
+import { Button, useConfirmDialog } from '@rozenite/ui';
 import { ConfirmDialog } from '@rozenite/ui';
 const meta = {
   component: ConfirmDialog,
@@ -17,5 +18,42 @@ export const Open: Story = {
       <Button>Trigger is represented by the open dialog</Button>
       <ConfirmDialog {...args} description="This action cannot be undone." tone="danger" />
     </>
+  ),
+};
+
+function ImperativeDemo() {
+  const confirm = useConfirmDialog();
+  const [result, setResult] = useState<string | null>(null);
+  return (
+    <div className="flex flex-col items-start gap-2">
+      <Button
+        tone="danger"
+        onClick={async () => {
+          const confirmed = await confirm({
+            title: 'Delete project?',
+            description: 'This action cannot be undone.',
+            tone: 'danger',
+            confirmLabel: 'Delete',
+          });
+          setResult(confirmed ? 'Confirmed' : 'Cancelled');
+        }}
+      >
+        Delete project
+      </Button>
+      {result && <span className="text-sm text-muted-foreground">{result}</span>}
+    </div>
+  );
+}
+/** `useConfirmDialog()` resolves a promise with the user's choice instead of
+ * driving `open` from local state — `PluginShell` mounts `ConfirmDialog.Provider`
+ * automatically, so plugin panels only need the hook.
+ * @summary Confirm imperatively with `useConfirmDialog()`.
+ */
+export const Imperative: Story = {
+  args: { open: false, onOpenChange: () => undefined, title: 'Delete project?' },
+  render: () => (
+    <ConfirmDialog.Provider>
+      <ImperativeDemo />
+    </ConfirmDialog.Provider>
   ),
 };

--- a/packages/feature-flags-plugin/src/ui/panel.tsx
+++ b/packages/feature-flags-plugin/src/ui/panel.tsx
@@ -266,7 +266,7 @@ function FeatureFlagsPanelContent() {
   );
 
   return (
-    <PluginShell>
+    <>
       <PluginShell.Body>
         {!connected || isLoading ? (
           <EmptyState
@@ -333,14 +333,16 @@ function FeatureFlagsPanelContent() {
           return handleSetOverride(jsonDialogFlag, value);
         }}
       />
-    </PluginShell>
+    </>
   );
 }
 
 export default function FeatureFlagsPanel() {
   return (
     <FeatureFlagsQueryClientProvider>
-      <FeatureFlagsPanelContent />
+      <PluginShell>
+        <FeatureFlagsPanelContent />
+      </PluginShell>
     </FeatureFlagsQueryClientProvider>
   );
 }

--- a/packages/feature-flags-plugin/src/ui/panel.tsx
+++ b/packages/feature-flags-plugin/src/ui/panel.tsx
@@ -1,15 +1,14 @@
 import type { ColumnDef } from '@tanstack/react-table';
 import {
   Badge,
-  ConfirmDialog,
   EmptyState,
   IconButton,
   PluginShell,
   SearchField,
   Sidebar,
   Split,
-  Toast,
   Toolbar,
+  useConfirmDialog,
   useToast,
   VirtualizedDataTable,
 } from '@rozenite/ui';
@@ -47,12 +46,12 @@ function FeatureFlagsPanelContent() {
     refresh,
   } = useFeatureFlags();
   const toast = useToast();
+  const confirm = useConfirmDialog();
   const providers = snapshot?.providers ?? [];
   const [selectedProviderId, setSelectedProviderId] = useState<string | null>(null);
   const [search, setSearch] = useState('');
   const [overriddenOnly, setOverriddenOnly] = useState(false);
   const [jsonDialogKey, setJsonDialogKey] = useState<string | null>(null);
-  const [showResetAllDialog, setShowResetAllDialog] = useState(false);
 
   useEffect(() => {
     setSelectedProviderId((current) =>
@@ -97,9 +96,15 @@ function FeatureFlagsPanelContent() {
     }
   };
 
-  const handleClearAllOverrides = async () => {
+  const handleResetAllClick = async () => {
     if (!selectedProvider) return;
-    setShowResetAllDialog(false);
+    const confirmed = await confirm({
+      title: 'Reset all overrides',
+      description: `Are you sure you want to clear every override for "${selectedProvider.name}"? This action cannot be undone.`,
+      tone: 'danger',
+      confirmLabel: 'Reset all',
+    });
+    if (!confirmed) return;
     try {
       await clearAllOverrides(selectedProvider.id);
     } catch (error) {
@@ -232,7 +237,7 @@ function FeatureFlagsPanelContent() {
       <Toolbar.Separator />
       <Toolbar.Group>
         <Toolbar.Button
-          onClick={() => setShowResetAllDialog(true)}
+          onClick={() => void handleResetAllClick()}
           disabled={!connected || !selectedProvider || !hasOverrides}
           aria-label="Reset all overrides"
           title="Reset all overrides"
@@ -328,20 +333,6 @@ function FeatureFlagsPanelContent() {
           return handleSetOverride(jsonDialogFlag, value);
         }}
       />
-      <ConfirmDialog
-        open={showResetAllDialog}
-        onOpenChange={setShowResetAllDialog}
-        variant="confirm"
-        tone="danger"
-        title="Reset all overrides"
-        description={
-          selectedProvider
-            ? `Are you sure you want to clear every override for "${selectedProvider.name}"? This action cannot be undone.`
-            : undefined
-        }
-        confirmLabel="Reset all"
-        onConfirm={handleClearAllOverrides}
-      />
     </PluginShell>
   );
 }
@@ -349,9 +340,7 @@ function FeatureFlagsPanelContent() {
 export default function FeatureFlagsPanel() {
   return (
     <FeatureFlagsQueryClientProvider>
-      <Toast.Provider>
-        <FeatureFlagsPanelContent />
-      </Toast.Provider>
+      <FeatureFlagsPanelContent />
     </FeatureFlagsQueryClientProvider>
   );
 }

--- a/packages/rhf-plugin/src/ui/panel.tsx
+++ b/packages/rhf-plugin/src/ui/panel.tsx
@@ -1,14 +1,13 @@
 import { useRozeniteDevToolsClient } from '@rozenite/plugin-bridge';
 import {
   Badge,
-  ConfirmDialog,
   EmptyState,
   PluginShell,
   SearchField,
   Sidebar,
   Split,
-  Toast,
   Toolbar,
+  useConfirmDialog,
   useToast,
 } from '@rozenite/ui';
 import { useEffect, useMemo, useState } from 'react';
@@ -205,9 +204,9 @@ function ReactHookFormPanelContent() {
   const [selectedFormId, setSelectedFormId] = useState<string | null>(null);
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedFieldName, setSelectedFieldName] = useState<string | null>(null);
-  const [showResetConfirm, setShowResetConfirm] = useState(false);
 
   const toast = useToast();
+  const confirm = useConfirmDialog();
   const client = useRozeniteDevToolsClient<RHFEventMap>({
     pluginId: PLUGIN_ID,
   });
@@ -273,9 +272,15 @@ function ReactHookFormPanelContent() {
 
   const canResetForm = Boolean(selectedFormId) && !staleIds.has(selectedFormId ?? '');
 
-  const handleResetForm = async () => {
+  const handleResetFormClick = async () => {
     if (!client || !selectedFormId) return;
-    setShowResetConfirm(false);
+    const confirmed = await confirm({
+      title: 'Reset Form',
+      description: `Are you sure you want to reset "${selectedFormId}" to its default values? This action cannot be undone.`,
+      tone: 'danger',
+      confirmLabel: 'Reset',
+    });
+    if (!confirmed) return;
     try {
       await client.request({
         requestType: 'reset-form',
@@ -332,7 +337,7 @@ function ReactHookFormPanelContent() {
                 <Toolbar>
                   <Toolbar.Group>
                     <Toolbar.Button
-                      onClick={() => setShowResetConfirm(true)}
+                      onClick={() => void handleResetFormClick()}
                       disabled={!canResetForm}
                       aria-label="Reset form"
                       title="Reset form"
@@ -403,29 +408,10 @@ function ReactHookFormPanelContent() {
         name={selectedFieldName}
         snapshot={selectedSnapshot}
       />
-
-      <ConfirmDialog
-        open={showResetConfirm}
-        onOpenChange={setShowResetConfirm}
-        variant="confirm"
-        tone="danger"
-        title="Reset Form"
-        description={
-          selectedFormId
-            ? `Are you sure you want to reset "${selectedFormId}" to its default values? This action cannot be undone.`
-            : undefined
-        }
-        confirmLabel="Reset"
-        onConfirm={handleResetForm}
-      />
     </PluginShell>
   );
 }
 
 export default function ReactHookFormPanel() {
-  return (
-    <Toast.Provider>
-      <ReactHookFormPanelContent />
-    </Toast.Provider>
-  );
+  return <ReactHookFormPanelContent />;
 }

--- a/packages/rhf-plugin/src/ui/panel.tsx
+++ b/packages/rhf-plugin/src/ui/panel.tsx
@@ -298,7 +298,7 @@ function ReactHookFormPanelContent() {
   };
 
   return (
-    <PluginShell>
+    <>
       <PluginShell.Body>
         <Split direction="horizontal" autoSaveId="rhf">
           <Split.Pane defaultSize={22} minSize={15} maxSize={40}>
@@ -408,10 +408,14 @@ function ReactHookFormPanelContent() {
         name={selectedFieldName}
         snapshot={selectedSnapshot}
       />
-    </PluginShell>
+    </>
   );
 }
 
 export default function ReactHookFormPanel() {
-  return <ReactHookFormPanelContent />;
+  return (
+    <PluginShell>
+      <ReactHookFormPanelContent />
+    </PluginShell>
+  );
 }

--- a/packages/storage-plugin/src/ui/__tests__/panel.test.tsx
+++ b/packages/storage-plugin/src/ui/__tests__/panel.test.tsx
@@ -109,6 +109,7 @@ vi.mock('@rozenite/ui', async () => {
     ConfirmDialog: () => null,
     EmptyState: () => <div />,
     PluginShell,
+    useConfirmDialog: () => async () => true,
     SearchField: ({
       value,
       onChange,

--- a/packages/storage-plugin/src/ui/add-entry-dialog.tsx
+++ b/packages/storage-plugin/src/ui/add-entry-dialog.tsx
@@ -1,4 +1,4 @@
-import { Button, ConfirmDialog, Dialog, Field, Input } from '@rozenite/ui';
+import { Button, Dialog, Field, Input, useConfirmDialog } from '@rozenite/ui';
 import { useEffect, useState } from 'react';
 import type { StorageEntry, StorageEntryType, StorageEntryValue } from '../shared/types';
 import { TypedValueEditor } from './typed-value-editor';
@@ -45,7 +45,7 @@ export const AddEntryDialog = ({
   const [currentValue, setCurrentValue] = useState<StorageEntryValue | null>(
     defaultValueForType(initialType),
   );
-  const [alert, setAlert] = useState<{ title: string; message: string } | null>(null);
+  const confirm = useConfirmDialog();
 
   // Reset state every time the dialog opens, so a previous session's
   // type / value doesn't bleed in.
@@ -66,21 +66,23 @@ export const AddEntryDialog = ({
     onClose();
   };
 
-  const handleAdd = () => {
+  const handleAdd = async () => {
     if (!newEntryKey.trim() || currentValue === null) return;
 
     if (!isCurrentTypeSupported) {
-      setAlert({
+      await confirm({
+        variant: 'alert',
         title: 'Unsupported Type',
-        message: 'Selected type is not supported by this storage.',
+        description: 'Selected type is not supported by this storage.',
       });
       return;
     }
 
     if (existingKeys.includes(newEntryKey)) {
-      setAlert({
+      await confirm({
+        variant: 'alert',
         title: 'Key Already Exists',
-        message: 'An entry with this key already exists.',
+        description: 'An entry with this key already exists.',
       });
       return;
     }
@@ -91,7 +93,7 @@ export const AddEntryDialog = ({
 
   const handleKeyDown = (event: React.KeyboardEvent) => {
     if (event.key === 'Enter' && newEntryKey.trim() && currentType !== 'buffer') {
-      handleAdd();
+      void handleAdd();
     }
   };
 
@@ -100,70 +102,58 @@ export const AddEntryDialog = ({
   const isAddDisabled = !newEntryKey.trim() || !isCurrentTypeSupported || currentValue === null;
 
   return (
-    <>
-      <Dialog
-        open={isOpen}
-        onOpenChange={(open) => {
-          if (!open) resetAndClose();
-        }}
-      >
-        <Dialog.Content onKeyDown={handleKeyDown}>
-          <Dialog.Header>
-            <Dialog.Title>Add New Entry</Dialog.Title>
-          </Dialog.Header>
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) resetAndClose();
+      }}
+    >
+      <Dialog.Content onKeyDown={handleKeyDown}>
+        <Dialog.Header>
+          <Dialog.Title>Add New Entry</Dialog.Title>
+        </Dialog.Header>
 
-          <div className="flex flex-col gap-4">
-            <Field>
-              <Field.Label htmlFor="new-entry-key">Key</Field.Label>
-              <Input
-                id="new-entry-key"
-                value={newEntryKey}
-                onChange={(event) => setNewEntryKey(event.target.value)}
-                placeholder="Enter key name"
-                autoFocus
-              />
-            </Field>
+        <div className="flex flex-col gap-4">
+          <Field>
+            <Field.Label htmlFor="new-entry-key">Key</Field.Label>
+            <Input
+              id="new-entry-key"
+              value={newEntryKey}
+              onChange={(event) => setNewEntryKey(event.target.value)}
+              placeholder="Enter key name"
+              autoFocus
+            />
+          </Field>
 
-            <Field>
-              <Field.Label htmlFor="new-entry-value">Value</Field.Label>
-              <TypedValueEditor
-                supportedTypes={supportedTypes}
-                type={currentType}
-                value={currentValue}
-                onChange={(nextType, nextValue) => {
-                  setCurrentType(nextType);
-                  setCurrentValue(nextValue);
-                }}
-                inputId="new-entry-value"
-              />
-              {!isCurrentTypeSupported && (
-                <Field.Description className="text-danger">
-                  Selected type is not supported by this storage.
-                </Field.Description>
-              )}
-            </Field>
-          </div>
+          <Field>
+            <Field.Label htmlFor="new-entry-value">Value</Field.Label>
+            <TypedValueEditor
+              supportedTypes={supportedTypes}
+              type={currentType}
+              value={currentValue}
+              onChange={(nextType, nextValue) => {
+                setCurrentType(nextType);
+                setCurrentValue(nextValue);
+              }}
+              inputId="new-entry-value"
+            />
+            {!isCurrentTypeSupported && (
+              <Field.Description className="text-danger">
+                Selected type is not supported by this storage.
+              </Field.Description>
+            )}
+          </Field>
+        </div>
 
-          <Dialog.Footer>
-            <Button tone="neutral" variant="outline" onClick={resetAndClose}>
-              Cancel
-            </Button>
-            <Button onClick={handleAdd} disabled={isAddDisabled}>
-              Add Entry
-            </Button>
-          </Dialog.Footer>
-        </Dialog.Content>
-      </Dialog>
-
-      <ConfirmDialog
-        open={alert !== null}
-        onOpenChange={(open) => {
-          if (!open) setAlert(null);
-        }}
-        variant="alert"
-        title={alert?.title ?? ''}
-        description={alert?.message}
-      />
-    </>
+        <Dialog.Footer>
+          <Button tone="neutral" variant="outline" onClick={resetAndClose}>
+            Cancel
+          </Button>
+          <Button onClick={() => void handleAdd()} disabled={isAddDisabled}>
+            Add Entry
+          </Button>
+        </Dialog.Footer>
+      </Dialog.Content>
+    </Dialog>
   );
 };

--- a/packages/storage-plugin/src/ui/edit-entry-dialog.tsx
+++ b/packages/storage-plugin/src/ui/edit-entry-dialog.tsx
@@ -1,4 +1,4 @@
-import { Button, ConfirmDialog, Dialog, Field } from '@rozenite/ui';
+import { Button, Dialog, Field, useConfirmDialog } from '@rozenite/ui';
 import { useEffect, useRef, useState } from 'react';
 import type { StorageEntry, StorageEntryType, StorageEntryValue } from '../shared/types';
 import { TypedValueEditor } from './typed-value-editor';
@@ -28,7 +28,7 @@ export const EditEntryDialog = ({
   const [currentValue, setCurrentValue] = useState<StorageEntryValue | null>(
     defaultValueForType('string'),
   );
-  const [alert, setAlert] = useState<{ title: string; message: string } | null>(null);
+  const confirm = useConfirmDialog();
 
   useEffect(() => {
     if (entry && isOpen) {
@@ -48,13 +48,14 @@ export const EditEntryDialog = ({
     onClose();
   };
 
-  const handleSave = () => {
+  const handleSave = async () => {
     if (!entry || currentValue === null) return;
 
     if (!isCurrentTypeSupported) {
-      setAlert({
+      await confirm({
+        variant: 'alert',
         title: 'Unsupported Type',
-        message: 'This storage does not support the selected type.',
+        description: 'This storage does not support the selected type.',
       });
       return;
     }
@@ -65,7 +66,7 @@ export const EditEntryDialog = ({
 
   const handleKeyDown = (event: React.KeyboardEvent) => {
     if (event.key === 'Enter' && currentType !== 'buffer') {
-      handleSave();
+      void handleSave();
     }
   };
 
@@ -79,69 +80,57 @@ export const EditEntryDialog = ({
   const isSaveDisabled = !isCurrentTypeSupported || currentValue === null;
 
   return (
-    <>
-      <Dialog
-        open={isOpen}
-        onOpenChange={(open) => {
-          if (!open) resetAndClose();
-        }}
-      >
-        <Dialog.Content onKeyDown={handleKeyDown}>
-          <Dialog.Header>
-            <Dialog.Title>Edit Entry</Dialog.Title>
-          </Dialog.Header>
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) resetAndClose();
+      }}
+    >
+      <Dialog.Content onKeyDown={handleKeyDown}>
+        <Dialog.Header>
+          <Dialog.Title>Edit Entry</Dialog.Title>
+        </Dialog.Header>
 
-          <div className="flex flex-col gap-4">
-            <Field>
-              <Field.Label>Key</Field.Label>
-              <div className="h-8 w-full truncate rounded-md border border-input bg-muted px-3 py-1.5 font-mono text-sm text-foreground">
-                {entryForDisplay.key}
-              </div>
-              <Field.Description>Key cannot be changed during editing</Field.Description>
-            </Field>
+        <div className="flex flex-col gap-4">
+          <Field>
+            <Field.Label>Key</Field.Label>
+            <div className="h-8 w-full truncate rounded-md border border-input bg-muted px-3 py-1.5 font-mono text-sm text-foreground">
+              {entryForDisplay.key}
+            </div>
+            <Field.Description>Key cannot be changed during editing</Field.Description>
+          </Field>
 
-            <Field>
-              <Field.Label htmlFor="edit-entry-value">Value</Field.Label>
-              <TypedValueEditor
-                key={entryForDisplay.key}
-                supportedTypes={supportedTypes}
-                type={currentType}
-                value={currentValue}
-                onChange={(nextType, nextValue) => {
-                  setCurrentType(nextType);
-                  setCurrentValue(nextValue);
-                }}
-                inputId="edit-entry-value"
-                autoFocus
-              />
-              {!isCurrentTypeSupported && (
-                <Field.Description className="text-danger">
-                  This storage does not support {currentType} values.
-                </Field.Description>
-              )}
-            </Field>
-          </div>
+          <Field>
+            <Field.Label htmlFor="edit-entry-value">Value</Field.Label>
+            <TypedValueEditor
+              key={entryForDisplay.key}
+              supportedTypes={supportedTypes}
+              type={currentType}
+              value={currentValue}
+              onChange={(nextType, nextValue) => {
+                setCurrentType(nextType);
+                setCurrentValue(nextValue);
+              }}
+              inputId="edit-entry-value"
+              autoFocus
+            />
+            {!isCurrentTypeSupported && (
+              <Field.Description className="text-danger">
+                This storage does not support {currentType} values.
+              </Field.Description>
+            )}
+          </Field>
+        </div>
 
-          <Dialog.Footer>
-            <Button tone="neutral" variant="outline" onClick={resetAndClose}>
-              Cancel
-            </Button>
-            <Button onClick={handleSave} disabled={isSaveDisabled}>
-              Save Changes
-            </Button>
-          </Dialog.Footer>
-        </Dialog.Content>
-      </Dialog>
-
-      <ConfirmDialog
-        open={alert !== null}
-        onOpenChange={(open) => {
-          if (!open) setAlert(null);
-        }}
-        variant="alert"
-        title={alert?.title ?? ''}
-        description={alert?.message}
-      />
-    </>
+        <Dialog.Footer>
+          <Button tone="neutral" variant="outline" onClick={resetAndClose}>
+            Cancel
+          </Button>
+          <Button onClick={() => void handleSave()} disabled={isSaveDisabled}>
+            Save Changes
+          </Button>
+        </Dialog.Footer>
+      </Dialog.Content>
+    </Dialog>
   );
 };

--- a/packages/storage-plugin/src/ui/panel.tsx
+++ b/packages/storage-plugin/src/ui/panel.tsx
@@ -3,7 +3,6 @@ import type { ColumnDef, OnChangeFn, SortingState } from '@tanstack/react-table'
 import { useRozeniteDevToolsClient } from '@rozenite/plugin-bridge';
 import {
   Badge,
-  ConfirmDialog,
   EmptyState,
   IconButton,
   PluginShell,
@@ -11,6 +10,7 @@ import {
   Sidebar,
   Split,
   Toolbar,
+  useConfirmDialog,
   VirtualizedDataTable,
 } from '@rozenite/ui';
 import { useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react';
@@ -48,7 +48,6 @@ import {
 import { buildExportFilename, downloadJson } from './utils';
 import './globals.css';
 
-type AlertState = { title: string; message: string };
 type FullEntryInteraction = { key: string; mode: 'detail' | 'edit' };
 
 const sameTarget = (a: StorageTarget, b: StorageTarget) =>
@@ -79,14 +78,12 @@ function StoragePanelContent() {
   const [keySortDirection, setKeySortDirection] = useState<'ascending' | 'descending'>('ascending');
   const [interaction, setInteraction] = useState<FullEntryInteraction | null>(null);
   const [showAddDialog, setShowAddDialog] = useState(false);
-  const [deleteKey, setDeleteKey] = useState<string | null>(null);
-  const [showPurgeDialog, setShowPurgeDialog] = useState(false);
   const [virtualListVersion, setVirtualListVersion] = useState(0);
   const [exportState, setExportState] = useState<
     { status: 'idle' } | { status: 'loading' } | { status: 'error'; message: string }
   >({ status: 'idle' });
   const [importFlight, setImportFlight] = useState<ImportFlightState | null>(null);
-  const [alertState, setAlertState] = useState<AlertState | null>(null);
+  const confirm = useConfirmDialog();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const selectedTargetRef = useRef<StorageTarget | null>(null);
   const discoveryRequestIdRef = useRef(0);
@@ -262,8 +259,6 @@ function StoragePanelContent() {
     importPreviewAbortControllerRef.current = null;
     activeImportRequestIdRef.current = null;
     setExportState({ status: 'idle' });
-    setDeleteKey(null);
-    setShowPurgeDialog(false);
     setInteraction(null);
     setImportFlight(null);
   }, [selectedTarget]);
@@ -312,10 +307,15 @@ function StoragePanelContent() {
     );
   };
 
-  const handleDeleteEntry = () => {
-    if (!client || !selectedTarget || !deleteKey) return;
-    const key = deleteKey;
-    setDeleteKey(null);
+  const handleDeleteClick = async (key: string) => {
+    if (!client || !selectedTarget) return;
+    const confirmed = await confirm({
+      title: 'Delete Entry',
+      description: `Are you sure you want to delete the entry "${key}"?`,
+      tone: 'danger',
+      confirmLabel: 'Delete',
+    });
+    if (!confirmed) return;
     mutateSelectedStorage(() =>
       client.send('delete-entry', {
         type: 'delete-entry',
@@ -325,16 +325,26 @@ function StoragePanelContent() {
     );
   };
 
-  const handlePurgeStorage = () => {
+  const handlePurgeClick = async () => {
     if (!client || !selectedTarget) return;
-    setShowPurgeDialog(false);
+    const confirmed = await confirm({
+      title: 'Purge Storage',
+      description: selectedDescriptor
+        ? `Are you sure you want to remove all entries from "${selectedDescriptor.storageName}"? This action cannot be undone.`
+        : 'Are you sure you want to remove all entries from this storage? This action cannot be undone.',
+      tone: 'danger',
+      confirmLabel: 'Purge',
+    });
+    if (!confirmed) return;
     client.send('purge-storage', {
       type: 'purge-storage',
       target: selectedTarget,
     });
   };
 
-  const showAlert = (title: string, message: string) => setAlertState({ title, message });
+  const showAlert = async (title: string, message: string) => {
+    await confirm({ variant: 'alert', title, description: message });
+  };
 
   const handleImportClick = () => {
     if (fileInputRef.current) {
@@ -509,7 +519,7 @@ function StoragePanelContent() {
               tone="neutral"
               variant="ghost"
               className="text-muted-foreground hover:text-danger"
-              onClick={() => setDeleteKey(row.original.key)}
+              onClick={() => void handleDeleteClick(row.original.key)}
               label={`Delete entry ${row.original.key}`}
             >
               <Trash2 className="h-3.5 w-3.5" />
@@ -518,7 +528,7 @@ function StoragePanelContent() {
         ),
       },
     ],
-    [],
+    [handleDeleteClick],
   );
   const sorting: SortingState = [{ id: 'key', desc: keySortDirection === 'descending' }];
   const handleSortingChange: OnChangeFn<SortingState> = (updater) => {
@@ -603,7 +613,7 @@ function StoragePanelContent() {
                     <Plus className="h-3.5 w-3.5" />
                   </Toolbar.Button>
                   <Toolbar.Button
-                    onClick={() => setShowPurgeDialog(true)}
+                    onClick={() => void handlePurgeClick()}
                     disabled={!client || !selectedTarget || previews.isFetching}
                     aria-label="Purge storage"
                     title="Purge storage"
@@ -735,43 +745,6 @@ function StoragePanelContent() {
         onApply={handleApplyImport}
         onCancel={() => setImportFlight(null)}
         onClose={() => setImportFlight(null)}
-      />
-      <ConfirmDialog
-        open={deleteKey !== null}
-        onOpenChange={(open) => {
-          if (!open) setDeleteKey(null);
-        }}
-        variant="confirm"
-        tone="danger"
-        title="Delete Entry"
-        description={
-          deleteKey ? `Are you sure you want to delete the entry "${deleteKey}"?` : undefined
-        }
-        confirmLabel="Delete"
-        onConfirm={handleDeleteEntry}
-      />
-      <ConfirmDialog
-        open={showPurgeDialog}
-        onOpenChange={setShowPurgeDialog}
-        variant="confirm"
-        tone="danger"
-        title="Purge Storage"
-        description={
-          selectedDescriptor
-            ? `Are you sure you want to remove all entries from "${selectedDescriptor.storageName}"? This action cannot be undone.`
-            : 'Are you sure you want to remove all entries from this storage? This action cannot be undone.'
-        }
-        confirmLabel="Purge"
-        onConfirm={handlePurgeStorage}
-      />
-      <ConfirmDialog
-        open={alertState !== null}
-        onOpenChange={(open) => {
-          if (!open) setAlertState(null);
-        }}
-        variant="alert"
-        title={alertState?.title ?? ''}
-        description={alertState?.message}
       />
     </PluginShell>
   );

--- a/packages/storage-plugin/src/ui/panel.tsx
+++ b/packages/storage-plugin/src/ui/panel.tsx
@@ -13,7 +13,7 @@ import {
   useConfirmDialog,
   VirtualizedDataTable,
 } from '@rozenite/ui';
-import { useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react';
 import { Database, Download, Edit3, Plus, RefreshCw, Trash2, Upload } from 'lucide-react';
 import type {
   StorageDiscoverStoragesResponseEvent,
@@ -307,23 +307,26 @@ function StoragePanelContent() {
     );
   };
 
-  const handleDeleteClick = async (key: string) => {
-    if (!client || !selectedTarget) return;
-    const confirmed = await confirm({
-      title: 'Delete Entry',
-      description: `Are you sure you want to delete the entry "${key}"?`,
-      tone: 'danger',
-      confirmLabel: 'Delete',
-    });
-    if (!confirmed) return;
-    mutateSelectedStorage(() =>
-      client.send('delete-entry', {
-        type: 'delete-entry',
-        target: selectedTarget,
-        key,
-      }),
-    );
-  };
+  const handleDeleteClick = useCallback(
+    async (key: string) => {
+      if (!client || !selectedTarget) return;
+      const confirmed = await confirm({
+        title: 'Delete Entry',
+        description: `Are you sure you want to delete the entry "${key}"?`,
+        tone: 'danger',
+        confirmLabel: 'Delete',
+      });
+      if (!confirmed) return;
+      mutateSelectedStorage(() =>
+        client.send('delete-entry', {
+          type: 'delete-entry',
+          target: selectedTarget,
+          key,
+        }),
+      );
+    },
+    [client, selectedTarget, confirm],
+  );
 
   const handlePurgeClick = async () => {
     if (!client || !selectedTarget) return;
@@ -360,12 +363,12 @@ function StoragePanelContent() {
     try {
       raw = JSON.parse(await file.text());
     } catch (error) {
-      showAlert('Could not read file', error instanceof Error ? error.message : String(error));
+      void showAlert('Could not read file', error instanceof Error ? error.message : String(error));
       return;
     }
     const parsed = parseSnapshot(raw);
     if (!parsed.ok) {
-      showAlert('Invalid snapshot', `${parsed.error.path}: ${parsed.error.message}`);
+      void showAlert('Invalid snapshot', `${parsed.error.path}: ${parsed.error.message}`);
       return;
     }
     importPreviewAbortControllerRef.current?.abort();
@@ -396,7 +399,7 @@ function StoragePanelContent() {
       });
     } catch {
       if (!controller.signal.aborted && sameTarget(target, selectedTargetRef.current ?? target)) {
-        showAlert(
+        void showAlert(
           'Could not preview import',
           'Could not inspect the selected storage. Please try again.',
         );
@@ -565,7 +568,7 @@ function StoragePanelContent() {
   const selectedStorageViewId = selectedTarget ? getStorageViewId(selectedTarget) : '';
 
   return (
-    <PluginShell>
+    <>
       <PluginShell.Body>
         <Split direction="horizontal" autoSaveId="storage">
           <Split.Pane defaultSize={22} minSize={15} maxSize={40}>
@@ -746,14 +749,16 @@ function StoragePanelContent() {
         onCancel={() => setImportFlight(null)}
         onClose={() => setImportFlight(null)}
       />
-    </PluginShell>
+    </>
   );
 }
 
 export default function StoragePanel() {
   return (
     <StorageQueryClientProvider>
-      <StoragePanelContent />
+      <PluginShell>
+        <StoragePanelContent />
+      </PluginShell>
     </StorageQueryClientProvider>
   );
 }

--- a/packages/ui/src/confirm-dialog/confirm-dialog.test.tsx
+++ b/packages/ui/src/confirm-dialog/confirm-dialog.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it } from 'vitest';
+import { ConfirmDialog, useConfirmDialog } from './confirm-dialog';
+import { PluginPortalContainerContext } from '../theme/theme-context';
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean | undefined;
+}
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | undefined;
+let container: HTMLDivElement | undefined;
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  document.body.replaceChildren();
+  root = undefined;
+  container = undefined;
+});
+
+function render(children: React.ReactNode) {
+  container = document.createElement('div');
+  document.body.append(container);
+  root = createRoot(container);
+  const portalContainer = container;
+  return act(async () => {
+    root?.render(
+      <PluginPortalContainerContext.Provider value={portalContainer}>
+        {children}
+      </PluginPortalContainerContext.Provider>,
+    );
+    await Promise.resolve();
+  });
+}
+
+function clickByText(text: string) {
+  const button = Array.from(document.querySelectorAll('button')).find(
+    (candidate) => candidate.textContent === text,
+  );
+  if (!button) throw new Error(`No button with text "${text}"`);
+  return act(async () => {
+    button.click();
+    await Promise.resolve();
+  });
+}
+
+function Asker({ label, title }: { label: string; title: string }) {
+  const confirm = useConfirmDialog();
+  return (
+    <button
+      onClick={() => {
+        void confirm({ title }).then((result) => {
+          document.title = `${label}:${result}`;
+        });
+      }}
+    >
+      {label}
+    </button>
+  );
+}
+
+describe('useConfirmDialog', () => {
+  it('throws when used outside ConfirmDialog.Provider', () => {
+    function Consumer() {
+      useConfirmDialog();
+      return null;
+    }
+    expect(() => {
+      container = document.createElement('div');
+      document.body.append(container);
+      root = createRoot(container);
+      act(() => root?.render(<Consumer />));
+    }).toThrow('useConfirmDialog must be used within a ConfirmDialog.Provider');
+  });
+
+  it('resolves true when the user confirms', async () => {
+    await render(
+      <ConfirmDialog.Provider>
+        <Asker label="ask" title="Delete project?" />
+      </ConfirmDialog.Provider>,
+    );
+
+    await clickByText('ask');
+    expect(document.body.textContent).toContain('Delete project?');
+
+    await clickByText('Confirm');
+    expect(document.title).toBe('ask:true');
+  });
+
+  it('resolves false when the user cancels', async () => {
+    await render(
+      <ConfirmDialog.Provider>
+        <Asker label="ask" title="Delete project?" />
+      </ConfirmDialog.Provider>,
+    );
+
+    await clickByText('ask');
+    await clickByText('Cancel');
+    expect(document.title).toBe('ask:false');
+  });
+
+  it('queues a second confirmation until the first is settled', async () => {
+    await render(
+      <ConfirmDialog.Provider>
+        <Asker label="first" title="First?" />
+        <Asker label="second" title="Second?" />
+      </ConfirmDialog.Provider>,
+    );
+
+    await clickByText('first');
+    await clickByText('second');
+    expect(document.body.textContent).toContain('First?');
+    expect(document.body.textContent).not.toContain('Second?');
+
+    await clickByText('Confirm');
+    expect(document.title).toBe('first:true');
+    expect(document.body.textContent).toContain('Second?');
+
+    await clickByText('Confirm');
+    expect(document.title).toBe('second:true');
+  });
+});

--- a/packages/ui/src/confirm-dialog/confirm-dialog.tsx
+++ b/packages/ui/src/confirm-dialog/confirm-dialog.tsx
@@ -1,4 +1,12 @@
-import { createContext, useCallback, useContext, useRef, useState, type ReactNode } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
 import { Dialog } from '../dialog/dialog';
 import { Button } from '../button/button';
 import type { Tone } from '../tokens/tone';
@@ -86,6 +94,8 @@ export type ConfirmDialogProviderProps = {
  */
 function ConfirmDialogProvider({ children }: ConfirmDialogProviderProps) {
   const [queue, setQueue] = useState<PendingConfirm[]>([]);
+  const queueRef = useRef(queue);
+  queueRef.current = queue;
   const nextIdRef = useRef(0);
 
   const confirm = useCallback<ConfirmFn>((options) => {
@@ -93,6 +103,14 @@ function ConfirmDialogProvider({ children }: ConfirmDialogProviderProps) {
       const id = nextIdRef.current++;
       setQueue((current) => [...current, { id, options, resolve }]);
     });
+  }, []);
+
+  // Resolve `false` for any confirmation still awaiting an answer when the
+  // provider unmounts, so callers don't hang forever on an abandoned panel.
+  useEffect(() => {
+    return () => {
+      queueRef.current.forEach((entry) => entry.resolve(false));
+    };
   }, []);
 
   const pending = queue[0] ?? null;
@@ -108,6 +126,7 @@ function ConfirmDialogProvider({ children }: ConfirmDialogProviderProps) {
       {children}
       {pending && (
         <ConfirmDialogRoot
+          key={pending.id}
           {...pending.options}
           open
           onOpenChange={(open) => {

--- a/packages/ui/src/confirm-dialog/confirm-dialog.tsx
+++ b/packages/ui/src/confirm-dialog/confirm-dialog.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { createContext, useCallback, useContext, useRef, useState, type ReactNode } from 'react';
 import { Dialog } from '../dialog/dialog';
 import { Button } from '../button/button';
 import type { Tone } from '../tokens/tone';
@@ -24,7 +24,7 @@ export type ConfirmDialogProps = {
 };
 
 /** A confirmation or acknowledgement dialog for destructive or important actions. */
-export function ConfirmDialog({
+function ConfirmDialogRoot({
   open,
   onOpenChange,
   title,
@@ -59,3 +59,78 @@ export function ConfirmDialog({
     </Dialog>
   );
 }
+
+export type ConfirmDialogOptions = Pick<
+  ConfirmDialogProps,
+  'title' | 'description' | 'variant' | 'tone' | 'confirmLabel' | 'cancelLabel'
+>;
+
+type ConfirmFn = (options: ConfirmDialogOptions) => Promise<boolean>;
+
+type PendingConfirm = {
+  id: number;
+  options: ConfirmDialogOptions;
+  resolve: (confirmed: boolean) => void;
+};
+
+const ConfirmDialogContext = createContext<ConfirmFn | null>(null);
+
+export type ConfirmDialogProviderProps = {
+  children?: ReactNode;
+};
+
+/**
+ * Renders at most one queued confirmation at a time — a second `confirm()`
+ * call while one is already showing waits its turn rather than stacking
+ * dialogs.
+ */
+function ConfirmDialogProvider({ children }: ConfirmDialogProviderProps) {
+  const [queue, setQueue] = useState<PendingConfirm[]>([]);
+  const nextIdRef = useRef(0);
+
+  const confirm = useCallback<ConfirmFn>((options) => {
+    return new Promise<boolean>((resolve) => {
+      const id = nextIdRef.current++;
+      setQueue((current) => [...current, { id, options, resolve }]);
+    });
+  }, []);
+
+  const pending = queue[0] ?? null;
+
+  const settle = (confirmed: boolean) => {
+    if (!pending) return;
+    pending.resolve(confirmed);
+    setQueue((current) => current.filter((entry) => entry.id !== pending.id));
+  };
+
+  return (
+    <ConfirmDialogContext.Provider value={confirm}>
+      {children}
+      {pending && (
+        <ConfirmDialogRoot
+          {...pending.options}
+          open
+          onOpenChange={(open) => {
+            if (!open) settle(false);
+          }}
+          onConfirm={() => settle(true)}
+        />
+      )}
+    </ConfirmDialogContext.Provider>
+  );
+}
+
+/** Imperatively show a confirmation or acknowledgement dialog. Must be used within a `ConfirmDialog.Provider` (which `PluginShell` mounts automatically). */
+export function useConfirmDialog(): ConfirmFn {
+  const context = useContext(ConfirmDialogContext);
+
+  if (!context) {
+    throw new Error('useConfirmDialog must be used within a ConfirmDialog.Provider');
+  }
+
+  return context;
+}
+
+export const ConfirmDialog = Object.assign(ConfirmDialogRoot, {
+  Provider: ConfirmDialogProvider,
+});

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -211,7 +211,11 @@ export { EmptyState } from './empty-state/empty-state';
 export type { EmptyStateProps } from './empty-state/empty-state';
 
 export { ConfirmDialog, useConfirmDialog } from './confirm-dialog/confirm-dialog';
-export type { ConfirmDialogProps, ConfirmDialogOptions } from './confirm-dialog/confirm-dialog';
+export type {
+  ConfirmDialogProps,
+  ConfirmDialogOptions,
+  ConfirmDialogProviderProps,
+} from './confirm-dialog/confirm-dialog';
 
 export { JsonInspector } from './json-inspector/json-inspector';
 export type { JsonInspectorProps } from './json-inspector/json-inspector';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -210,8 +210,8 @@ export type {
 export { EmptyState } from './empty-state/empty-state';
 export type { EmptyStateProps } from './empty-state/empty-state';
 
-export { ConfirmDialog } from './confirm-dialog/confirm-dialog';
-export type { ConfirmDialogProps } from './confirm-dialog/confirm-dialog';
+export { ConfirmDialog, useConfirmDialog } from './confirm-dialog/confirm-dialog';
+export type { ConfirmDialogProps, ConfirmDialogOptions } from './confirm-dialog/confirm-dialog';
 
 export { JsonInspector } from './json-inspector/json-inspector';
 export type { JsonInspectorProps } from './json-inspector/json-inspector';

--- a/packages/ui/src/plugin-shell/plugin-shell.tsx
+++ b/packages/ui/src/plugin-shell/plugin-shell.tsx
@@ -5,6 +5,8 @@ import {
   PluginThemeProvider,
   usePluginTheme,
 } from '../theme/theme-context';
+import { ConfirmDialog } from '../confirm-dialog/confirm-dialog';
+import { Toast } from '../toast/toast';
 
 export type PluginShellProps = ComponentProps<'div'> & {
   /**
@@ -23,7 +25,9 @@ function PluginShellRoot({ unstyled = false, className, children, ...props }: Pl
         className={cn('flex h-screen min-h-0 flex-col', className)}
         {...props}
       >
-        {children}
+        <Toast>
+          <ConfirmDialog.Provider>{children}</ConfirmDialog.Provider>
+        </Toast>
       </div>
     );
   }
@@ -53,7 +57,9 @@ function ThemedShell({ className, children, ...props }: Omit<PluginShellProps, '
       {...props}
     >
       <PluginPortalContainerContext.Provider value={rootElement}>
-        {children}
+        <Toast>
+          <ConfirmDialog.Provider>{children}</ConfirmDialog.Provider>
+        </Toast>
       </PluginPortalContainerContext.Provider>
     </div>
   );


### PR DESCRIPTION
## Description

Adds `useConfirmDialog()` to `@rozenite/ui`: an imperative counterpart to `ConfirmDialog` that resolves a promise with the user's choice instead of driving `open`/`onOpenChange` from local state. `PluginShell` now mounts `Toast` and `ConfirmDialog.Provider` automatically for every plugin panel, so panels no longer need to hand-mount `<Toast.Provider>` to use `useToast()`.

Migrates the feature-flags, React Hook Form, and storage DevTools panels to `useConfirmDialog()`, replacing their declarative confirm/alert dialogs (open/onOpenChange + local state) and dropping the now-redundant `Toast.Provider` wrappers.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
No existing issue tracks this change; opened without one at the requester's direction.

## Context

- `ConfirmDialog`'s existing default export is renamed internally to `ConfirmDialogRoot`; `ConfirmDialog` itself is unchanged as a callable export and gains a `Provider` (`ConfirmDialog.Provider`), mirroring the `Toast`/`Toast.Provider` pattern already in the package.
- `ConfirmDialogProvider` queues at most one pending confirmation at a time; a second `confirm()` call while one is showing waits its turn.
- In `storage-plugin`, delete-entry and purge-storage now capture their target/key in the click-time closure instead of separate confirmation-pending state. This means the confirmation always acts on what the user was looking at when they clicked, even if the selected storage changes while the dialog is open — a behavior change worth flagging for review, though arguably more correct for a devtools panel.
- Added a version plan (`.changeset/imperative-confirm-dialog.md`) covering `@rozenite/ui`, `@rozenite/feature-flags-plugin`, `@rozenite/storage-plugin`, and `@rozenite/rhf-plugin`.
- Added a Storybook story (`ConfirmDialog.stories.tsx` → `Imperative`) demonstrating `useConfirmDialog()` under `ConfirmDialog.Provider`.

## Testing

Automated:

- `pnpm --filter @rozenite/ui typecheck / lint / test`
- `pnpm --filter @rozenite/storage-plugin --filter @rozenite/feature-flags-plugin --filter @rozenite/rhf-plugin typecheck / lint / test`
- `pnpm typecheck:all`, `pnpm lint:all`, `pnpm format:all` (repo-wide, all green aside from pre-existing unrelated formatting drift in 3 untouched files)
- `pnpm release:plan` — confirms the changeset is picked up

Manual:

- Started `apps/ui-storybook` and used `agent-browser` to open the new `Imperative` `ConfirmDialog` story, click through to open the dialog, confirm it, and verify the promise resolved (`true`) and the demo rendered "Confirmed".