### PR TITLE
feat(cli): add rozenite agent tap to stream plugin messages to stdout

### DIFF
--- a/.changeset/tap-plugin-message-stream.md
+++ b/.changeset/tap-plugin-message-stream.md
@@ -5,6 +5,6 @@
 'rozenite': minor
 ---
 
-Add `rozenite tap`, a CLI command that streams a Rozenite Agent session's plugin messages to stdout in both directions, without opening a browser or React Native DevTools. `--plugin` filters the stream to one plugin; `--type` and `--payload` send one message before watching, so a plugin's native side can be poked and its response observed directly from the terminal. Pass `--json` for newline-delimited JSON output.
+Add `rozenite agent tap`, a CLI command that streams a Rozenite Agent session's plugin messages to stdout in both directions, without opening a browser or React Native DevTools. `--plugin` filters the stream to one plugin; `--type` and `--payload` send one message before watching, so a plugin's native side can be poked and its response observed directly from the terminal. Pass `--json` for newline-delimited JSON output.
 
 Because a device serves only one debugger connection at a time, a tap rides the same connection `rozenite agent` uses and replaces React Native DevTools if it is already attached, the same tradeoff `rozenite agent` already makes.

--- a/.changeset/tap-plugin-message-stream.md
+++ b/.changeset/tap-plugin-message-stream.md
@@ -1,0 +1,10 @@
+---
+'@rozenite/middleware': minor
+'@rozenite/agent-sdk': minor
+'@rozenite/agent-shared': minor
+'rozenite': minor
+---
+
+Add `rozenite tap`, a CLI command that streams a Rozenite Agent session's plugin messages to stdout in both directions, without opening a browser or React Native DevTools. `--plugin` filters the stream to one plugin; `--type` and `--payload` send one message before watching, so a plugin's native side can be poked and its response observed directly from the terminal. Pass `--json` for newline-delimited JSON output.
+
+Because a device serves only one debugger connection at a time, a tap rides the same connection `rozenite agent` uses and replaces React Native DevTools if it is already attached, the same tradeoff `rozenite agent` already makes.

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -9,6 +9,9 @@ export type {
   AgentSessionClient,
   AgentSessionDomains,
   AgentSessionTools,
+  AgentTapFilter,
+  AgentTapStreamHandle,
+  AgentTapStreamHandlers,
   AgentToolSchema,
   DomainDefinition,
 } from './types.js';
@@ -22,4 +25,8 @@ export type {
   AgentToolTraits,
   JSONSchema7,
   MetroTarget,
+  SendAgentSessionTapMessageRequest,
+  SendAgentSessionTapMessageResponse,
+  TapDirection,
+  TapEvent,
 } from '@rozenite/agent-shared';

--- a/packages/agent-sdk/src/transport.ts
+++ b/packages/agent-sdk/src/transport.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_AGENT_PORT,
   getAgentSessionCallToolRoute,
   getAgentSessionRoute,
+  getAgentSessionTapRoute,
   getAgentSessionToolsRoute,
   type AgentResponseEnvelope,
   type CallAgentSessionToolResponse,
@@ -17,8 +18,10 @@ import {
   type GetAgentSessionToolsResponse,
   type GetAgentTargetsResponse,
   type ListAgentSessionsResponse,
+  type SendAgentSessionTapMessageResponse,
+  type TapEvent,
 } from '@rozenite/agent-shared';
-import type { AgentClientOptions, AgentTransport } from './types.js';
+import type { AgentClientOptions, AgentTapStreamHandle, AgentTransport } from './types.js';
 
 export type { AgentClientOptions, AgentTransport } from './types.js';
 
@@ -116,6 +119,98 @@ const requestJson = async <TResult>(input: {
   });
 };
 
+/**
+ * Opens the tap route's chunked newline-delimited-JSON stream and parses it
+ * line by line. This bypasses `requestJson` (built around a single buffered
+ * JSON envelope) since the tap response never ends on its own — the caller
+ * closes it, typically on Ctrl-C.
+ */
+const openTapStream = (input: {
+  host: string;
+  port: number;
+  sessionId: string;
+  pluginId?: string;
+  type?: string;
+  onOpen?: () => void;
+  onEvent: (event: TapEvent) => void;
+  onError: (error: Error) => void;
+  onEnd: () => void;
+}): AgentTapStreamHandle => {
+  const url = new URL(
+    `http://${input.host}:${input.port}${getAgentSessionTapRoute(input.sessionId)}`,
+  );
+  if (input.pluginId) {
+    url.searchParams.set('pluginId', input.pluginId);
+  }
+  if (input.type) {
+    url.searchParams.set('type', input.type);
+  }
+
+  const req = httpRequest(url, { method: 'GET' }, (res) => {
+    res.setEncoding('utf8');
+
+    if ((res.statusCode ?? 500) >= 400) {
+      let errorBody = '';
+      res.on('data', (chunk: string) => {
+        errorBody += chunk;
+      });
+      res.on('end', () => {
+        try {
+          const parsed = JSON.parse(errorBody) as AgentResponseEnvelope<never>;
+          input.onError(
+            new Error(
+              !parsed.ok
+                ? parsed.error.message
+                : `Tap request failed with status ${res.statusCode ?? 500}`,
+            ),
+          );
+        } catch {
+          input.onError(new Error(`Tap request failed with status ${res.statusCode ?? 500}`));
+        }
+      });
+      return;
+    }
+
+    input.onOpen?.();
+
+    let buffer = '';
+    res.on('data', (chunk: string) => {
+      buffer += chunk;
+      let newlineIndex = buffer.indexOf('\n');
+      while (newlineIndex >= 0) {
+        const line = buffer.slice(0, newlineIndex);
+        buffer = buffer.slice(newlineIndex + 1);
+        newlineIndex = buffer.indexOf('\n');
+
+        if (!line) {
+          continue;
+        }
+
+        try {
+          input.onEvent(JSON.parse(line) as TapEvent);
+        } catch {
+          // Ignore a malformed line rather than tearing down the stream.
+        }
+      }
+    });
+    res.on('end', () => {
+      input.onEnd();
+    });
+  });
+
+  req.once('error', (error) => {
+    input.onError(createMetroConnectionError(input.host, input.port, error));
+  });
+
+  req.end();
+
+  return {
+    close: () => {
+      req.destroy();
+    },
+  };
+};
+
 export const createAgentTransport = (options?: AgentClientOptions): AgentTransport => {
   const host = options?.host ?? DEFAULT_AGENT_HOST;
   const port = options?.port ?? DEFAULT_AGENT_PORT;
@@ -186,6 +281,28 @@ export const createAgentTransport = (options?: AgentClientOptions): AgentTranspo
         port,
         method: 'POST',
         pathname: getAgentSessionCallToolRoute(sessionId),
+        body,
+      });
+    },
+    openSessionTap: (sessionId, filter, handlers) => {
+      return openTapStream({
+        host,
+        port,
+        sessionId,
+        pluginId: filter.pluginId,
+        type: filter.type,
+        onOpen: handlers.onOpen,
+        onEvent: handlers.onEvent,
+        onError: handlers.onError,
+        onEnd: handlers.onEnd,
+      });
+    },
+    sendSessionTapMessage: async (sessionId, body) => {
+      return await requestJson<SendAgentSessionTapMessageResponse>({
+        host,
+        port,
+        method: 'POST',
+        pathname: getAgentSessionTapRoute(sessionId),
         body,
       });
     },

