### PR TITLE
chore: release @rozenite/ui breaking batch as minor instead of major

### DIFF
--- a/.changeset/ui-design-system-phase-3-breaking-batch.md
+++ b/.changeset/ui-design-system-phase-3-breaking-batch.md
@@ -1,8 +1,8 @@
 ---
-'@rozenite/ui': major
+'@rozenite/ui': minor
 ---
 
-Unify the size scale, split tone from emphasis, and remove layout-leakage margins across `@rozenite/ui` components. All `@rozenite/*` packages bump together since this is a breaking release.
+Unify the size scale, split tone from emphasis, and remove layout-leakage margins across `@rozenite/ui` components. `@rozenite/ui` is mainly consumed internally by Rozenite's own plugin panels, so the blast radius of these changes is small; released as `minor` rather than `major` on that basis. All `@rozenite/*` packages bump together.
 
 **Migration table:**
 


### PR DESCRIPTION
## Summary

- Lowers the bump level of the `ui-design-system-phase-3-breaking-batch` changeset for `@rozenite/ui` from `major` to `minor`.
- `@rozenite/ui` is mainly consumed internally by Rozenite's own plugin panels, so the practical risk/blast radius of these changes is small — released as `minor` rather than `major` on that basis.
- Since all `@rozenite/*` packages (and `rozenite` itself) are pinned together (`.changeset/config.json`'s `fixed` group), this changes the next release from `3.0.0` to `2.2.0`.

## Test plan

- [ ] `pnpm release:plan` (`changeset status`) picks up the updated bump level
- [ ] Confirm the next `Release` workflow run produces `2.2.0` rather than `3.0.0`

---
_Generated by [Claude Code](https://claude.ai/code/session_01J4SFwjUuNXMZPyjLNMxJd1)_