### PR TITLE
ci: cache Turborepo artifacts, writing only from main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,23 @@ jobs:
       - name: Check formatting
         run: pnpm format:all
 
+      # Rotates weekly. There is deliberately no fallback to the previous
+      # period's key: falling back would carry the accumulated cache forward and
+      # defeat the reset. Turborepo never prunes .turbo/cache, so without this it
+      # grows with every artifact ever built and eventually hits the 10GB
+      # per-repository cache limit. The cost is one cold run per week, which is
+      # no worse than today's behaviour.
+      - name: Compute cache period
+        id: cache-period
+        run: echo "value=$(date -u +%Y-%V)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Turborepo cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .turbo/cache
+          key: turbo-${{ runner.os }}-${{ steps.cache-period.outputs.value }}-${{ github.sha }}
+          restore-keys: turbo-${{ runner.os }}-${{ steps.cache-period.outputs.value }}-
+
       - name: Fetch base branch
         if: github.event_name == 'pull_request'
         run: git fetch origin ${{ github.event.pull_request.base.ref }}
@@ -52,3 +69,17 @@ jobs:
         env:
           TURBO_SCM_BASE: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.event.pull_request.base.ref) || 'HEAD~1' }}
         run: pnpm turbo run typecheck build lint test --affected
+
+      # Only pushes to main write the cache. A pull request run cannot write to
+      # main's cache scope anyway, but this also stops a run from writing a cache
+      # that a later re-run of the same pull request would restore. A poisoned
+      # Turborepo artifact makes tasks report a cache hit without executing and
+      # replays their stored logs, so a fork pull request could otherwise forge a
+      # green check. Saving only from main means every cached artifact was
+      # produced by already-merged, reviewed code.
+      - name: Save Turborepo cache
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .turbo/cache
+          key: turbo-${{ runner.os }}-${{ steps.cache-period.outputs.value }}-${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,10 @@ jobs:
           node-version: 24
           registry-url: https://registry.npmjs.org
 
+      # Deliberately no build or dependency cache in this job. It holds
+      # id-token: write and publishes to npm, so a restored artifact would be
+      # published with provenance attesting to something that was never built
+      # from this source. Everything here must be built from a clean checkout.
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Description

Caches Turborepo artifacts in CI, restoring on every run but writing only from pushes to `main`.

The Validate job spends **319s of its 6m19s** inside `turbo run`. Nothing persists between runs today: `.turbo` is gitignored and only the pnpm store is cached, so every run rebuilds affected packages and their entire dependency chain from scratch.

> Stacked on #436 — the base will retarget to `main` once that merges. Only the two workflow files are this PR's own change.

## Related Issue

None — repository tooling, follow-up to #435.

## Context

**Why saves are restricted to `main`.** GitHub scopes a pull request's cache to its merge ref, and that cache "can only be restored by re-runs of the pull request" — so a fork PR cannot reach `main`'s scope or another PR's regardless. Restricting saves closes the remaining case: a run writing a cache that a later re-run *of the same PR* would restore.

That distinction matters more for Turborepo than for the pnpm store. A poisoned store still leaves every task to actually run. A poisoned Turborepo artifact makes tasks report a cache hit **without executing** and replays their stored logs — and #435's `outputLogs` now suppresses cache-hit logs, so the replay is quieter than it used to be. A fork PR could use that to forge a green check on a diff that would otherwise fail. Nothing detects this for us: pnpm documents `verifyStoreIntegrity` as catching accidental corruption, explicitly not deliberate tampering, and Turborepo's signature verification applies only to *remote* caches, not the filesystem cache `actions/cache` persists. Scope is the control that matters.

Saving only from `main` means every cached artifact was produced by already-merged, reviewed code. PRs still restore `main`'s cache, which covers every dependency build they did not change; they only re-execute tasks for the packages they actually touch, which `--affected` already bounds.

**Why the key rotates weekly with no fallback.** Turborepo never prunes `.turbo/cache`. The accumulated local cache in this repository is already **1.8GB across 10050 entries**. Because each `main` run restores before it saves, the saved artifact is the union of everything cached so far — so an unrotated key grows without limit until it hits the 10GB per-repository cache limit and evicts everything else, including the pnpm store cache.

There is deliberately no `restore-keys` fallback to the previous period: falling back would carry the accumulation forward and defeat the reset. The cost is one cold run at the start of each week, which is no worse than today's behaviour, where every run is cold.

**Why `release.yml` stays uncached.** It holds `contents: write` and `id-token: write` and publishes to npm. A restored artifact would be published with provenance attesting to something that was never built from this source. The job now carries a comment saying so, since this is exactly the kind of thing a later "optimization" would undo.

## Testing

- Both workflow files re-parsed as YAML after editing; step order and `if:` conditions verified
- `actions/cache` pinned to `55cc8345863c7cc4c66a329aec7e433d2d1c52a9`, confirmed via the API to be v6.1.0 in the first-party `actions/` org, matching this repository's pin-everything convention
- Confirmed the `restore` and `save` sub-actions exist at that exact SHA
- `npx turbo run typecheck lint test` — **118 tasks, all successful**
- `pnpm format:all` — passes

Cache behaviour itself can only be confirmed on a real run. Two things to watch:

1. **The path.** Turborepo resolves `.turbo/cache` at the repository root in a plain clone; I could only verify the resolution logic locally inside a git worktree, where it deliberately redirects to the main checkout. If the path were wrong the symptom is a cache that never hits, not a wrong result.
2. **Effect on runtime.** The baseline to beat is the 6m19s Validate run on #435. The first push to `main` after this merges is still cold — it populates the cache. Subsequent runs are the ones to measure.