--- a/packages/agent-sdk/src/types.ts
+++ b/packages/agent-sdk/src/types.ts
@@ -18,6 +18,9 @@ import type {
   JSONSchema7,
   ListAgentSessionsResponse,
   MetroTarget,
+  SendAgentSessionTapMessageRequest,
+  SendAgentSessionTapMessageResponse,
+  TapEvent,
 } from '@rozenite/agent-shared';
 
 export interface DomainDefinition {
@@ -104,6 +107,29 @@ export interface AgentSessionClient {
 
 export type AgentSessionCallback<T> = (session: AgentSessionClient) => Promise<T> | T;
 
+export interface AgentTapStreamHandle {
+  /** Aborts the underlying HTTP request and releases the tap subscription. */
+  close: () => void;
+}
+
+export interface AgentTapFilter {
+  pluginId?: string;
+  type?: string;
+}
+
+export interface AgentTapStreamHandlers {
+  /**
+   * Called once the server has accepted the stream and subscribed to the
+   * session's tap — the earliest point at which sending a message is
+   * guaranteed not to race the subscription.
+   */
+  onOpen?: () => void;
+  onEvent: (event: TapEvent) => void;
+  onError: (error: Error) => void;
+  /** Called when the server ends the response (e.g. the session stopped). */
+  onEnd: () => void;
+}
+
 export interface AgentTransport {
   host: string;
   port: number;
@@ -118,6 +144,16 @@ export interface AgentTransport {
     sessionId: string,
     body: CallAgentSessionToolRequest,
   ) => Promise<CallAgentSessionToolResponse>;
+  /** Opens the tap event stream for a session; call `.close()` to stop it. */
+  openSessionTap: (
+    sessionId: string,
+    filter: AgentTapFilter,
+    handlers: AgentTapStreamHandlers,
+  ) => AgentTapStreamHandle;
+  sendSessionTapMessage: (
+    sessionId: string,
+    body: SendAgentSessionTapMessageRequest,
+  ) => Promise<SendAgentSessionTapMessageResponse>;
 }
 
 export interface AgentClient {

--- a/packages/agent-shared/src/index.ts
+++ b/packages/agent-shared/src/index.ts
@@ -20,6 +20,7 @@ export const AGENT_SESSIONS_ROUTE = `${AGENT_ROUTE_BASE}/sessions`;
 export const AGENT_SESSION_ROUTE_PATTERN = `${AGENT_SESSIONS_ROUTE}/:sessionId`;
 export const AGENT_SESSION_TOOLS_ROUTE_PATTERN = `${AGENT_SESSION_ROUTE_PATTERN}/tools`;
 export const AGENT_SESSION_CALL_TOOL_ROUTE_PATTERN = `${AGENT_SESSION_ROUTE_PATTERN}/call-tool`;
+export const AGENT_SESSION_TAP_ROUTE_PATTERN = `${AGENT_SESSION_ROUTE_PATTERN}/tap`;
 
 export const getAgentSessionRoute = (sessionId: string): string => {
   return `${AGENT_SESSIONS_ROUTE}/${encodeURIComponent(sessionId)}`;
@@ -31,6 +32,10 @@ export const getAgentSessionToolsRoute = (sessionId: string): string => {
 
 export const getAgentSessionCallToolRoute = (sessionId: string): string => {
   return `${getAgentSessionRoute(sessionId)}/call-tool`;
+};
+
+export const getAgentSessionTapRoute = (sessionId: string): string => {
+  return `${getAgentSessionRoute(sessionId)}/tap`;
 };
 
 export interface JSONSchema7 {
@@ -326,6 +331,28 @@ export type DevToolsPluginMessage = {
   pluginId: string;
   type: string;
   payload: unknown;
+};
+
+/** Direction of a tapped message relative to this machine: `in` was received
+ * from the device, `out` was sent to it. */
+export type TapDirection = 'in' | 'out';
+
+export type TapEvent = {
+  direction: TapDirection;
+  timestamp: number;
+  pluginId: string;
+  type: string;
+  payload: unknown;
+};
+
+export type SendAgentSessionTapMessageRequest = {
+  pluginId: string;
+  type: string;
+  payload: unknown;
+};
+
+export type SendAgentSessionTapMessageResponse = {
+  sent: true;
 };
 
 export type RegisterToolPayload = {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -14,6 +14,7 @@ The Rozenite CLI is the primary tool for scaffolding, building, and developing R
 - **Development Server**: Hot-reload development environment with file watchers
 - **Template System**: Pre-configured templates with TypeScript, Vite, and Rozenite integration
 - **Rozenite for Agents**: Agent-facing CLI for inspecting running apps, discovering domains, and calling tools via `rozenite agent`
+- **Tap**: Stream a plugin's messages to the terminal in both directions, and optionally poke one, via `rozenite tap`
 
 ## Installation
 
@@ -149,6 +150,43 @@ rozenite open --deviceId <id>
 # Point at a Metro server on a non-default host/port
 rozenite open --host 192.168.1.10 --port 8082
 ```
+
+### `rozenite tap`
+
+Stream a Rozenite Agent session's plugin messages to stdout, in both
+directions, without opening a browser or React Native DevTools. Because it's
+bidirectional, it also doubles as a minimal stand-in for DevTools: send one
+message from the terminal with `--type`/`--payload`, then keep watching for
+what comes back. A device serves only one debugger connection at a time, so
+a tap **replaces** React Native DevTools if it's already attached — the same
+tradeoff `rozenite agent` makes. Stop the tap (Ctrl-C) to free the connection
+back up. Requires an existing session; create one with
+`rozenite agent session create`.
+
+**Options:**
+
+- `-s, --session <id>` - Target Agent session ID (required)
+- `-p, --plugin <id>` - Filter the stream to this plugin ID; required with `--type`
+- `-t, --type <name>` - Send one message of this type before watching (requires `--plugin`)
+- `-a, --payload <json>` - JSON payload for the sent message (defaults to `{}`)
+- `--json` - Newline-delimited JSON output, one message per line
+- `--host <host>` / `--port <port>` - Metro host/port (defaults to `127.0.0.1:8081`)
+
+**Examples:**
+
+```bash
+# Watch a plugin's traffic
+rozenite tap --session <id> --plugin @acme/sqlite-plugin
+
+# Poke a plugin and watch what comes back
+rozenite tap --session <id> --plugin @acme/sqlite-plugin --type sqlite:query --payload '{"sql":"select 1"}'
+
+# Newline-delimited JSON, for scripts and agents
+rozenite tap --session <id> --json
+```
+
+See the [Tap docs](https://rozenite.dev/docs/agent/tap) for the full output
+contract.
 
 ## Plugin Structure
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -14,7 +14,7 @@ The Rozenite CLI is the primary tool for scaffolding, building, and developing R
 - **Development Server**: Hot-reload development environment with file watchers
 - **Template System**: Pre-configured templates with TypeScript, Vite, and Rozenite integration
 - **Rozenite for Agents**: Agent-facing CLI for inspecting running apps, discovering domains, and calling tools via `rozenite agent`
-- **Tap**: Stream a plugin's messages to the terminal in both directions, and optionally poke one, via `rozenite tap`
+- **Tap**: Stream a plugin's messages to the terminal in both directions, and optionally poke one, via `rozenite agent tap`
 
 ## Installation
 
@@ -151,7 +151,7 @@ rozenite open --deviceId <id>
 rozenite open --host 192.168.1.10 --port 8082
 ```
 
-### `rozenite tap`
+### `rozenite agent tap`
 
 Stream a Rozenite Agent session's plugin messages to stdout, in both
 directions, without opening a browser or React Native DevTools. Because it's
@@ -170,19 +170,19 @@ back up. Requires an existing session; create one with
 - `-t, --type <name>` - Send one message of this type before watching (requires `--plugin`)
 - `-a, --payload <json>` - JSON payload for the sent message (defaults to `{}`)
 - `--json` - Newline-delimited JSON output, one message per line
-- `--host <host>` / `--port <port>` - Metro host/port (defaults to `127.0.0.1:8081`)
+- `--host <host>` / `--port <port>` - Metro host/port, inherited from `rozenite agent`, so they go before `tap` (defaults to `127.0.0.1:8081`)
 
 **Examples:**
 
 ```bash
 # Watch a plugin's traffic
-rozenite tap --session <id> --plugin @acme/sqlite-plugin
+rozenite agent tap --session <id> --plugin @acme/sqlite-plugin
 
 # Poke a plugin and watch what comes back
-rozenite tap --session <id> --plugin @acme/sqlite-plugin --type sqlite:query --payload '{"sql":"select 1"}'
+rozenite agent tap --session <id> --plugin @acme/sqlite-plugin --type sqlite:query --payload '{"sql":"select 1"}'
 
 # Newline-delimited JSON, for scripts and agents
-rozenite tap --session <id> --json
+rozenite agent tap --session <id> --json
 ```
 
 See the [Tap docs](https://rozenite.dev/docs/agent/tap) for the full output

--- a/packages/cli/src/__tests__/agent-tap-command.test.ts
+++ b/packages/cli/src/__tests__/agent-tap-command.test.ts
@@ -1,0 +1,269 @@
+import { Command } from 'commander';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { registerTapCommand, runTapCommand } from '../commands/agent/register-tap-command.js';
+
+const mocks = vi.hoisted(() => ({
+  createAgentTransport: vi.fn(),
+  transport: {
+    openSessionTap: vi.fn(),
+    sendSessionTapMessage: vi.fn(),
+  },
+}));
+
+vi.mock('@rozenite/agent-sdk/transport', () => ({
+  createAgentTransport: mocks.createAgentTransport,
+}));
+
+type Handlers = {
+  onOpen?: () => void;
+  onEvent: (event: unknown) => void;
+  onError: (error: Error) => void;
+  onEnd: () => void;
+};
+
+describe('rozenite tap', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    process.exitCode = undefined;
+    process.removeAllListeners('SIGINT');
+    process.removeAllListeners('SIGTERM');
+  });
+
+  const setupTransport = () => {
+    mocks.createAgentTransport.mockReturnValue(mocks.transport);
+  };
+
+  const baseOptions = {
+    host: '127.0.0.1',
+    port: '8081',
+    session: 'session-1',
+    payload: '{}',
+  };
+
+  it('rejects invalid --payload JSON before opening a session', async () => {
+    setupTransport();
+    const stderrWrite = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    await runTapCommand({ ...baseOptions, payload: 'not-json' });
+
+    expect(stderrWrite).toHaveBeenCalledWith('--payload must be valid JSON\n');
+    expect(process.exitCode).toBe(1);
+    expect(mocks.transport.openSessionTap).not.toHaveBeenCalled();
+  });
+
+  it('reports invalid --payload as a JSON envelope in --json mode', async () => {
+    setupTransport();
+    const stdoutWrite = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await runTapCommand({ ...baseOptions, payload: 'not-json', json: true });
+
+    expect(stdoutWrite).toHaveBeenCalledWith(
+      '{"error":{"message":"--payload must be valid JSON"}}\n',
+    );
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('requires --plugin when --type is provided', async () => {
+    setupTransport();
+    const stderrWrite = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    await runTapCommand({ ...baseOptions, type: 'sqlite:query' });
+
+    expect(stderrWrite).toHaveBeenCalledWith('--plugin is required when --type is provided\n');
+    expect(mocks.transport.openSessionTap).not.toHaveBeenCalled();
+  });
+
+  it('opens the stream filtered to --plugin only, not --type', async () => {
+    setupTransport();
+    let handlers: Handlers | undefined;
+    mocks.transport.openSessionTap.mockImplementation((_sessionId, _filter, h: Handlers) => {
+      handlers = h;
+      return { close: vi.fn() };
+    });
+
+    const done = runTapCommand({ ...baseOptions, plugin: '@acme/sqlite-plugin' });
+    await vi.waitFor(() => expect(mocks.transport.openSessionTap).toHaveBeenCalled());
+
+    expect(mocks.transport.openSessionTap).toHaveBeenCalledWith(
+      'session-1',
+      { pluginId: '@acme/sqlite-plugin' },
+      expect.any(Object),
+    );
+
+    handlers?.onEnd();
+    await done;
+  });
+
+  it('prints a human-readable line per event by default', async () => {
+    setupTransport();
+    let handlers: Handlers | undefined;
+    mocks.transport.openSessionTap.mockImplementation((_sessionId, _filter, h: Handlers) => {
+      handlers = h;
+      return { close: vi.fn() };
+    });
+    const stdoutWrite = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const done = runTapCommand(baseOptions);
+    await vi.waitFor(() => expect(handlers).toBeDefined());
+
+    handlers?.onEvent({
+      direction: 'in',
+      timestamp: 0,
+      pluginId: '@acme/sqlite-plugin',
+      type: 'list-tables-request',
+      payload: { requestId: 'a1' },
+    });
+    handlers?.onEnd();
+    await done;
+
+    const printedLine = stdoutWrite.mock.calls.map(([chunk]) => String(chunk)).join('');
+    expect(printedLine).toContain('←');
+    expect(printedLine).toContain('list-tables-request');
+    expect(printedLine).toContain('{"requestId":"a1"}');
+  });
+
+  it('prints newline-delimited JSON with --json', async () => {
+    setupTransport();
+    let handlers: Handlers | undefined;
+    mocks.transport.openSessionTap.mockImplementation((_sessionId, _filter, h: Handlers) => {
+      handlers = h;
+      return { close: vi.fn() };
+    });
+    const stdoutWrite = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const done = runTapCommand({ ...baseOptions, json: true });
+    await vi.waitFor(() => expect(handlers).toBeDefined());
+
+    const event = {
+      direction: 'out' as const,
+      timestamp: 5,
+      pluginId: '@acme/sqlite-plugin',
+      type: 'query',
+      payload: { sql: 'select 1' },
+    };
+    handlers?.onEvent(event);
+    handlers?.onEnd();
+    await done;
+
+    expect(stdoutWrite).toHaveBeenCalledWith(`${JSON.stringify(event)}\n`);
+  });
+
+  it('sends one message once the stream is open, then keeps watching', async () => {
+    setupTransport();
+    let handlers: Handlers | undefined;
+    mocks.transport.openSessionTap.mockImplementation((_sessionId, _filter, h: Handlers) => {
+      handlers = h;
+      return { close: vi.fn() };
+    });
+    mocks.transport.sendSessionTapMessage.mockResolvedValue({ sent: true });
+
+    const done = runTapCommand({
+      ...baseOptions,
+      plugin: '@acme/sqlite-plugin',
+      type: 'sqlite:query',
+      payload: '{"sql":"select 1"}',
+    });
+    await vi.waitFor(() => expect(handlers).toBeDefined());
+
+    handlers?.onOpen?.();
+    await vi.waitFor(() =>
+      expect(mocks.transport.sendSessionTapMessage).toHaveBeenCalledWith('session-1', {
+        pluginId: '@acme/sqlite-plugin',
+        type: 'sqlite:query',
+        payload: { sql: 'select 1' },
+      }),
+    );
+
+    handlers?.onEnd();
+    await done;
+  });
+
+  it('reports a send failure and closes the stream', async () => {
+    setupTransport();
+    let handlers: Handlers | undefined;
+    const close = vi.fn();
+    mocks.transport.openSessionTap.mockImplementation((_sessionId, _filter, h: Handlers) => {
+      handlers = h;
+      return { close };
+    });
+    mocks.transport.sendSessionTapMessage.mockRejectedValue(new Error('boom'));
+    const stderrWrite = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    const done = runTapCommand({
+      ...baseOptions,
+      plugin: '@acme/sqlite-plugin',
+      type: 'sqlite:query',
+    });
+    await vi.waitFor(() => expect(handlers).toBeDefined());
+    handlers?.onOpen?.();
+
+    await done;
+
+    expect(stderrWrite).toHaveBeenCalledWith('boom\n');
+    expect(process.exitCode).toBe(1);
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a stream error and stops', async () => {
+    setupTransport();
+    let handlers: Handlers | undefined;
+    mocks.transport.openSessionTap.mockImplementation((_sessionId, _filter, h: Handlers) => {
+      handlers = h;
+      return { close: vi.fn() };
+    });
+    const stderrWrite = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    const done = runTapCommand(baseOptions);
+    await vi.waitFor(() => expect(handlers).toBeDefined());
+
+    handlers?.onError(new Error('Unknown session "session-1"'));
+    await done;
+
+    expect(stderrWrite).toHaveBeenCalledWith('Unknown session "session-1"\n');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('closes the tap and exits cleanly on SIGINT', async () => {
+    setupTransport();
+    const close = vi.fn();
+    mocks.transport.openSessionTap.mockImplementation(() => ({ close }));
+
+    const done = runTapCommand(baseOptions);
+    await vi.waitFor(() => expect(mocks.transport.openSessionTap).toHaveBeenCalled());
+
+    process.emit('SIGINT');
+    await done;
+
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('wires --session as required and passes host/port through to the transport', async () => {
+    setupTransport();
+    mocks.transport.openSessionTap.mockImplementation((_sessionId, _filter, h: Handlers) => {
+      // End the stream immediately so `parseAsync` (which awaits the action)
+      // doesn't hang waiting for a Ctrl-C that never comes in this test.
+      queueMicrotask(() => h.onEnd());
+      return { close: vi.fn() };
+    });
+
+    const program = new Command();
+    registerTapCommand(program);
+
+    const tapCommand = program.commands.find((command) => command.name() === 'tap');
+    expect(tapCommand?.options.some((option) => option.long === '--payload')).toBe(true);
+    expect(tapCommand?.options.find((option) => option.long === '--payload')?.defaultValue).toBe(
+      '{}',
+    );
+
+    await program.parseAsync(
+      ['node', 'test', 'tap', '--session', 'session-1', '--host', '10.0.0.5', '--port', '9090'],
+      { from: 'node' },
+    );
+
+    expect(mocks.createAgentTransport).toHaveBeenCalledWith({
+      host: '10.0.0.5',
+      port: 9090,
+    });
+  });
+});

--- a/packages/cli/src/__tests__/agent-tap-command.test.ts
+++ b/packages/cli/src/__tests__/agent-tap-command.test.ts
@@ -21,7 +21,7 @@ type Handlers = {
   onEnd: () => void;
 };
 
-describe('rozenite tap', () => {
+describe('rozenite agent tap', () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.clearAllMocks();
@@ -82,7 +82,10 @@ describe('rozenite tap', () => {
       return { close: vi.fn() };
     });
 
-    const done = runTapCommand({ ...baseOptions, plugin: '@acme/sqlite-plugin' });
+    const done = runTapCommand({
+      ...baseOptions,
+      plugin: '@acme/sqlite-plugin',
+    });
     await vi.waitFor(() => expect(mocks.transport.openSessionTap).toHaveBeenCalled());
 
     expect(mocks.transport.openSessionTap).toHaveBeenCalledWith(
@@ -238,7 +241,7 @@ describe('rozenite tap', () => {
     expect(close).toHaveBeenCalledTimes(1);
   });
 
-  it('wires --session as required and passes host/port through to the transport', async () => {
+  it('registers under `agent` and inherits its host/port globals', async () => {
     setupTransport();
     mocks.transport.openSessionTap.mockImplementation((_sessionId, _filter, h: Handlers) => {
       // End the stream immediately so `parseAsync` (which awaits the action)
@@ -248,16 +251,37 @@ describe('rozenite tap', () => {
     });
 
     const program = new Command();
-    registerTapCommand(program);
+    const agentCommand = program
+      .command('agent')
+      .option('--host <host>', 'Metro host', '127.0.0.1')
+      .option('--port <port>', 'Metro port', '8081');
+    registerTapCommand(agentCommand);
 
-    const tapCommand = program.commands.find((command) => command.name() === 'tap');
+    const tapCommand = agentCommand.commands.find((command) => command.name() === 'tap');
+    expect(tapCommand).toBeDefined();
+    expect(program.commands.some((command) => command.name() === 'tap')).toBe(false);
     expect(tapCommand?.options.some((option) => option.long === '--payload')).toBe(true);
     expect(tapCommand?.options.find((option) => option.long === '--payload')?.defaultValue).toBe(
       '{}',
     );
+    // `--host`/`--port` come from the parent `agent` command, so `tap` must
+    // not redeclare them.
+    expect(tapCommand?.options.some((option) => option.long === '--host')).toBe(false);
+    expect(tapCommand?.options.some((option) => option.long === '--port')).toBe(false);
 
     await program.parseAsync(
-      ['node', 'test', 'tap', '--session', 'session-1', '--host', '10.0.0.5', '--port', '9090'],
+      [
+        'node',
+        'test',
+        'agent',
+        '--host',
+        '10.0.0.5',
+        '--port',
+        '9090',
+        'tap',
+        '--session',
+        'session-1',
+      ],
       { from: 'node' },
     );
 

--- a/packages/cli/src/__tests__/agent-tap-format.test.ts
+++ b/packages/cli/src/__tests__/agent-tap-format.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatTapEventLine,
+  formatTapEventNdjson,
+  formatTapTimestamp,
+} from '../commands/agent/tap-format.js';
+
+describe('tap output formatting', () => {
+  describe('formatTapTimestamp', () => {
+    it('renders local HH:MM:SS.mmm, zero-padded', () => {
+      const date = new Date(2024, 0, 1, 9, 4, 5, 7);
+      expect(formatTapTimestamp(date.getTime())).toBe('09:04:05.007');
+    });
+
+    it('pads a three-digit millisecond value without truncating it', () => {
+      const date = new Date(2024, 0, 1, 12, 4, 31, 220);
+      expect(formatTapTimestamp(date.getTime())).toBe('12:04:31.220');
+    });
+  });
+
+  describe('formatTapEventLine', () => {
+    it('renders an inbound message with a left arrow', () => {
+      const line = formatTapEventLine({
+        direction: 'in',
+        timestamp: new Date(2024, 0, 1, 12, 4, 31, 220).getTime(),
+        pluginId: '@acme/sqlite-plugin',
+        type: 'list-tables-request',
+        payload: { requestId: 'a1' },
+      });
+
+      expect(line.startsWith('← 12:04:31.220')).toBe(true);
+      expect(line).toContain('list-tables-request');
+      expect(line.endsWith('{"requestId":"a1"}')).toBe(true);
+    });
+
+    it('renders an outbound message with a right arrow', () => {
+      const line = formatTapEventLine({
+        direction: 'out',
+        timestamp: new Date(2024, 0, 1, 12, 4, 31, 244).getTime(),
+        pluginId: '@acme/sqlite-plugin',
+        type: 'list-tables-response',
+        payload: { requestId: 'a1', tables: ['users', 'posts'] },
+      });
+
+      expect(line.startsWith('→ 12:04:31.244')).toBe(true);
+    });
+
+    it('starts the payload at the same column for a short and a long type', () => {
+      const short = formatTapEventLine({
+        direction: 'in',
+        timestamp: 0,
+        pluginId: 'p',
+        type: 'a',
+        payload: 1,
+      });
+      const long = formatTapEventLine({
+        direction: 'in',
+        timestamp: 0,
+        pluginId: 'p',
+        type: 'b',
+        payload: 2,
+      });
+
+      expect(short.indexOf('1')).toBe(long.indexOf('2'));
+    });
+
+    it('does not truncate a type longer than the padded column width', () => {
+      const longType = 'a-very-long-message-type-name-that-exceeds-the-column';
+      const line = formatTapEventLine({
+        direction: 'in',
+        timestamp: 0,
+        pluginId: 'p',
+        type: longType,
+        payload: null,
+      });
+
+      expect(line).toContain(longType);
+      expect(line.endsWith('null')).toBe(true);
+    });
+  });
+
+  describe('formatTapEventNdjson', () => {
+    it('serializes the full event as compact JSON', () => {
+      const event = {
+        direction: 'out' as const,
+        timestamp: 1700000000000,
+        pluginId: '@acme/sqlite-plugin',
+        type: 'query',
+        payload: { sql: 'select 1' },
+      };
+
+      expect(formatTapEventNdjson(event)).toBe(JSON.stringify(event));
+      expect(formatTapEventNdjson(event)).not.toContain('\n');
+    });
+  });
+});

--- a/packages/cli/src/__tests__/agent-tap-format.test.ts
+++ b/packages/cli/src/__tests__/agent-tap-format.test.ts
@@ -46,22 +46,26 @@ describe('tap output formatting', () => {
     });
 
     it('starts the payload at the same column for a short and a long type', () => {
+      const timestamp = new Date(2024, 0, 1, 12, 4, 31, 220).getTime();
       const short = formatTapEventLine({
         direction: 'in',
-        timestamp: 0,
+        timestamp,
         pluginId: 'p',
         type: 'a',
-        payload: 1,
+        payload: 'short-payload',
       });
       const long = formatTapEventLine({
         direction: 'in',
-        timestamp: 0,
+        timestamp,
         pluginId: 'p',
-        type: 'b',
-        payload: 2,
+        type: 'a-longer-type',
+        payload: 'long-payload',
       });
 
-      expect(short.indexOf('1')).toBe(long.indexOf('2'));
+      // Search for the payload rather than a bare digit: the timestamp is
+      // local, so a digit-based search finds a different column depending on
+      // the machine's time zone.
+      expect(short.indexOf('"short-payload"')).toBe(long.indexOf('"long-payload"'));
     });
 
     it('does not truncate a type longer than the padded column width', () => {

--- a/packages/cli/src/commands/agent/register-agent-command.ts
+++ b/packages/cli/src/commands/agent/register-agent-command.ts
@@ -14,6 +14,7 @@ import {
 import { printOutput } from './output.js';
 import { formatAgentCommand, paginateRows } from './output-shaping.js';
 import { getErrorMessage } from './error-message.js';
+import { registerTapCommand } from './register-tap-command.js';
 import { getPackageJSON } from '../../package-json.js';
 
 const REMOVED_ROZENITE_DOMAIN_HINT =
@@ -456,6 +457,8 @@ export const registerAgentCommand = (program: Command): void => {
         printOutput(payload, true, !!options.pretty);
       });
     });
+
+  registerTapCommand(mcpCommand);
 
   const sessionCommand = mcpCommand
     .command('session')

--- a/packages/cli/src/commands/agent/register-tap-command.ts
+++ b/packages/cli/src/commands/agent/register-tap-command.ts
@@ -1,0 +1,138 @@
+import { Command } from 'commander';
+import { createAgentTransport } from '@rozenite/agent-sdk/transport';
+import type { AgentTapStreamHandle } from '@rozenite/agent-sdk';
+import { DEFAULT_AGENT_HOST, DEFAULT_AGENT_PORT } from '@rozenite/agent-shared';
+import { formatTapEventLine, formatTapEventNdjson } from './tap-format.js';
+import { getErrorMessage } from './error-message.js';
+
+type TapCommandOptions = {
+  host: string;
+  port: string;
+  session: string;
+  plugin?: string;
+  type?: string;
+  payload: string;
+  json?: boolean;
+};
+
+export const parseTapPayload = (raw: string): unknown => {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    throw new Error('--payload must be valid JSON');
+  }
+};
+
+const reportTapError = (error: unknown, asJson: boolean): void => {
+  const message = getErrorMessage(error);
+  if (asJson) {
+    process.stdout.write(`${JSON.stringify({ error: { message } })}\n`);
+  } else {
+    process.stderr.write(`${message}\n`);
+  }
+  process.exitCode = 1;
+};
+
+export const runTapCommand = async (options: TapCommandOptions): Promise<void> => {
+  const asJson = !!options.json;
+
+  let payload: unknown;
+  try {
+    payload = parseTapPayload(options.payload);
+  } catch (error) {
+    reportTapError(error, asJson);
+    return;
+  }
+
+  if (options.type && !options.plugin) {
+    reportTapError(new Error('--plugin is required when --type is provided'), asJson);
+    return;
+  }
+
+  const transport = createAgentTransport({
+    host: options.host,
+    port: Number(options.port),
+  });
+
+  await new Promise<void>((resolve) => {
+    let settled = false;
+
+    const finish = (): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      process.off('SIGINT', onSignal);
+      process.off('SIGTERM', onSignal);
+      resolve();
+    };
+
+    const onSignal = (): void => {
+      handle.close();
+      finish();
+    };
+
+    const handle: AgentTapStreamHandle = transport.openSessionTap(
+      options.session,
+      // `--type` names the outbound message being sent, not a display
+      // filter — filtering on it would hide the very response the poke is
+      // meant to surface. Only `--plugin` narrows what's streamed.
+      { pluginId: options.plugin },
+      {
+        onOpen: () => {
+          if (!options.type || !options.plugin) {
+            return;
+          }
+
+          transport
+            .sendSessionTapMessage(options.session, {
+              pluginId: options.plugin,
+              type: options.type,
+              payload,
+            })
+            .catch((error: unknown) => {
+              reportTapError(error, asJson);
+              handle.close();
+              finish();
+            });
+        },
+        onEvent: (event) => {
+          process.stdout.write(
+            `${asJson ? formatTapEventNdjson(event) : formatTapEventLine(event)}\n`,
+          );
+        },
+        onError: (error) => {
+          reportTapError(error, asJson);
+          finish();
+        },
+        onEnd: finish,
+      },
+    );
+
+    // Registered after `handle` exists: nothing yields the event loop
+    // between the two, so no signal can arrive in between.
+    process.once('SIGINT', onSignal);
+    process.once('SIGTERM', onSignal);
+  });
+};
+
+export const registerTapCommand = (program: Command): void => {
+  program
+    .command('tap')
+    .description(
+      "Stream a session's Rozenite plugin messages to stdout in both directions, and optionally send one",
+    )
+    .option('--host <host>', 'Metro host', DEFAULT_AGENT_HOST)
+    .option('--port <port>', 'Metro port', String(DEFAULT_AGENT_PORT))
+    .requiredOption('-s, --session <id>', 'Target Agent session ID')
+    .option('-p, --plugin <id>', 'Filter the stream to this plugin ID; required with --type')
+    .option(
+      '-t, --type <name>',
+      'Send one message of this type before watching the stream (requires --plugin)',
+    )
+    .option('-a, --payload <json>', 'JSON payload for the sent message', '{}')
+    .option('--json', 'Newline-delimited JSON output, one message per line')
+    .action(async (options: TapCommandOptions) => {
+      await runTapCommand(options);
+    });
+};

--- a/packages/cli/src/commands/agent/register-tap-command.ts
+++ b/packages/cli/src/commands/agent/register-tap-command.ts
@@ -5,14 +5,17 @@ import { DEFAULT_AGENT_HOST, DEFAULT_AGENT_PORT } from '@rozenite/agent-shared';
 import { formatTapEventLine, formatTapEventNdjson } from './tap-format.js';
 import { getErrorMessage } from './error-message.js';
 
-type TapCommandOptions = {
-  host: string;
-  port: string;
+type TapOptions = {
   session: string;
   plugin?: string;
   type?: string;
   payload: string;
   json?: boolean;
+};
+
+type TapCommandOptions = TapOptions & {
+  host: string;
+  port: string;
 };
 
 export const parseTapPayload = (raw: string): unknown => {
@@ -116,14 +119,12 @@ export const runTapCommand = async (options: TapCommandOptions): Promise<void> =
   });
 };
 
-export const registerTapCommand = (program: Command): void => {
-  program
+export const registerTapCommand = (agentCommand: Command): void => {
+  agentCommand
     .command('tap')
     .description(
       "Stream a session's Rozenite plugin messages to stdout in both directions, and optionally send one",
     )
-    .option('--host <host>', 'Metro host', DEFAULT_AGENT_HOST)
-    .option('--port <port>', 'Metro port', String(DEFAULT_AGENT_PORT))
     .requiredOption('-s, --session <id>', 'Target Agent session ID')
     .option('-p, --plugin <id>', 'Filter the stream to this plugin ID; required with --type')
     .option(
@@ -132,7 +133,17 @@ export const registerTapCommand = (program: Command): void => {
     )
     .option('-a, --payload <json>', 'JSON payload for the sent message', '{}')
     .option('--json', 'Newline-delimited JSON output, one message per line')
-    .action(async (options: TapCommandOptions) => {
-      await runTapCommand(options);
+    // `--host`/`--port` are inherited from `rozenite agent`, the same way
+    // `rozenite agent targets` reads them, rather than redeclared here.
+    .action(async (options: TapOptions, command: Command) => {
+      const globals = command.optsWithGlobals<{
+        host?: string;
+        port?: string;
+      }>();
+      await runTapCommand({
+        ...options,
+        host: globals.host ?? DEFAULT_AGENT_HOST,
+        port: String(globals.port ?? DEFAULT_AGENT_PORT),
+      });
     });
 };

--- a/packages/cli/src/commands/agent/tap-format.ts
+++ b/packages/cli/src/commands/agent/tap-format.ts
@@ -1,0 +1,34 @@
+import type { TapEvent } from '@rozenite/agent-shared';
+
+const ARROW_IN = '←';
+const ARROW_OUT = '→';
+
+/**
+ * Width the `type` column is padded to in human-readable output, so the
+ * payload starts at the same column on every line regardless of its
+ * neighbors — the stream is unbounded, so alignment can't look ahead at
+ * future lines the way a buffered table could.
+ */
+const TYPE_COLUMN_WIDTH = 28;
+
+const pad2 = (value: number): string => String(value).padStart(2, '0');
+const pad3 = (value: number): string => String(value).padStart(3, '0');
+
+/** `HH:MM:SS.mmm` in local time, matching the issue's worked example. */
+export const formatTapTimestamp = (timestamp: number): string => {
+  const date = new Date(timestamp);
+  return `${pad2(date.getHours())}:${pad2(date.getMinutes())}:${pad2(date.getSeconds())}.${pad3(date.getMilliseconds())}`;
+};
+
+/** Human-readable line: direction arrow, timestamp, type, payload. */
+export const formatTapEventLine = (event: TapEvent): string => {
+  const arrow = event.direction === 'in' ? ARROW_IN : ARROW_OUT;
+  const time = formatTapTimestamp(event.timestamp);
+  const type =
+    event.type.length >= TYPE_COLUMN_WIDTH ? event.type : event.type.padEnd(TYPE_COLUMN_WIDTH);
+
+  return `${arrow} ${time}  ${type}  ${JSON.stringify(event.payload)}`;
+};
+
+/** One compact JSON object per line — the documented `--json` shape. */
+export const formatTapEventNdjson = (event: TapEvent): string => JSON.stringify(event);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,6 +10,7 @@ import { devCommand } from './commands/dev-command.js';
 import { initCommand } from './commands/init-command.js';
 import { openCommand } from './commands/open-command.js';
 import { registerAgentCommand } from './commands/agent/register-agent-command.js';
+import { registerTapCommand } from './commands/agent/register-tap-command.js';
 import { registerSkillsCommand } from './commands/register-skills-command.js';
 import { getErrorMessage } from './commands/agent/error-message.js';
 
@@ -101,6 +102,7 @@ const main = async () => {
     });
 
   registerAgentCommand(program);
+  registerTapCommand(program);
   registerSkillsCommand(program);
 
   await program.parseAsync(process.argv);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,7 +10,6 @@ import { devCommand } from './commands/dev-command.js';
 import { initCommand } from './commands/init-command.js';
 import { openCommand } from './commands/open-command.js';
 import { registerAgentCommand } from './commands/agent/register-agent-command.js';
-import { registerTapCommand } from './commands/agent/register-tap-command.js';
 import { registerSkillsCommand } from './commands/register-skills-command.js';
 import { getErrorMessage } from './commands/agent/error-message.js';
 
@@ -102,7 +101,6 @@ const main = async () => {
     });
 
   registerAgentCommand(program);
-  registerTapCommand(program);
   registerSkillsCommand(program);
 
   await program.parseAsync(process.argv);

--- a/packages/middleware/src/__tests__/agent-routes-tap.test.ts
+++ b/packages/middleware/src/__tests__/agent-routes-tap.test.ts
@@ -1,0 +1,261 @@
+import { createServer, get, request as httpRequest, type IncomingMessage } from 'node:http';
+import express from 'express';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { AgentResponseEnvelope, TapEvent } from '@rozenite/agent-shared';
+import { createAgentRoutes } from '../agent/routes.js';
+import type { AgentSessionManager } from '../agent/session-manager.js';
+import type { TapListener } from '../agent/tap.js';
+
+let activeServer: ReturnType<typeof createServer> | null = null;
+
+afterEach(async () => {
+  await new Promise<void>((resolve, reject) => {
+    if (!activeServer) {
+      resolve();
+      return;
+    }
+
+    activeServer.close((error) => {
+      activeServer = null;
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+});
+
+const createFakeManager = (overrides: Partial<AgentSessionManager> = {}): AgentSessionManager => {
+  return {
+    syncEndpoint: vi.fn(),
+    getInfo: vi.fn(),
+    listTargets: vi.fn(async () => []),
+    createSession: vi.fn(async () => {
+      throw new Error('not implemented in this fake');
+    }),
+    listSessions: vi.fn(() => []),
+    getSession: vi.fn(() => {
+      throw new Error('Unknown session "missing"');
+    }),
+    stopSession: vi.fn(async () => ({ stopped: true })),
+    getSessionTools: vi.fn(() => []),
+    callSessionTool: vi.fn(async () => undefined),
+    subscribeSessionTap: vi.fn(() => vi.fn()),
+    sendSessionTapMessage: vi.fn(async () => undefined),
+    dispose: vi.fn(async () => undefined),
+    ...overrides,
+  } as unknown as AgentSessionManager;
+};
+
+const startServer = async (manager: AgentSessionManager): Promise<number> => {
+  // Mount on a real `express()` app rather than invoking the bare `Router`
+  // against a plain `http.createServer` handler — a Router alone doesn't
+  // get Express's request/response augmentation (`res.json`, `req.query`,
+  // etc.), which every route here relies on. This mirrors how
+  // `getMiddleware` mounts it in `middleware.ts`.
+  const app = express();
+  app.use(createAgentRoutes(manager));
+  activeServer = createServer(app);
+
+  await new Promise<void>((resolve) => {
+    activeServer!.listen(0, resolve);
+  });
+
+  const address = activeServer.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Expected an ephemeral TCP port');
+  }
+  return address.port;
+};
+
+const readJson = async (response: IncomingMessage): Promise<unknown> => {
+  let body = '';
+  response.setEncoding('utf8');
+  for await (const chunk of response) {
+    body += chunk;
+  }
+  return JSON.parse(body);
+};
+
+describe('agent tap routes', () => {
+  it('returns a 404 envelope for an unknown session instead of starting a stream', async () => {
+    const manager = createFakeManager();
+    const port = await startServer(manager);
+
+    const response = await new Promise<IncomingMessage>((resolve, reject) => {
+      get(`http://127.0.0.1:${port}/rozenite/agent/sessions/missing/tap`, resolve).on(
+        'error',
+        reject,
+      );
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.headers['content-type']).toContain('application/json');
+    await expect(readJson(response)).resolves.toEqual({
+      ok: false,
+      error: { message: 'Unknown session "missing"' },
+    });
+    expect(manager.subscribeSessionTap).not.toHaveBeenCalled();
+  });
+
+  it('streams tapped events as newline-delimited JSON for a known session', async () => {
+    let capturedListener: TapListener | undefined;
+    const unsubscribe = vi.fn();
+    const manager = createFakeManager({
+      getSession: vi.fn(() => ({ id: 'device-1' }) as never),
+      subscribeSessionTap: vi.fn((_sessionId, listener) => {
+        capturedListener = listener;
+        return unsubscribe;
+      }),
+    });
+    const port = await startServer(manager);
+
+    const req = httpRequest(`http://127.0.0.1:${port}/rozenite/agent/sessions/device-1/tap`);
+    req.end();
+
+    const response = await new Promise<IncomingMessage>((resolve) => {
+      req.on('response', resolve);
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['content-type']).toContain('application/x-ndjson');
+    expect(manager.subscribeSessionTap).toHaveBeenCalledWith('device-1', expect.any(Function));
+
+    const firstLine = new Promise<string>((resolve) => {
+      response.setEncoding('utf8');
+      response.once('data', resolve);
+    });
+
+    const event: TapEvent = {
+      direction: 'in',
+      timestamp: 1700000000000,
+      pluginId: '@acme/sqlite-plugin',
+      type: 'list-tables-request',
+      payload: { requestId: 'a1' },
+    };
+    capturedListener?.(event);
+
+    expect(JSON.parse((await firstLine).trim())).toEqual(event);
+
+    req.destroy();
+    // Both the request's and the response's `close` event can fire on an
+    // abrupt disconnect, so `unsubscribe` may run more than once — the real
+    // implementation (a `Set.delete`) tolerates that, and the route doesn't
+    // try to dedupe it.
+    await vi.waitFor(() => expect(unsubscribe).toHaveBeenCalled());
+  });
+
+  it('filters the stream to the requested pluginId', async () => {
+    let capturedListener: TapListener | undefined;
+    const manager = createFakeManager({
+      getSession: vi.fn(() => ({ id: 'device-1' }) as never),
+      subscribeSessionTap: vi.fn((_sessionId, listener) => {
+        capturedListener = listener;
+        return vi.fn();
+      }),
+    });
+    const port = await startServer(manager);
+
+    const req = httpRequest(
+      `http://127.0.0.1:${port}/rozenite/agent/sessions/device-1/tap?pluginId=${encodeURIComponent('@acme/sqlite-plugin')}`,
+    );
+    req.end();
+    const response = await new Promise<IncomingMessage>((resolve) => {
+      req.on('response', resolve);
+    });
+    response.setEncoding('utf8');
+
+    const lines: string[] = [];
+    response.on('data', (chunk: string) => {
+      lines.push(...chunk.split('\n').filter(Boolean));
+    });
+
+    capturedListener?.({
+      direction: 'in',
+      timestamp: 1,
+      pluginId: '@other/plugin',
+      type: 'noise',
+      payload: {},
+    });
+    capturedListener?.({
+      direction: 'out',
+      timestamp: 2,
+      pluginId: '@acme/sqlite-plugin',
+      type: 'query',
+      payload: { sql: 'select 1' },
+    });
+
+    await vi.waitFor(() => expect(lines).toHaveLength(1));
+    expect(JSON.parse(lines[0])).toMatchObject({ pluginId: '@acme/sqlite-plugin', type: 'query' });
+
+    req.destroy();
+  });
+
+  it('rejects a POST send without pluginId or type', async () => {
+    const manager = createFakeManager({ getSession: vi.fn(() => ({ id: 'device-1' }) as never) });
+    const port = await startServer(manager);
+
+    const response = await postJson(port, '/rozenite/agent/sessions/device-1/tap', {});
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({
+      ok: false,
+      error: { message: '"pluginId" is required' },
+    });
+    expect(manager.sendSessionTapMessage).not.toHaveBeenCalled();
+  });
+
+  it('sends a tap message and reports success', async () => {
+    const manager = createFakeManager({ getSession: vi.fn(() => ({ id: 'device-1' }) as never) });
+    const port = await startServer(manager);
+
+    const response = await postJson(port, '/rozenite/agent/sessions/device-1/tap', {
+      pluginId: '@acme/sqlite-plugin',
+      type: 'query',
+      payload: { sql: 'select 1' },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ ok: true, result: { sent: true } });
+    expect(manager.sendSessionTapMessage).toHaveBeenCalledWith('device-1', {
+      pluginId: '@acme/sqlite-plugin',
+      type: 'query',
+      payload: { sql: 'select 1' },
+    });
+  });
+});
+
+const postJson = async (
+  port: number,
+  path: string,
+  body: unknown,
+): Promise<{ status: number; body: AgentResponseEnvelope<unknown> }> => {
+  const payload = JSON.stringify(body);
+
+  return new Promise((resolve, reject) => {
+    const req = httpRequest(
+      `http://127.0.0.1:${port}${path}`,
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'content-length': Buffer.byteLength(payload, 'utf8'),
+        },
+      },
+      (res) => {
+        res.setEncoding('utf8');
+        let data = '';
+        res.on('data', (chunk: string) => {
+          data += chunk;
+        });
+        res.on('end', () => {
+          resolve({ status: res.statusCode ?? 0, body: JSON.parse(data) });
+        });
+      },
+    );
+    req.on('error', reject);
+    req.write(payload);
+    req.end();
+  });
+};

--- a/packages/middleware/src/__tests__/agent-session-manager.test.ts
+++ b/packages/middleware/src/__tests__/agent-session-manager.test.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_AGENT_PORT,
   getAgentSessionCallToolRoute,
   getAgentSessionRoute,
+  getAgentSessionTapRoute,
   getAgentSessionToolsRoute,
 } from '@rozenite/agent-shared';
 import { createAgentSessionManager } from '../agent/session-manager.js';
@@ -20,6 +21,8 @@ const mocks = vi.hoisted(() => {
   const getTools = vi.fn();
   const callTool = vi.fn();
   const isReusable = vi.fn(() => true);
+  const subscribeTap = vi.fn(() => vi.fn());
+  const sendTapMessage = vi.fn(async () => undefined);
   const createAgentSession = vi.fn(() => ({
     id: 'device-1',
     start,
@@ -27,6 +30,8 @@ const mocks = vi.hoisted(() => {
     getInfo,
     getTools,
     callTool,
+    subscribeTap,
+    sendTapMessage,
     isReusable,
   }));
 
@@ -38,6 +43,8 @@ const mocks = vi.hoisted(() => {
     getInfo,
     getTools,
     callTool,
+    subscribeTap,
+    sendTapMessage,
     isReusable,
     createAgentSession,
   };
@@ -58,6 +65,10 @@ describe('agent session manager', () => {
     mocks.start.mockReset();
     mocks.start.mockResolvedValue(undefined);
     mocks.isReusable.mockReturnValue(true);
+    mocks.subscribeTap.mockReset();
+    mocks.subscribeTap.mockReturnValue(vi.fn());
+    mocks.sendTapMessage.mockReset();
+    mocks.sendTapMessage.mockResolvedValue(undefined);
   });
 
   const target = {
@@ -79,6 +90,7 @@ describe('agent session manager', () => {
     expect(getAgentSessionCallToolRoute('device-1')).toBe(
       '/rozenite/agent/sessions/device-1/call-tool',
     );
+    expect(getAgentSessionTapRoute('device-1')).toBe('/rozenite/agent/sessions/device-1/tap');
   });
 
   it('uses default loopback Metro endpoint', () => {
@@ -212,6 +224,36 @@ describe('agent session manager', () => {
     await expect(manager.callSessionTool('device-1', 'startTrace', {})).resolves.toEqual({
       ok: true,
     });
+  });
+
+  it('delegates tap subscription and sending to the session instance', async () => {
+    mocks.resolveMetroTarget.mockResolvedValue(target);
+    mocks.getInfo.mockReturnValue({ id: 'device-1', deviceName: 'Phone' });
+    const listener = vi.fn();
+    const unsubscribe = vi.fn();
+    mocks.subscribeTap.mockReturnValue(unsubscribe);
+
+    const manager = createAgentSessionManager({ projectRoot: '/app' });
+    await manager.createSession({ deviceId: 'device-1' });
+
+    const returnedUnsubscribe = manager.subscribeSessionTap('device-1', listener);
+    expect(mocks.subscribeTap).toHaveBeenCalledWith(listener);
+    expect(returnedUnsubscribe).toBe(unsubscribe);
+
+    const message = { pluginId: 'p', type: 't', payload: { a: 1 } };
+    await manager.sendSessionTapMessage('device-1', message);
+    expect(mocks.sendTapMessage).toHaveBeenCalledWith(message);
+  });
+
+  it('throws for tap operations against an unknown session', async () => {
+    const manager = createAgentSessionManager({ projectRoot: '/app' });
+
+    expect(() => manager.subscribeSessionTap('missing', vi.fn())).toThrow(
+      'Unknown session "missing"',
+    );
+    await expect(
+      manager.sendSessionTapMessage('missing', { pluginId: 'p', type: 't', payload: {} }),
+    ).rejects.toThrow('Unknown session "missing"');
   });
 
   it('waits for session startup before resolving createSession', async () => {

--- a/packages/middleware/src/__tests__/agent-session.test.ts
+++ b/packages/middleware/src/__tests__/agent-session.test.ts
@@ -702,4 +702,124 @@ describe('agent session', () => {
     socket.close();
     await rejection;
   });
+
+  describe('tap', () => {
+    it('tees an inbound rozenite-domain plugin message to subscribers', async () => {
+      const { session } = await bootstrapSession();
+      const listener = vi.fn();
+      session.subscribeTap(listener);
+
+      await emitRozeniteBindingPayload(mocks.wsInstances[0], {
+        pluginId: '@acme/sqlite-plugin',
+        type: 'list-tables-request',
+        payload: { requestId: 'a1' },
+      });
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({
+          direction: 'in',
+          pluginId: '@acme/sqlite-plugin',
+          type: 'list-tables-request',
+          payload: { requestId: 'a1' },
+        }),
+      );
+    });
+
+    it('tees a message sent through the device sender as outbound', async () => {
+      const { session } = await bootstrapSession();
+      const listener = vi.fn();
+      session.subscribeTap(listener);
+
+      const sender = mocks.handler.connectDevice.mock.calls[0]?.[2] as
+        | { sendMessage: (message: unknown) => void }
+        | undefined;
+      expect(sender).toBeDefined();
+
+      sender?.sendMessage({
+        pluginId: 'rozenite-agent',
+        type: 'tool-call',
+        payload: { callId: '1', toolName: 'echo', arguments: {} },
+      });
+      await flushMicrotasks();
+
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({
+          direction: 'out',
+          pluginId: 'rozenite-agent',
+          type: 'tool-call',
+        }),
+      );
+    });
+
+    it('does not tee a malformed outbound message missing pluginId/type', async () => {
+      const { session } = await bootstrapSession();
+      const listener = vi.fn();
+      session.subscribeTap(listener);
+
+      const sender = mocks.handler.connectDevice.mock.calls[0]?.[2] as
+        | { sendMessage: (message: unknown) => void }
+        | undefined;
+
+      sender?.sendMessage({ marker: 'not-a-plugin-message' });
+      await flushMicrotasks();
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('stops delivering to a subscriber that unsubscribed', async () => {
+      const { session } = await bootstrapSession();
+      const listener = vi.fn();
+      const unsubscribe = session.subscribeTap(listener);
+      unsubscribe();
+
+      await emitRozeniteBindingPayload(mocks.wsInstances[0], {
+        pluginId: '@acme/sqlite-plugin',
+        type: 'list-tables-request',
+        payload: {},
+      });
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('sends and tees a message via sendTapMessage while connected', async () => {
+      const { session } = await bootstrapSession();
+      const listener = vi.fn();
+      session.subscribeTap(listener);
+
+      await session.sendTapMessage({
+        pluginId: '@acme/sqlite-plugin',
+        type: 'query',
+        payload: { sql: 'select 1' },
+      });
+
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({
+          direction: 'out',
+          pluginId: '@acme/sqlite-plugin',
+          type: 'query',
+          payload: { sql: 'select 1' },
+        }),
+      );
+
+      // The Runtime.evaluate expression embeds the message as a JSON string
+      // literal, so its own quotes come through backslash-escaped.
+      const expressions = getExpressions();
+      expect(
+        expressions.some(
+          (expression) =>
+            expression.includes('sendMessage("rozenite"') &&
+            expression.includes('\\"type\\":\\"query\\"'),
+        ),
+      ).toBe(true);
+    });
+
+    it('rejects sendTapMessage when the session is not connected', async () => {
+      const { session } = createStartedSession();
+
+      await expect(
+        session.sendTapMessage({ pluginId: 'plugin', type: 'type', payload: {} }),
+      ).rejects.toThrow('is not connected to a device');
+    });
+  });
 });

--- a/packages/middleware/src/__tests__/agent-tap.test.ts
+++ b/packages/middleware/src/__tests__/agent-tap.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createTapEmitter, isDevToolsPluginMessage, matchesTapFilter } from '../agent/tap.js';
+
+describe('agent tap', () => {
+  describe('createTapEmitter', () => {
+    it('does nothing when there are no subscribers', () => {
+      const tap = createTapEmitter();
+
+      expect(() =>
+        tap.emit('in', { pluginId: '@acme/sqlite-plugin', type: 'query', payload: {} }),
+      ).not.toThrow();
+    });
+
+    it('delivers a timestamped event to every subscriber', () => {
+      const tap = createTapEmitter();
+      const listenerA = vi.fn();
+      const listenerB = vi.fn();
+      tap.subscribe(listenerA);
+      tap.subscribe(listenerB);
+
+      const before = Date.now();
+      tap.emit('in', {
+        pluginId: '@acme/sqlite-plugin',
+        type: 'list-tables-request',
+        payload: { requestId: 'a1' },
+      });
+      const after = Date.now();
+
+      expect(listenerA).toHaveBeenCalledTimes(1);
+      expect(listenerB).toHaveBeenCalledTimes(1);
+
+      const event = listenerA.mock.calls[0][0];
+      expect(event).toMatchObject({
+        direction: 'in',
+        pluginId: '@acme/sqlite-plugin',
+        type: 'list-tables-request',
+        payload: { requestId: 'a1' },
+      });
+      expect(event.timestamp).toBeGreaterThanOrEqual(before);
+      expect(event.timestamp).toBeLessThanOrEqual(after);
+      expect(listenerB.mock.calls[0][0]).toEqual(event);
+    });
+
+    it('stops delivering to a listener after it unsubscribes', () => {
+      const tap = createTapEmitter();
+      const listener = vi.fn();
+      const unsubscribe = tap.subscribe(listener);
+
+      tap.emit('out', { pluginId: 'plugin', type: 'a', payload: null });
+      unsubscribe();
+      tap.emit('out', { pluginId: 'plugin', type: 'b', payload: null });
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener).toHaveBeenCalledWith(expect.objectContaining({ type: 'a' }));
+    });
+
+    it('leaves other subscribers intact when one unsubscribes', () => {
+      const tap = createTapEmitter();
+      const listenerA = vi.fn();
+      const listenerB = vi.fn();
+      const unsubscribeA = tap.subscribe(listenerA);
+      tap.subscribe(listenerB);
+
+      unsubscribeA();
+      tap.emit('in', { pluginId: 'plugin', type: 'a', payload: null });
+
+      expect(listenerA).not.toHaveBeenCalled();
+      expect(listenerB).toHaveBeenCalledTimes(1);
+    });
+
+    it('tolerates unsubscribing twice', () => {
+      const tap = createTapEmitter();
+      const unsubscribe = tap.subscribe(vi.fn());
+
+      expect(() => {
+        unsubscribe();
+        unsubscribe();
+      }).not.toThrow();
+    });
+  });
+
+  describe('isDevToolsPluginMessage', () => {
+    it('accepts a well-formed plugin message', () => {
+      expect(
+        isDevToolsPluginMessage({ pluginId: '@acme/plugin', type: 'query', payload: { a: 1 } }),
+      ).toBe(true);
+    });
+
+    it('accepts an explicit undefined payload, since the key is still present', () => {
+      expect(isDevToolsPluginMessage({ pluginId: 'p', type: 't', payload: undefined })).toBe(true);
+    });
+
+    it.each([
+      ['null', null],
+      ['a string', 'not-an-object'],
+      ['missing pluginId', { type: 't', payload: {} }],
+      ['a non-string pluginId', { pluginId: 42, type: 't', payload: {} }],
+      ['missing type', { pluginId: 'p', payload: {} }],
+      ['a non-string type', { pluginId: 'p', type: 9, payload: {} }],
+      ['missing payload entirely', { pluginId: 'p', type: 't' }],
+    ])('rejects %s', (_label, value) => {
+      expect(isDevToolsPluginMessage(value)).toBe(false);
+    });
+  });
+
+  describe('matchesTapFilter', () => {
+    const event = {
+      direction: 'in' as const,
+      timestamp: 1,
+      pluginId: '@acme/sqlite-plugin',
+      type: 'list-tables-request',
+      payload: {},
+    };
+
+    it('matches everything when the filter is empty', () => {
+      expect(matchesTapFilter(event, {})).toBe(true);
+    });
+
+    it('matches on pluginId alone', () => {
+      expect(matchesTapFilter(event, { pluginId: '@acme/sqlite-plugin' })).toBe(true);
+      expect(matchesTapFilter(event, { pluginId: '@other/plugin' })).toBe(false);
+    });
+
+    it('matches on type alone', () => {
+      expect(matchesTapFilter(event, { type: 'list-tables-request' })).toBe(true);
+      expect(matchesTapFilter(event, { type: 'list-tables-response' })).toBe(false);
+    });
+
+    it('requires both dimensions to match when both are given', () => {
+      expect(
+        matchesTapFilter(event, { pluginId: '@acme/sqlite-plugin', type: 'list-tables-request' }),
+      ).toBe(true);
+      expect(matchesTapFilter(event, { pluginId: '@acme/sqlite-plugin', type: 'wrong-type' })).toBe(
+        false,
+      );
+      expect(
+        matchesTapFilter(event, { pluginId: '@other/plugin', type: 'list-tables-request' }),
+      ).toBe(false);
+    });
+  });
+});

--- a/packages/middleware/src/agent/routes.ts
+++ b/packages/middleware/src/agent/routes.ts
@@ -3,6 +3,7 @@ import {
   AGENT_INFO_ROUTE,
   AGENT_SESSION_CALL_TOOL_ROUTE_PATTERN,
   AGENT_SESSION_ROUTE_PATTERN,
+  AGENT_SESSION_TAP_ROUTE_PATTERN,
   AGENT_SESSION_TOOLS_ROUTE_PATTERN,
   AGENT_SESSIONS_ROUTE,
   AGENT_TARGETS_ROUTE,
@@ -16,8 +17,10 @@ import {
   type CreateAgentSessionResponse,
   type DeleteAgentSessionResponse,
   type CallAgentSessionToolResponse,
+  type SendAgentSessionTapMessageResponse,
 } from '@rozenite/agent-shared';
 import type { AgentSessionManager } from './session-manager.js';
+import { matchesTapFilter } from './tap.js';
 
 const getRequestHost = (req: Request): string => {
   const hostHeader = req.headers.host;
@@ -173,6 +176,77 @@ export const createAgentRoutes = (manager: AgentSessionManager): Router => {
       sendResult<CallAgentSessionToolResponse>(res, {
         result,
       } satisfies CallAgentSessionToolResponse);
+    } catch (error) {
+      sendError(res, error);
+    }
+  });
+
+  // GET streams tapped `rozenite`-domain messages for this session as
+  // newline-delimited JSON (chunked transfer encoding) until the client
+  // disconnects. There's no other streaming route on this server to match a
+  // house style against, so this follows the same shape as every other
+  // route here — a plain Express handler on the existing Metro-owned HTTP
+  // server — rather than introducing a WebSocket upgrade path this server
+  // doesn't otherwise own.
+  router.get(AGENT_SESSION_TAP_ROUTE_PATTERN, (req, res) => {
+    syncEndpoint(manager, req);
+
+    let sessionId: string;
+    try {
+      sessionId = getSessionId(req);
+      // Resolve the session before flushing headers: once a chunked
+      // response starts, a 404 can no longer be reported through the usual
+      // JSON error envelope.
+      manager.getSession(sessionId);
+    } catch (error) {
+      sendError(res, error);
+      return;
+    }
+
+    const pluginId = typeof req.query.pluginId === 'string' ? req.query.pluginId : undefined;
+    const type = typeof req.query.type === 'string' ? req.query.type : undefined;
+
+    res.status(200);
+    res.setHeader('Content-Type', 'application/x-ndjson');
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Connection', 'keep-alive');
+    res.flushHeaders();
+
+    const unsubscribe = manager.subscribeSessionTap(sessionId, (event) => {
+      if (!matchesTapFilter(event, { pluginId, type })) {
+        return;
+      }
+      res.write(`${JSON.stringify(event)}\n`);
+    });
+
+    const cleanup = (): void => {
+      unsubscribe();
+    };
+
+    req.on('close', cleanup);
+    res.on('close', cleanup);
+  });
+
+  // POST injects one message into the same tap channel a GET on this route
+  // streams — the CLI's `--type`/`--payload` "poke" path.
+  router.post(AGENT_SESSION_TAP_ROUTE_PATTERN, async (req, res) => {
+    syncEndpoint(manager, req);
+    try {
+      const body = getBodyRecord(req);
+      if (typeof body.pluginId !== 'string' || body.pluginId.length === 0) {
+        throw new Error('"pluginId" is required');
+      }
+      if (typeof body.type !== 'string' || body.type.length === 0) {
+        throw new Error('"type" is required');
+      }
+
+      await manager.sendSessionTapMessage(getSessionId(req), {
+        pluginId: body.pluginId,
+        type: body.type,
+        payload: body.payload,
+      });
+
+      sendResult<SendAgentSessionTapMessageResponse>(res, { sent: true });
     } catch (error) {
       sendError(res, error);
     }

--- a/packages/middleware/src/agent/session-manager.ts
+++ b/packages/middleware/src/agent/session-manager.ts
@@ -5,9 +5,11 @@ import {
   type AgentSessionInfo,
   type AgentTool,
   type CreateAgentSessionRequest,
+  type DevToolsPluginMessage,
 } from '@rozenite/agent-shared';
 import { getMetroTargets, resolveMetroTarget } from './metro-discovery.js';
 import { createAgentSession, type AgentSession } from './session.js';
+import type { TapListener } from './tap.js';
 
 export type AgentSessionManager = ReturnType<typeof createAgentSessionManager>;
 
@@ -145,6 +147,17 @@ export const createAgentSessionManager = (options: {
     return await getSessionOrThrow(sessionId).callTool(toolName, args);
   };
 
+  const subscribeSessionTap = (sessionId: string, listener: TapListener): (() => void) => {
+    return getSessionOrThrow(sessionId).subscribeTap(listener);
+  };
+
+  const sendSessionTapMessage = async (
+    sessionId: string,
+    message: DevToolsPluginMessage,
+  ): Promise<void> => {
+    await getSessionOrThrow(sessionId).sendTapMessage(message);
+  };
+
   const dispose = async (): Promise<void> => {
     const activeSessions = Array.from(sessions.values());
     sessions.clear();
@@ -161,6 +174,8 @@ export const createAgentSessionManager = (options: {
     stopSession,
     getSessionTools,
     callSessionTool,
+    subscribeSessionTap,
+    sendSessionTapMessage,
     dispose,
   };
 };

--- a/packages/middleware/src/agent/session.ts
+++ b/packages/middleware/src/agent/session.ts
@@ -10,6 +10,7 @@ import { createAgentArtifacts } from './artifacts.js';
 import { createAgentMessageHandler } from './runtime/handler.js';
 import { extractConsoleMessage } from './runtime/console/extract.js';
 import { parseRozeniteBindingPayload } from './runtime/bindings.js';
+import { createTapEmitter, isDevToolsPluginMessage, type TapListener } from './tap.js';
 import type { DevToolsPluginMessage } from './runtime/types.js';
 import {
   createMemoryDomainService,
@@ -104,6 +105,7 @@ export const createAgentSession = (options: {
   let target = options.target;
   const handler = createAgentMessageHandler();
   const artifacts = createAgentArtifacts(options.projectRoot, options.target.id);
+  const tap = createTapEmitter();
   const createdAt = Date.now();
 
   let lastActivityAt = createdAt;
@@ -776,6 +778,12 @@ export const createAgentSession = (options: {
       }
 
       const devToolsMessage = bindingPayload.message as DevToolsPluginMessage;
+      // Tee every rozenite-domain message — not just the ones the built-in
+      // handler understands (AGENT_PLUGIN_ID) — so a tap can observe
+      // arbitrary third-party plugin traffic too.
+      if (isDevToolsPluginMessage(devToolsMessage)) {
+        tap.emit('in', devToolsMessage);
+      }
       handler.handleDeviceMessage(options.target.id, devToolsMessage);
       if (devToolsMessage.type === 'register-tool') {
         notePluginReadinessActivity();
@@ -815,6 +823,9 @@ export const createAgentSession = (options: {
         touch();
         handler.connectDevice(options.target.id, options.target.name, {
           sendMessage: (message: unknown) => {
+            if (isDevToolsPluginMessage(message)) {
+              tap.emit('out', message);
+            }
             void sendDomainMessage('rozenite', message);
           },
         });
@@ -901,6 +912,19 @@ export const createAgentSession = (options: {
       ...handler.getTools(options.target.id),
       ...localServices.flatMap((service) => service.getTools()),
     ];
+  };
+
+  const subscribeTap: (listener: TapListener) => () => void = tap.subscribe;
+
+  const sendTapMessage = async (message: DevToolsPluginMessage): Promise<void> => {
+    if (status !== 'connected') {
+      throw new Error(`Session "${options.target.id}" is not connected to a device`);
+    }
+
+    // Injected the same way `handler`-originated messages are: teed for
+    // observers, then handed to the device over the existing CDP socket.
+    tap.emit('out', message);
+    await sendDomainMessage('rozenite', message);
   };
 
   const callTool = async (toolName: string, args: unknown): Promise<unknown> => {
@@ -1017,6 +1041,8 @@ export const createAgentSession = (options: {
     getInfo,
     getTools,
     callTool,
+    subscribeTap,
+    sendTapMessage,
     isReusable: (nextTarget: MetroTarget) =>
       status === 'connected' && target.pageId === nextTarget.pageId,
   };

--- a/packages/middleware/src/agent/tap.ts
+++ b/packages/middleware/src/agent/tap.ts
@@ -1,0 +1,78 @@
+import type { DevToolsPluginMessage, TapDirection, TapEvent } from '@rozenite/agent-shared';
+
+export type TapListener = (event: TapEvent) => void;
+
+export type TapEmitter = {
+  /** Tees a plugin message into every subscriber as a timestamped `TapEvent`. */
+  emit: (direction: TapDirection, message: DevToolsPluginMessage) => void;
+  /** Registers a listener; call the returned function to unsubscribe. */
+  subscribe: (listener: TapListener) => () => void;
+};
+
+/**
+ * A small pub/sub the Agent session tees `rozenite`-domain plugin messages
+ * into, in both directions. Kept independent of `AgentSession` so it can be
+ * created and exercised on its own — the session only calls `emit` at its
+ * two existing chokepoints (the device message handler and the outbound
+ * `sendMessage` callback) and hands `subscribe` to callers such as the agent
+ * server's tap route.
+ */
+export const createTapEmitter = (): TapEmitter => {
+  const listeners = new Set<TapListener>();
+
+  return {
+    emit: (direction, message) => {
+      if (listeners.size === 0) {
+        return;
+      }
+
+      const event: TapEvent = {
+        direction,
+        timestamp: Date.now(),
+        pluginId: message.pluginId,
+        type: message.type,
+        payload: message.payload,
+      };
+
+      for (const listener of listeners) {
+        listener(event);
+      }
+    },
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+  };
+};
+
+/** Narrows an outbound `sendMessage` payload to a taggable plugin message. */
+export const isDevToolsPluginMessage = (value: unknown): value is DevToolsPluginMessage => {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { pluginId?: unknown }).pluginId === 'string' &&
+    typeof (value as { type?: unknown }).type === 'string' &&
+    'payload' in value
+  );
+};
+
+export type TapFilter = {
+  pluginId?: string;
+  type?: string;
+};
+
+/** Pure predicate behind tap's plugin/type filtering, usable by both the
+ * server (to avoid streaming events nobody asked for) and tests. */
+export const matchesTapFilter = (event: TapEvent, filter: TapFilter): boolean => {
+  if (filter.pluginId && event.pluginId !== filter.pluginId) {
+    return false;
+  }
+
+  if (filter.type && event.type !== filter.type) {
+    return false;
+  }
+
+  return true;
+};

--- a/website/src/docs/agent/_meta.json
+++ b/website/src/docs/agent/_meta.json
@@ -23,5 +23,10 @@
     "type": "file",
     "name": "sdk",
     "label": "Agent SDK"
+  },
+  {
+    "type": "file",
+    "name": "tap",
+    "label": "Tap"
   }
 ]

--- a/website/src/docs/agent/overview.mdx
+++ b/website/src/docs/agent/overview.mdx
@@ -70,3 +70,4 @@ If you want to give a coding agent this workflow directly, install the [`rozenit
 - [Adding tools to your application](/docs/agent/adding-tools-to-your-application) – expose custom tools from your app for agents to call.
 - [Making your plugin agent-enabled](/docs/agent/making-your-plugin-agent-enabled) – expose tools from your Rozenite plugin to agents.
 - [Agent SDK](/docs/agent/sdk) – build custom tooling or automation on top of the agent workflow.
+- [Tap](/docs/agent/tap) – stream a plugin's messages to the terminal, both directions, without opening a browser.

--- a/website/src/docs/agent/tap.mdx
+++ b/website/src/docs/agent/tap.mdx
@@ -1,6 +1,6 @@
 # Tap
 
-`rozenite tap` connects to a device and prints Rozenite plugin messages as they flow, in both directions, without opening a browser or React Native DevTools.
+`rozenite agent tap` connects to a device and prints Rozenite plugin messages as they flow, in both directions, without opening a browser or React Native DevTools.
 
 The full loop for checking that a plugin's native side behaves — Metro, a simulator, the app, a browser running React Native DevTools, the shell, and the panel — is a lot of overhead just to watch a handful of messages when the thing you're testing lives on the device. `tap` skips the browser half entirely.
 
@@ -11,7 +11,7 @@ Rozenite for Agents (including `tap`) is experimental and may change. If you run
 ## Watch a plugin's traffic
 
 ```bash
-npx rozenite tap --session <id> --plugin @acme/sqlite-plugin
+npx rozenite agent tap --session <id> --plugin @acme/sqlite-plugin
 ```
 
 ```
@@ -31,7 +31,7 @@ Omit `--plugin` to watch every plugin's traffic on the session. `tap` keeps runn
 Because the stream is bidirectional, `tap` doubles as a minimal stand-in for DevTools: send one message from the terminal, then keep watching for whatever comes back.
 
 ```bash
-npx rozenite tap --session <id> --plugin @acme/sqlite-plugin --type sqlite:query --payload '{"sql":"select 1"}'
+npx rozenite agent tap --session <id> --plugin @acme/sqlite-plugin --type sqlite:query --payload '{"sql":"select 1"}'
 ```
 
 `--plugin`, `--type`, and `--payload` map directly onto the three fields of the message sent to the device (`pluginId`, `type`, `payload`). `--payload` defaults to `{}` and is validated as JSON on its own, so a malformed payload is reported against `--payload`, not against a blended argument. `--type` requires `--plugin`, since a message needs to know which plugin it's addressed to.
@@ -43,7 +43,7 @@ npx rozenite tap --session <id> --plugin @acme/sqlite-plugin --type sqlite:query
 Pass `--json` for newline-delimited JSON, one message per line, so another program or agent can consume the stream directly instead of screenshotting a terminal:
 
 ```bash
-npx rozenite tap --session <id> --json
+npx rozenite agent tap --session <id> --json
 ```
 
 ```json
@@ -73,7 +73,7 @@ Each line has this shape:
 - `-t, --type <name>` — send one message of this type before watching. Requires `--plugin`.
 - `-a, --payload <json>` — JSON payload for the sent message. Defaults to `{}`.
 - `--json` — newline-delimited JSON output instead of the human-readable format.
-- `--host <host>` / `--port <port>` — Metro host and port (defaults to `127.0.0.1:8081`).
+- `--host <host>` / `--port <port>` — Metro host and port, inherited from `rozenite agent`, so they go before `tap`: `npx rozenite agent --host 192.168.1.10 --port 8082 tap --session <id>` (defaults to `127.0.0.1:8081`).
 
 ## `tap` replaces React Native DevTools
 

--- a/website/src/docs/agent/tap.mdx
+++ b/website/src/docs/agent/tap.mdx
@@ -1,0 +1,85 @@
+# Tap
+
+`rozenite tap` connects to a device and prints Rozenite plugin messages as they flow, in both directions, without opening a browser or React Native DevTools.
+
+The full loop for checking that a plugin's native side behaves — Metro, a simulator, the app, a browser running React Native DevTools, the shell, and the panel — is a lot of overhead just to watch a handful of messages when the thing you're testing lives on the device. `tap` skips the browser half entirely.
+
+:::warning Experimental
+Rozenite for Agents (including `tap`) is experimental and may change. If you run into a bug, please [open an issue](https://github.com/callstackincubator/rozenite/issues).
+:::
+
+## Watch a plugin's traffic
+
+```bash
+npx rozenite tap --session <id> --plugin @acme/sqlite-plugin
+```
+
+```
+← 12:04:31.220  sqlite:list-tables-request   {"requestId":"a1"}
+→ 12:04:31.244  sqlite:list-tables-response  {"requestId":"a1","tables":["users","posts"]}
+```
+
+Each line is a direction arrow, a local timestamp, the message type, and the JSON payload:
+
+- `←` — received from the device.
+- `→` — sent to the device.
+
+Omit `--plugin` to watch every plugin's traffic on the session. `tap` keeps running until you stop it with Ctrl-C, closing the underlying connection cleanly.
+
+## Poke a plugin and watch what comes back
+
+Because the stream is bidirectional, `tap` doubles as a minimal stand-in for DevTools: send one message from the terminal, then keep watching for whatever comes back.
+
+```bash
+npx rozenite tap --session <id> --plugin @acme/sqlite-plugin --type sqlite:query --payload '{"sql":"select 1"}'
+```
+
+`--plugin`, `--type`, and `--payload` map directly onto the three fields of the message sent to the device (`pluginId`, `type`, `payload`). `--payload` defaults to `{}` and is validated as JSON on its own, so a malformed payload is reported against `--payload`, not against a blended argument. `--type` requires `--plugin`, since a message needs to know which plugin it's addressed to.
+
+`--plugin` also filters the stream — `--type` does not, since filtering on it would hide the very response your poke is meant to surface.
+
+## Machine-readable output
+
+Pass `--json` for newline-delimited JSON, one message per line, so another program or agent can consume the stream directly instead of screenshotting a terminal:
+
+```bash
+npx rozenite tap --session <id> --json
+```
+
+```json
+{
+  "direction": "in",
+  "timestamp": 1700000000000,
+  "pluginId": "@acme/sqlite-plugin",
+  "type": "list-tables-request",
+  "payload": { "requestId": "a1" }
+}
+```
+
+Each line has this shape:
+
+| Field       | Description                                                        |
+| ----------- | ------------------------------------------------------------------ |
+| `direction` | `"in"` (received from the device) or `"out"` (sent to the device). |
+| `timestamp` | Milliseconds since the Unix epoch.                                 |
+| `pluginId`  | The plugin the message belongs to.                                 |
+| `type`      | The message type.                                                  |
+| `payload`   | The message payload, unmodified.                                   |
+
+## Options
+
+- `-s, --session <id>` — target Agent session ID (required). Create one with `npx rozenite agent session create`.
+- `-p, --plugin <id>` — filter the stream to this plugin ID; required together with `--type`.
+- `-t, --type <name>` — send one message of this type before watching. Requires `--plugin`.
+- `-a, --payload <json>` — JSON payload for the sent message. Defaults to `{}`.
+- `--json` — newline-delimited JSON output instead of the human-readable format.
+- `--host <host>` / `--port <port>` — Metro host and port (defaults to `127.0.0.1:8081`).
+
+## `tap` replaces React Native DevTools
+
+A device serves only one debugger connection at a time. `tap` rides the same connection `rozenite agent` uses, so starting a tap — like starting an agent session — disconnects React Native DevTools if it's already attached, and a tap keeps that same device from being opened in DevTools while it's running. This matches the point of `tap` (working entirely from the terminal), but it will surprise you if you don't expect it. Stop the tap (Ctrl-C) to free the connection back up.
+
+## Next steps
+
+- [Rozenite for Agents](/docs/agent/overview) — the wider agent-facing workflow `tap` is part of.
+- [Agent SDK](/docs/agent/sdk) — build custom tooling on top of the same session `tap` uses.


### PR DESCRIPTION
## Description

Adds `rozenite agent tap`, a CLI command that streams the plugin messages of a Rozenite Agent session to stdout as they flow, in both directions, without needing a browser or React Native DevTools attached.

- `rozenite agent tap --session SESSION_ID --plugin PLUGIN_ID` watches the traffic for that plugin, printing a direction arrow (`←` for a message received from the device, `→` for a message sent to it), a local timestamp, the message type, and the JSON payload, one line per message.
- `--type` and `--payload` (mapping onto the `type`/`payload` fields of the message, alongside `--plugin` for `pluginId`) send one message before watching, so the native side of a plugin can be poked from a terminal and its response observed directly, as a minimal bidirectional stand-in for DevTools. `--payload` defaults to `{}` and is validated as JSON on its own.
- `--json` switches to newline-delimited JSON, one message per line, documented with a stable `{direction, timestamp, pluginId, type, payload}` shape, for another program or agent to consume.
- Ctrl-C closes the tap cleanly and releases the debugger connection.
- The command lives under `rozenite agent` rather than at the top level: it is session-scoped (it cannot do anything without a session from `rozenite agent session create`, and it talks to the agent server over the same transport every other agent command uses), so it sits with the rest of the session-scoped surface and inherits `--host`/`--port` from the `agent` command instead of redeclaring them, the same way `rozenite agent targets` does. This reserves `tap` from the dynamic plugin-domain namespace under `agent`, exactly as `session`, `targets`, and `list-domains` already do.

## Related Issue

Closes https://github.com/callstackincubator/rozenite/issues/431

## Context

A device serves one debugger connection at a time (session.ts already handles [NEW_DEBUGGER_OPENED] by giving up rather than fighting for the socket), so a tap has to ride the connection rozenite agent already holds instead of opening a second one. I teed the existing AgentSession at its two existing chokepoints, the inbound Runtime.bindingCalled handler and the outbound sendMessage callback passed to handler.connectDevice, into a small pub/sub (packages/middleware/src/agent/tap.ts), independent of the CDP/bootstrap machinery so it can be unit-tested directly. The existing behavior at both chokepoints is unchanged; the tee is additive, an emit call added before/alongside the existing logic. AgentSession exposes the resulting subscribeTap/sendTapMessage, and AgentSessionManager forwards them by session id, matching how every other session operation (callTool, getSessionTools, and so on) is already exposed.

For the agent-server route, the existing surface is exclusively HTTP request/response JSON envelopes served over the Express app Metro runs (getMiddleware mounts createAgentRoutes(...) as a plain Router). There is no WebSocket server or SSE precedent anywhere in the codebase to match a house style against, and this server does not own the raw http.Server (Metro does), so adding a WebSocket upgrade path would mean reaching for infrastructure the codebase does not otherwise have. I used a plain GET route that keeps the response open and writes newline-delimited JSON (chunked transfer encoding, application/x-ndjson) until the client disconnects, the smallest addition consistent with treating this as just another Express route, and it happens to match the ndjson shape already used by the --json output on the CLI exactly. Sending a message reuses the same URL as a POST (the existing session route already does GET/DELETE on one pattern).

--plugin filters the stream; --type does not, even though it is also the flag used to construct the outbound poke message, since filtering the display on it would hide the very response a poke is meant to surface.

Why @rozenite/agent-sdk and @rozenite/agent-shared changed too: the only path the CLI has to the agent server is the transport in @rozenite/agent-sdk (it already implements session create/list/show/stop and tool calls the same way), so reaching the new tap route from `rozenite agent tap` required extending that transport with openSessionTap/sendSessionTapMessage, since there is no other client the CLI has. @rozenite/agent-shared is where the wire types both sides already share live (DevToolsPluginMessage, the other AGENT_SESSION_*_ROUTE constants, AgentResponseEnvelope, and so on), so the new TapEvent type and AGENT_SESSION_TAP_ROUTE_PATTERN constant belong there for the same reason the existing ones do: middleware and agent-sdk both need the identical route path and event shape. Both changes are scoped to exactly that: new route/type plumbing for tap, added the same way the existing session-lifecycle plumbing is. I did not touch the higher-level client.ts/domain-utils.ts in agent-sdk (the domain/tool-resolution layer); tap does not need domain resolution, so it stays at the transport level only, the same layer already used by the session create/list/show/stop commands on the CLI.

One drive-by fix included here: the payload-alignment assertion in `agent-tap-format.test.ts` searched for a bare digit (`indexOf('1')`) in a line whose timestamp is rendered in local time, so the digit matched inside the timestamp rather than the payload on any machine east of UTC, and the test failed there. It now uses a fixed local-constructed timestamp and searches for the payload string.

## Testing

Automated (all passed), run per-package with --filter rather than repo-wide:

- pnpm --filter @rozenite/middleware build
- pnpm --filter @rozenite/middleware test, 126 tests passed (13 files), including the new agent-tap.test.ts, agent-routes-tap.test.ts, and tap additions to agent-session.test.ts and agent-session-manager.test.ts
- pnpm --filter @rozenite/middleware typecheck
- pnpm --filter @rozenite/middleware lint
- pnpm --filter rozenite build (the CLI package is named rozenite, not @rozenite/cli)
- pnpm --filter rozenite test, 131 tests passed (14 files), including the new agent-tap-format.test.ts and agent-tap-command.test.ts
- pnpm --filter rozenite typecheck
- pnpm --filter rozenite lint
- pnpm --filter @rozenite/agent-shared build
- pnpm --filter @rozenite/agent-sdk build
- pnpm --filter @rozenite/metro test: the CJS-load smoke test that requires the built @rozenite/middleware, @rozenite/tools, and @rozenite/metro bundles in a real node subprocess and runs withRozenite() end-to-end, per docs/agents/metro-testing.md
- pnpm format:all on every file this PR touches (a repo-wide run also flagged three pre-existing, unrelated files already failing on main; those were left untouched)
- pnpm release:plan, confirming the changeset is present and valid

After moving the command under `agent`, the following were re-run from the repository root and all passed: `turbo run build test typecheck lint --filter=rozenite` (131 tests, 14 files) and `oxfmt --check .` (clean apart from four files already unformatted on this branch before the move). The built CLI was also exercised directly: `rozenite agent tap --help` renders, `rozenite agent --help` lists tap alongside `targets`/`session`, and `rozenite tap` now reports `unknown command 'tap'`. Real-device verification is still absent, as described below.

The paragraphs below describe the state of the original submission.

Those were the last checks run before pushing. Everything added afterward was documentation-only (the changeset body, the CLI README section, the website tap.mdx page) and does not participate in any of the runs above. I did not re-run these, or any full-repo check, after that point. This container turned out to be shared with another concurrent agent session, and a repo-wide typecheck:all/lint:all (which the pre-push hook normally runs, hence pushing with --no-verify) was oversubscribing it. At the direction of the user I stopped running local validation for this final submission and am relying on CI as the verification path here.

Verification against a real device was not performed. This environment cannot run a simulator, a device, or Metro, so the tap route and `rozenite agent tap` have only ever been exercised against fake session/socket and fake-manager test harnesses, never against a real CDP connection. That is the remaining risk for a reviewer.

