### PR TITLE
chore: enforce formatting in CI and fix existing drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Check formatting
+        run: pnpm format:all
+
       - name: Fetch base branch
         if: github.event_name == 'pull_request'
         run: git fetch origin ${{ github.event.pull_request.base.ref }}

--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,7 @@ yarn-error.log
 
 # Vercel
 .vercel
+
+# Claude Code local state (shared config under .claude/ is intentionally tracked)
+.claude/settings.local.json
+.claude/worktrees/

--- a/packages/network-activity-plugin/src/react-native/websocket/websocket-interceptor.ts
+++ b/packages/network-activity-plugin/src/react-native/websocket/websocket-interceptor.ts
@@ -99,10 +99,7 @@ export const getWebSocketInterceptor = (): WebSocketInterceptor => {
       eventEmitter.addListener(
         'websocketMessage',
         (ev: { type?: 'binary' | 'text'; data: string; id: number }) => {
-          onMessageCallback?.(
-            ev.type === 'binary' ? arrayBufferToString(ev.data) : ev.data,
-            ev.id,
-          );
+          onMessageCallback?.(ev.type === 'binary' ? arrayBufferToString(ev.data) : ev.data, ev.id);
         },
       ),
       eventEmitter.addListener('websocketOpen', (ev: { id: number }) => {

--- a/packages/web/src/react-native/fuseboxReactDevToolsDispatcher.ts
+++ b/packages/web/src/react-native/fuseboxReactDevToolsDispatcher.ts
@@ -12,13 +12,7 @@
 
 import type { FuseboxDomain } from './types.js';
 
-type JSONValue =
-  | string
-  | number
-  | boolean
-  | null
-  | { [key: string]: JSONValue }
-  | JSONValue[];
+type JSONValue = string | number | boolean | null | { [key: string]: JSONValue } | JSONValue[];
 type DomainName = 'react-devtools';
 
 class EventScope<T> {
@@ -45,9 +39,7 @@ class Domain implements FuseboxDomain {
   onMessage: EventScope<JSONValue>;
 
   constructor(name: DomainName) {
-    if (
-      (global as Record<string, unknown>)[FuseboxReactDevToolsDispatcher.BINDING_NAME] == null
-    ) {
+    if ((global as Record<string, unknown>)[FuseboxReactDevToolsDispatcher.BINDING_NAME] == null) {
       throw new Error(`Could not create domain ${name}: receiving end doesn't exist`);
     }
 
@@ -60,9 +52,9 @@ class Domain implements FuseboxDomain {
     const serializedMessageWithDomain = JSON.stringify(messageWithDomain);
 
     (
-      (global as Record<string, unknown>)[
-        FuseboxReactDevToolsDispatcher.BINDING_NAME
-      ] as (message: string) => void
+      (global as Record<string, unknown>)[FuseboxReactDevToolsDispatcher.BINDING_NAME] as (
+        message: string,
+      ) => void
     )(serializedMessageWithDomain);
   }
 }

--- a/website/src/docs/compatibility.mdx
+++ b/website/src/docs/compatibility.mdx
@@ -2,8 +2,8 @@
 
 ## Supported versions
 
-| Rozenite | Expo SDK | React Native | Re.Pack |
-| -------- | -------- | ------------ | ------- |
+| Rozenite         | Expo SDK | React Native | Re.Pack |
+| ---------------- | -------- | ------------ | ------- |
 | 1.13.0, >= 2.0.0 | 52+      | 0.76+        | 5.2+    |
 
 Rozenite tracks Expo SDK releases as its primary compatibility baseline, since each


### PR DESCRIPTION
## Description

`pnpm format:all` fails on `main` today. That matters more since #435, because CONTRIBUTING.md and the pull request guide now point contributors at `pnpm checks:affected`, and that script ends in `format:all`.

- Reformats three files that predate the move to oxfmt.
- Adds a `Check formatting` step to CI so it cannot drift again.
- Ignores Claude Code's local state, which was breaking `format:all` independently.

## Related Issue

None — repository tooling, follow-up to #435.

## Context

**Why the three files were unformatted.** The diffs *unwrap* lines rather than wrapping them — a six-line union type collapses to one line, a markdown table's column padding widens. That is the signature of files formatted at Prettier's narrower print width and never reformatted when the repo moved to oxfmt. They are stale leftovers, not new drift.

The only token-level changes are trailing commas appearing/disappearing as arguments collapse onto one line, and one leading union `|` — all semantically inert. Verified by checksumming both revisions with whitespace, commas and that pipe stripped, and by a full typecheck/lint/test pass on both affected packages. No behavioral change, so no version plan.

**Why nothing caught it.** No workflow has ever run `pnpm format:all`; CI runs `turbo run typecheck build lint test --affected` only. The new step runs before the turbo step so it fails fast — oxfmt checks all 1246 files in under 400ms.

One gap this does not close: the workflow has `paths-ignore: website/**`, so a website-only PR runs no CI at all and could still land unformatted `.mdx`. Whether website PRs should gate on CI is a separate decision.

**Why only two `.claude/` paths are ignored.** `.claude/settings.local.json` and `.claude/worktrees/` were excluded only through per-machine files — the global git excludes file that Claude Code writes to, and `.git/info/exclude`. Git therefore ignored them but oxfmt did not, since oxfmt reads `.gitignore`/`.prettierignore` from the repo only. The result was that `pnpm format:all` failed for anyone using Claude Code, regardless of the three files above.

Ignoring `.claude/` wholesale would be wrong: per the Claude Code settings documentation, `.claude/settings.json`, `agents/`, `skills/` and `commands/` are all intended to be committed and shared with the team. Only the two machine-local paths are ignored here.

## Testing

- `pnpm format:all` — passes (1246 files, 383ms)
- `npx turbo run typecheck lint test` — **118 tasks, all successful**
- `npx turbo run typecheck lint test --filter=@rozenite/network-activity-plugin --filter=@rozenite/web` — 38 tasks, all successful
- Confirmed the reformatting is semantically inert by checksum, as described above
- CI workflow YAML re-parsed after editing; step order verified
