### PR TITLE
feat(ui): add ToggleGroup, VirtualizedList, and QueryField

### DIFF
--- a/.changeset/ui-log-panel-primitives.md
+++ b/.changeset/ui-log-panel-primitives.md
@@ -1,0 +1,22 @@
+---
+'@rozenite/ui': minor
+---
+
+Add three primitives for building log and stream panels.
+
+`ToggleGroup` is a segmented control for filters where more than one option
+can be active at once — log levels, tags, sources. It reads as a sibling of
+`Tabs`, and supports single or multiple selection, icon-only items, and the
+three control sizes.
+
+`VirtualizedList` is the non-tabular counterpart to `VirtualizedDataTable`,
+for large streams of freely-composed rows that vary in height. Rows need no
+measurement or fixed height, and `followOutput` pins the view to the newest
+row while entries stream in, releasing as soon as the reader scrolls away —
+the affordance a live log tail needs.
+
+`QueryField` is a query input that highlights the parts of a query as the
+reader types. It owns no grammar and no operator vocabulary: the caller
+tokenizes its own query language and hands over ranges, and `QueryField`
+paints them, so a panel can bring any query syntax. Malformed fragments can
+be marked so a typo is visible before the query is run.

--- a/apps/ui-storybook/src/stories/QueryField.stories.tsx
+++ b/apps/ui-storybook/src/stories/QueryField.stories.tsx
@@ -1,0 +1,151 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { QueryField, type QueryToken } from '@rozenite/ui';
+
+// QueryField is presentation-only — it has no query grammar. Tokenizing
+// `level>=warn tag:auth -"retry"` is entirely the story's (the consumer's)
+// job; QueryField only paints the ranges it's handed.
+const realisticQuery = 'level>=warn tag:auth -"retry"';
+const realisticTokens: QueryToken[] = [
+  { start: 0, end: 5, kind: 'field' }, // level
+  { start: 5, end: 7, kind: 'operator' }, // >=
+  { start: 7, end: 11, kind: 'value' }, // warn
+  { start: 12, end: 15, kind: 'field' }, // tag
+  { start: 15, end: 16, kind: 'operator' }, // :
+  { start: 16, end: 20, kind: 'value' }, // auth
+  { start: 21, end: 22, kind: 'negation' }, // -
+  { start: 22, end: 29, kind: 'value' }, // "retry"
+];
+
+const meta = {
+  component: QueryField,
+  title: 'Components/QueryField',
+} satisfies Meta<typeof QueryField>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function ControlledQueryField(props: {
+  initialValue: string;
+  tokens: QueryToken[];
+  size?: 'sm' | 'md' | 'lg';
+  className?: string;
+  placeholder?: string;
+}) {
+  const [value, setValue] = useState(props.initialValue);
+
+  return (
+    <QueryField
+      value={value}
+      onValueChange={setValue}
+      onClear={() => setValue('')}
+      tokens={props.tokens}
+      size={props.size}
+      className={props.className}
+      placeholder={props.placeholder}
+    />
+  );
+}
+
+/** A realistic pre-tokenized log query, showing field/operator/value/negation
+ * painted over plain text as the user would type it into a log panel.
+ * @summary A log query with field, operator, value, and negation highlighted.
+ */
+export const Default: Story = {
+  render: () => (
+    <div className="w-96">
+      <ControlledQueryField initialValue={realisticQuery} tokens={realisticTokens} />
+    </div>
+  ),
+};
+
+/** The caller marks a malformed fragment as `error`; QueryField only applies
+ * the danger/wavy-underline treatment — it never judges validity itself.
+ * @summary An unterminated quote flagged as an error token.
+ */
+export const ErrorToken: Story = {
+  render: () => (
+    <div className="w-96">
+      <ControlledQueryField
+        initialValue='level=warn tag:"auth'
+        tokens={[
+          { start: 0, end: 5, kind: 'field' },
+          { start: 5, end: 6, kind: 'operator' },
+          { start: 6, end: 10, kind: 'value' },
+          { start: 11, end: 14, kind: 'field' },
+          { start: 14, end: 15, kind: 'operator' },
+          { start: 15, end: 20, kind: 'error' },
+        ]}
+      />
+    </div>
+  ),
+};
+
+/** With no value and no tokens, QueryField falls back to its placeholder like
+ * any other text input.
+ * @summary Empty state with a placeholder.
+ */
+export const Empty: Story = {
+  render: () => (
+    <div className="w-96">
+      <ControlledQueryField initialValue="" tokens={[]} placeholder="level>=warn tag:auth…" />
+    </div>
+  ),
+};
+
+/** `size` scales the same way as the rest of the form controls in this kit.
+ * @summary Three sizes, small to large.
+ */
+export const Sizes: Story = {
+  render: () => (
+    <div className="flex w-96 flex-col gap-3">
+      <ControlledQueryField initialValue={realisticQuery} tokens={realisticTokens} size="sm" />
+      <ControlledQueryField initialValue={realisticQuery} tokens={realisticTokens} size="md" />
+      <ControlledQueryField initialValue={realisticQuery} tokens={realisticTokens} size="lg" />
+    </div>
+  ),
+};
+
+const longQuery =
+  'level>=warn tag:auth service:checkout region:us-east-1 -"retry" -"heartbeat" status:failed duration>1500 user.id:8231';
+const longQueryTokens: QueryToken[] = [
+  { start: 0, end: 5, kind: 'field' },
+  { start: 5, end: 7, kind: 'operator' },
+  { start: 7, end: 11, kind: 'value' },
+  { start: 12, end: 15, kind: 'field' },
+  { start: 15, end: 16, kind: 'operator' },
+  { start: 16, end: 20, kind: 'value' },
+  { start: 21, end: 28, kind: 'field' },
+  { start: 28, end: 29, kind: 'operator' },
+  { start: 29, end: 37, kind: 'value' },
+  { start: 38, end: 44, kind: 'field' },
+  { start: 44, end: 45, kind: 'operator' },
+  { start: 45, end: 54, kind: 'value' },
+  { start: 55, end: 56, kind: 'negation' },
+  { start: 56, end: 63, kind: 'value' },
+  { start: 64, end: 65, kind: 'negation' },
+  { start: 65, end: 76, kind: 'value' },
+  { start: 77, end: 83, kind: 'field' },
+  { start: 83, end: 84, kind: 'operator' },
+  { start: 84, end: 90, kind: 'value' },
+  { start: 91, end: 99, kind: 'field' },
+  { start: 99, end: 100, kind: 'operator' },
+  { start: 100, end: 104, kind: 'value' },
+  { start: 105, end: 112, kind: 'field' },
+  { start: 112, end: 113, kind: 'operator' },
+  { start: 113, end: 117, kind: 'value' },
+];
+
+/** The value is wider than the field, so the input scrolls horizontally.
+ * QueryField syncs the mirror's `scrollLeft` to the input's on every scroll
+ * event so the painted colors never drift from the caret. Click into the
+ * field and use the arrow keys or End to scroll it and see the highlight
+ * track along.
+ * @summary A long query demonstrating horizontal scroll stays in sync.
+ */
+export const LongQueryScrollSync: Story = {
+  render: () => (
+    <div className="w-72">
+      <ControlledQueryField initialValue={longQuery} tokens={longQueryTokens} />
+    </div>
+  ),
+};

--- a/apps/ui-storybook/src/stories/ToggleGroup.stories.tsx
+++ b/apps/ui-storybook/src/stories/ToggleGroup.stories.tsx
@@ -1,0 +1,105 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ToggleGroup, Info, AlertTriangle, XCircle } from '@rozenite/ui';
+const meta = {
+  component: ToggleGroup,
+  title: 'Components/ToggleGroup',
+} satisfies Meta<typeof ToggleGroup>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Use for a single-select segmented control, e.g. switching between related views.
+ * @summary Switch between mutually exclusive views.
+ */
+export const Default: Story = {
+  render: () => (
+    <ToggleGroup defaultValue={['list']}>
+      <ToggleGroup.Item value="list">List</ToggleGroup.Item>
+      <ToggleGroup.Item value="grid">Grid</ToggleGroup.Item>
+      <ToggleGroup.Item value="table">Table</ToggleGroup.Item>
+    </ToggleGroup>
+  ),
+};
+
+/** Use `multiple` to model several independent on/off facets in one control,
+ * such as log level filters where several levels can be pressed at once.
+ * @summary Toggle several independent facets at once.
+ */
+export const Multiple: Story = {
+  render: () => (
+    <ToggleGroup multiple defaultValue={['info', 'warn', 'error']}>
+      <ToggleGroup.Item value="verbose">Verbose</ToggleGroup.Item>
+      <ToggleGroup.Item value="info">Info</ToggleGroup.Item>
+      <ToggleGroup.Item value="warn">Warn</ToggleGroup.Item>
+      <ToggleGroup.Item value="error">Error</ToggleGroup.Item>
+    </ToggleGroup>
+  ),
+};
+
+/** Icon-only items are a first-class case, such as a compact toolbar of log
+ * level filters. Pass an icon child and your own `aria-label` on each item.
+ * @summary Filter by icon alone, each item labelled for accessibility.
+ */
+export const IconOnly: Story = {
+  render: () => (
+    <ToggleGroup multiple defaultValue={['warn', 'error']}>
+      <ToggleGroup.Item value="info" aria-label="Info">
+        <Info />
+      </ToggleGroup.Item>
+      <ToggleGroup.Item value="warn" aria-label="Warn">
+        <AlertTriangle />
+      </ToggleGroup.Item>
+      <ToggleGroup.Item value="error" aria-label="Error">
+        <XCircle />
+      </ToggleGroup.Item>
+    </ToggleGroup>
+  ),
+};
+
+/** `size` is set on both the root and each item, matching how `Tabs` sizes its list and tabs.
+ * @summary Three sizes, small to large.
+ */
+export const Sizes: Story = {
+  render: () => (
+    <div className="flex items-center gap-4">
+      <ToggleGroup size="sm" defaultValue={['list']}>
+        <ToggleGroup.Item size="sm" value="list">
+          List
+        </ToggleGroup.Item>
+        <ToggleGroup.Item size="sm" value="grid">
+          Grid
+        </ToggleGroup.Item>
+      </ToggleGroup>
+      <ToggleGroup size="md" defaultValue={['list']}>
+        <ToggleGroup.Item size="md" value="list">
+          List
+        </ToggleGroup.Item>
+        <ToggleGroup.Item size="md" value="grid">
+          Grid
+        </ToggleGroup.Item>
+      </ToggleGroup>
+      <ToggleGroup size="lg" defaultValue={['list']}>
+        <ToggleGroup.Item size="lg" value="list">
+          List
+        </ToggleGroup.Item>
+        <ToggleGroup.Item size="lg" value="grid">
+          Grid
+        </ToggleGroup.Item>
+      </ToggleGroup>
+    </div>
+  ),
+};
+
+/** A single item can be disabled while the rest of the group stays interactive.
+ * @summary Disable one item within an otherwise active group.
+ */
+export const DisabledItem: Story = {
+  render: () => (
+    <ToggleGroup defaultValue={['list']}>
+      <ToggleGroup.Item value="list">List</ToggleGroup.Item>
+      <ToggleGroup.Item value="grid">Grid</ToggleGroup.Item>
+      <ToggleGroup.Item value="table" disabled>
+        Table
+      </ToggleGroup.Item>
+    </ToggleGroup>
+  ),
+};

--- a/apps/ui-storybook/src/stories/VirtualizedList.stories.tsx
+++ b/apps/ui-storybook/src/stories/VirtualizedList.stories.tsx
@@ -1,0 +1,150 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useEffect, useRef, useState } from 'react';
+import { Badge, VirtualizedList } from '@rozenite/ui';
+
+type Level = 'info' | 'warn' | 'error';
+type LogEntry = { id: string; level: Level; message: string };
+
+const levelTone = {
+  info: 'info',
+  warn: 'warning',
+  error: 'danger',
+} as const satisfies Record<Level, 'info' | 'warning' | 'danger'>;
+
+const lorem =
+  'Connection established, negotiating protocol version and exchanging capability flags with the remote peer before the handshake finishes and the session becomes ready for traffic.';
+
+const data: LogEntry[] = Array.from({ length: 200 }, (_, index) => {
+  const level: Level = index % 9 === 0 ? 'error' : index % 3 === 0 ? 'warn' : 'info';
+  const wordCount = 3 + ((index * 7) % 30);
+
+  return {
+    id: `log-${index}`,
+    level,
+    message: `Event ${index}: ${lorem.split(' ').slice(0, wordCount).join(' ')}`,
+  };
+});
+
+const renderLogItem = (entry: LogEntry) => (
+  <div className="flex items-start gap-2 px-3 py-2">
+    <Badge tone={levelTone[entry.level]}>{entry.level}</Badge>
+    <span className="text-sm text-foreground">{entry.message}</span>
+  </div>
+);
+
+const meta = {
+  component: VirtualizedList,
+  title: 'Components/VirtualizedList',
+} satisfies Meta<typeof VirtualizedList>;
+export default meta;
+type Story = StoryObj;
+
+/** Use for large streams of variable-height rows, such as a log panel — a
+ * message plus badges, one entry per row, with no manual measurement.
+ * @summary Render a large stream of variable-height rows.
+ */
+export const Default: Story = {
+  render: () => (
+    <VirtualizedList<LogEntry>
+      ariaLabel="Log entries"
+      data={data}
+      getItemKey={(item) => item.id}
+      getItemTextValue={(item) => item.message}
+      renderItem={renderLogItem}
+      style={{ height: 320 }}
+    />
+  ),
+};
+
+function ClickableDemo() {
+  const [selected, setSelected] = useState<string | null>(null);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <VirtualizedList<LogEntry>
+        ariaLabel="Log entries"
+        data={data.slice(0, 30)}
+        getItemKey={(item) => item.id}
+        getItemTextValue={(item) => item.message}
+        onItemClick={(item) => setSelected(item.message)}
+        renderItem={renderLogItem}
+        style={{ height: 320 }}
+      />
+      {selected && <span className="text-sm text-muted-foreground">Selected: {selected}</span>}
+    </div>
+  );
+}
+
+/** Rows can be made actionable, for example to open a details drawer.
+ * @summary Handle clicks on individual rows.
+ */
+export const Clickable: Story = {
+  render: () => <ClickableDemo />,
+};
+
+/** Shown when the data set is empty and nothing is loading.
+ * @summary Render the empty state.
+ */
+export const Empty: Story = {
+  render: () => (
+    <VirtualizedList<LogEntry>
+      ariaLabel="Log entries"
+      data={[]}
+      emptyMessage="No log entries yet."
+      renderItem={renderLogItem}
+      style={{ height: 200 }}
+    />
+  ),
+};
+
+/** Shown while the first page of data is being fetched.
+ * @summary Render the loading state.
+ */
+export const Loading: Story = {
+  render: () => (
+    <VirtualizedList<LogEntry>
+      ariaLabel="Log entries"
+      data={[]}
+      loading
+      renderItem={renderLogItem}
+      style={{ height: 200 }}
+    />
+  ),
+};
+
+function LiveTailDemo() {
+  const [entries, setEntries] = useState<LogEntry[]>(() => data.slice(0, 8));
+  const nextIndexRef = useRef(8);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const next = data[nextIndexRef.current % data.length];
+
+      nextIndexRef.current += 1;
+      setEntries((current) => [...current, next]);
+    }, 700);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <VirtualizedList<LogEntry>
+      ariaLabel="Live log tail"
+      data={entries}
+      followOutput="smooth"
+      getItemKey={(item, index) => `${item.id}-${index}`}
+      getItemTextValue={(item) => item.message}
+      renderItem={renderLogItem}
+      style={{ height: 320 }}
+    />
+  );
+}
+
+/** `followOutput` pins the view to the newest row while entries stream in
+ * every 700ms, and releases as soon as the user scrolls away — the affordance
+ * a live log tail needs.
+ * @summary Pin the view to the newest row as it streams in.
+ */
+export const LiveTail: Story = {
+  render: () => <LiveTailDemo />,
+};

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -191,6 +191,8 @@ export { DataTable } from './data-table/data-table';
 export type { DataTableProps, DataTableColumn } from './data-table/data-table';
 export { VirtualizedDataTable } from './virtualized-data-table/virtualized-data-table';
 export type { VirtualizedDataTableProps } from './virtualized-data-table/virtualized-data-table';
+export { VirtualizedList } from './virtualized-list/virtualized-list';
+export type { VirtualizedListProps } from './virtualized-list/virtualized-list';
 export { DataTableEditableCell } from './data-table/data-table-editable-cell';
 export type { DataTableEditableCellProps } from './data-table/data-table-editable-cell';
 export { updateCellValue } from './data-table/data-table-utils';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -125,6 +125,9 @@ export type {
 export { Tabs } from './tabs/tabs';
 export type { TabsProps, TabsListProps, TabsTabProps, TabsPanelProps } from './tabs/tabs';
 
+export { ToggleGroup } from './toggle-group/toggle-group';
+export type { ToggleGroupProps, ToggleGroupItemProps } from './toggle-group/toggle-group';
+
 export { ScrollArea } from './scroll-area/scroll-area';
 export type { ScrollAreaProps } from './scroll-area/scroll-area';
 

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -187,6 +187,9 @@ export type { SwitchProps } from './switch/switch';
 export { SearchField } from './search-field/search-field';
 export type { SearchFieldProps } from './search-field/search-field';
 
+export { QueryField } from './query-field/query-field';
+export type { QueryFieldProps, QueryToken, QueryTokenKind } from './query-field/query-field';
+
 export { DataTable } from './data-table/data-table';
 export type { DataTableProps, DataTableColumn } from './data-table/data-table';
 export { VirtualizedDataTable } from './virtualized-data-table/virtualized-data-table';

--- a/packages/ui/src/query-field/query-field.test.tsx
+++ b/packages/ui/src/query-field/query-field.test.tsx
@@ -1,0 +1,290 @@
+// @vitest-environment jsdom
+
+import { act, type ComponentProps } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { QueryField, normalizeQueryTokens, type QueryToken } from './query-field';
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean | undefined;
+}
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | undefined;
+let container: HTMLDivElement | undefined;
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  root = undefined;
+  container = undefined;
+});
+
+const renderField = (props: Partial<ComponentProps<typeof QueryField>> = {}) => {
+  container = document.createElement('div');
+  document.body.append(container);
+  root = createRoot(container);
+
+  act(() => {
+    root?.render(<QueryField value="" onChange={() => {}} {...props} />);
+  });
+
+  return container;
+};
+
+const mirrorText = (view: HTMLElement) =>
+  view.querySelector('[data-slot="query-field-mirror"]')?.textContent ?? '';
+
+describe('normalizeQueryTokens', () => {
+  it('returns one segment per accepted token, in order', () => {
+    const tokens: QueryToken[] = [
+      { start: 0, end: 5, kind: 'field' },
+      { start: 5, end: 7, kind: 'operator' },
+      { start: 7, end: 11, kind: 'value' },
+    ];
+
+    expect(normalizeQueryTokens('level>=warn', tokens)).toEqual([
+      { start: 0, end: 5, kind: 'field' },
+      { start: 5, end: 7, kind: 'operator' },
+      { start: 7, end: 11, kind: 'value' },
+    ]);
+  });
+
+  it('fills gaps between tokens with unstyled segments', () => {
+    const tokens: QueryToken[] = [{ start: 4, end: 8, kind: 'value' }];
+
+    expect(normalizeQueryTokens('abcdefghij', tokens)).toEqual([
+      { start: 0, end: 4, kind: null },
+      { start: 4, end: 8, kind: 'value' },
+      { start: 8, end: 10, kind: null },
+    ]);
+  });
+
+  it('returns a single unstyled segment when there are no tokens', () => {
+    expect(normalizeQueryTokens('hello', [])).toEqual([{ start: 0, end: 5, kind: null }]);
+  });
+
+  it('returns nothing for an empty value regardless of tokens', () => {
+    expect(normalizeQueryTokens('', [{ start: 0, end: 5, kind: 'field' }])).toEqual([]);
+  });
+
+  it('clamps out-of-range start/end into the value bounds', () => {
+    const tokens: QueryToken[] = [{ start: -5, end: 100, kind: 'field' }];
+
+    expect(normalizeQueryTokens('abc', tokens)).toEqual([{ start: 0, end: 3, kind: 'field' }]);
+  });
+
+  it('drops zero-length ranges', () => {
+    const tokens: QueryToken[] = [{ start: 2, end: 2, kind: 'field' }];
+
+    expect(normalizeQueryTokens('abcdef', tokens)).toEqual([{ start: 0, end: 6, kind: null }]);
+  });
+
+  it('drops inverted ranges', () => {
+    const tokens: QueryToken[] = [{ start: 5, end: 1, kind: 'field' }];
+
+    expect(normalizeQueryTokens('abcdef', tokens)).toEqual([{ start: 0, end: 6, kind: null }]);
+  });
+
+  it('drops a later token that overlaps one already accepted — first wins', () => {
+    const tokens: QueryToken[] = [
+      { start: 0, end: 5, kind: 'field' },
+      { start: 3, end: 8, kind: 'error' },
+    ];
+
+    expect(normalizeQueryTokens('abcdefgh', tokens)).toEqual([
+      { start: 0, end: 5, kind: 'field' },
+      { start: 5, end: 8, kind: null },
+    ]);
+  });
+
+  it('drops a token nested entirely inside one already accepted', () => {
+    const tokens: QueryToken[] = [
+      { start: 0, end: 8, kind: 'field' },
+      { start: 2, end: 4, kind: 'error' },
+    ];
+
+    expect(normalizeQueryTokens('abcdefgh', tokens)).toEqual([{ start: 0, end: 8, kind: 'field' }]);
+  });
+
+  it('accepts adjacent, non-overlapping tokens (start === previous end)', () => {
+    const tokens: QueryToken[] = [
+      { start: 0, end: 4, kind: 'field' },
+      { start: 4, end: 8, kind: 'value' },
+    ];
+
+    expect(normalizeQueryTokens('abcdefgh', tokens)).toEqual([
+      { start: 0, end: 4, kind: 'field' },
+      { start: 4, end: 8, kind: 'value' },
+    ]);
+  });
+
+  it('resolves ties at the same start by accepted order, honoring first-wins after sort', () => {
+    const tokens: QueryToken[] = [
+      { start: 2, end: 3, kind: 'field' },
+      { start: 2, end: 8, kind: 'error' },
+    ];
+
+    expect(normalizeQueryTokens('abcdefgh', tokens)).toEqual([
+      { start: 0, end: 2, kind: null },
+      { start: 2, end: 3, kind: 'field' },
+      { start: 3, end: 8, kind: null },
+    ]);
+  });
+
+  it('never drops or duplicates characters for a fuzz-ish set of awkward token inputs', () => {
+    const value = 'level>=warn tag:auth -"retry" extra garbage 1234567890';
+    const awkwardTokenSets: QueryToken[][] = [
+      [],
+      [{ start: 0, end: 0, kind: 'field' }],
+      [{ start: 5, end: 5, kind: 'field' }],
+      [{ start: -10, end: -1, kind: 'field' }],
+      [{ start: 1000, end: 2000, kind: 'field' }],
+      [{ start: -10, end: 1000, kind: 'field' }],
+      [
+        { start: 0, end: 5, kind: 'field' },
+        { start: 0, end: 5, kind: 'operator' },
+      ],
+      [
+        { start: 0, end: 20, kind: 'field' },
+        { start: 5, end: 10, kind: 'operator' },
+        { start: 15, end: 25, kind: 'value' },
+      ],
+      [
+        { start: 10, end: 5, kind: 'error' },
+        { start: 0, end: value.length, kind: 'text' },
+      ],
+      Array.from({ length: 20 }, (_, index) => ({
+        start: index * 2,
+        end: index * 2 + 3,
+        kind: (index % 2 === 0 ? 'field' : 'value') as QueryToken['kind'],
+      })),
+    ];
+
+    for (const tokens of awkwardTokenSets) {
+      const segments = normalizeQueryTokens(value, tokens);
+      const rebuilt = segments.map((segment) => value.slice(segment.start, segment.end)).join('');
+
+      expect(rebuilt).toBe(value);
+
+      // Segments must be contiguous and non-overlapping, covering [0, length).
+      let expectedStart = 0;
+      for (const segment of segments) {
+        expect(segment.start).toBe(expectedStart);
+        expect(segment.end).toBeGreaterThan(segment.start);
+        expectedStart = segment.end;
+      }
+      expect(expectedStart).toBe(value.length);
+    }
+  });
+});
+
+describe('QueryField', () => {
+  it('paints token ranges into the mirror with the right classes', () => {
+    const tokens: QueryToken[] = [
+      { start: 0, end: 5, kind: 'field' },
+      { start: 5, end: 7, kind: 'operator' },
+      { start: 7, end: 11, kind: 'value' },
+    ];
+    const view = renderField({ value: 'level>=warn', tokens });
+    const spans = view.querySelectorAll('[data-slot="query-field-mirror"] span');
+
+    expect(spans).toHaveLength(3);
+    expect(spans[0]?.textContent).toBe('level');
+    expect(spans[0]?.className).toContain('text-primary');
+    expect(spans[1]?.textContent).toBe('>=');
+    expect(spans[1]?.className).toContain('text-muted-foreground');
+    expect(spans[2]?.textContent).toBe('warn');
+    expect(spans[2]?.className).toContain('text-foreground');
+  });
+
+  // jsdom computes no layout, so these two can only be guarded structurally.
+  // Both were real misalignment bugs: a block mirror paints its text above an
+  // input's vertically-centered line, and a non-flex wrapper drops the
+  // absolutely-positioned clear button at the top of the field.
+  it('centers the mirror and the clear button against the input line', () => {
+    const view = renderField({ value: 'tag:auth', onClear: () => {} });
+
+    expect(view.querySelector('[data-slot="query-field-mirror"]')?.className).toContain(
+      'items-center',
+    );
+    expect(view.querySelector('[data-slot="query-field"]')?.className).toContain('items-center');
+  });
+
+  it('renders an unstyled span for gaps outside any token', () => {
+    const tokens: QueryToken[] = [{ start: 6, end: 10, kind: 'value' }];
+    const view = renderField({ value: 'tag:auth extra', tokens });
+    const spans = view.querySelectorAll('[data-slot="query-field-mirror"] span');
+
+    expect(spans[0]?.textContent).toBe('tag:au');
+    expect(spans[0]?.className).toBe('');
+  });
+
+  it('marks an error token with the danger/wavy-underline treatment', () => {
+    const tokens: QueryToken[] = [{ start: 0, end: 4, kind: 'error' }];
+    const view = renderField({ value: 'bad(', tokens });
+    const span = view.querySelector('[data-slot="query-field-mirror"] span');
+
+    expect(span?.className).toContain('text-danger');
+    expect(span?.className).toContain('decoration-wavy');
+  });
+
+  it('never corrupts the rendered text for out-of-range, inverted, zero-length, and overlapping tokens', () => {
+    const value = 'level>=warn tag:auth -"retry"';
+    const tokens: QueryToken[] = [
+      { start: -20, end: 5, kind: 'field' },
+      { start: 3, end: 3, kind: 'error' },
+      { start: 10, end: 2, kind: 'error' },
+      { start: 5, end: 500, kind: 'operator' },
+      { start: 5, end: 8, kind: 'value' },
+    ];
+    const view = renderField({ value, tokens });
+
+    expect(mirrorText(view)).toBe(value);
+  });
+
+  it('fires onValueChange with the new value', () => {
+    const onValueChange = vi.fn();
+    const view = renderField({ value: 'lev', onValueChange });
+    const input = view.querySelector('[data-slot="query-field-input"]') as HTMLInputElement;
+    // React tracks the DOM value setter to detect real changes, so setting
+    // `input.value` directly is a no-op from its perspective — go through
+    // the native setter, as React Testing Library's fireEvent does.
+    const nativeValueSetter = Object.getOwnPropertyDescriptor(
+      HTMLInputElement.prototype,
+      'value',
+    )?.set;
+
+    act(() => {
+      nativeValueSetter?.call(input, 'level');
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    expect(onValueChange).toHaveBeenCalledExactlyOnceWith('level');
+  });
+
+  it('shows the clear button only when onClear and a non-empty value are both present', () => {
+    const withoutOnClear = renderField({ value: 'level' });
+    expect(withoutOnClear.querySelector('[data-slot="query-field-clear"]')).toBeNull();
+
+    act(() => root?.unmount());
+    container?.remove();
+
+    const withEmptyValue = renderField({ value: '', onClear: () => {} });
+    expect(withEmptyValue.querySelector('[data-slot="query-field-clear"]')).toBeNull();
+
+    act(() => root?.unmount());
+    container?.remove();
+
+    const onClear = vi.fn();
+    const withBoth = renderField({ value: 'level', onClear });
+    const clearButton = withBoth.querySelector(
+      '[data-slot="query-field-clear"]',
+    ) as HTMLButtonElement;
+
+    expect(clearButton).not.toBeNull();
+    act(() => clearButton.click());
+    expect(onClear).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/ui/src/query-field/query-field.tsx
+++ b/packages/ui/src/query-field/query-field.tsx
@@ -1,0 +1,223 @@
+import type { ChangeEvent, ComponentProps, UIEvent } from 'react';
+import { useMemo, useRef } from 'react';
+import { X } from 'lucide-react';
+import { cn } from '../utils/cn';
+import { fieldSurface } from '../utils/control-surfaces';
+import { sizeHeight } from '../tokens/size';
+import type { Size } from '../tokens/size';
+
+export type QueryTokenKind = 'field' | 'operator' | 'value' | 'negation' | 'text' | 'error';
+
+export type QueryToken = {
+  /** Inclusive start offset into the field's value. */
+  start: number;
+  /** Exclusive end offset into the field's value. */
+  end: number;
+  kind: QueryTokenKind;
+};
+
+/** A slice of `value` and the kind to paint it with, or `null` for an
+ *  unclaimed gap rendered as plain text. */
+export type QuerySegment = {
+  start: number;
+  end: number;
+  kind: QueryTokenKind | null;
+};
+
+/**
+ * Normalizes caller-supplied token ranges against `value` into a gapless,
+ * non-overlapping run of segments that together cover the whole string
+ * exactly once — so the mirror can never drop or duplicate a character
+ * regardless of what the caller passes in.
+ *
+ * - `start`/`end` are clamped into `[0, value.length]`.
+ * - Zero-length or inverted ranges (`end <= start` after clamping) are dropped.
+ * - Remaining tokens are sorted by `start`; a token that overlaps one
+ *   already accepted is dropped — first wins.
+ * - The gaps between accepted tokens come back as `kind: null` segments.
+ */
+export function normalizeQueryTokens(
+  value: string,
+  tokens: readonly QueryToken[] = [],
+): QuerySegment[] {
+  const length = value.length;
+
+  if (length === 0) {
+    return [];
+  }
+
+  const candidates = tokens
+    .map((token) => ({
+      start: Math.min(Math.max(token.start, 0), length),
+      end: Math.min(Math.max(token.end, 0), length),
+      kind: token.kind,
+    }))
+    .filter((token) => token.end > token.start)
+    .sort((a, b) => a.start - b.start);
+
+  const accepted: { start: number; end: number; kind: QueryTokenKind }[] = [];
+  let cursor = 0;
+
+  for (const token of candidates) {
+    if (token.start < cursor) {
+      continue;
+    }
+    accepted.push(token);
+    cursor = token.end;
+  }
+
+  const segments: QuerySegment[] = [];
+  let position = 0;
+
+  for (const token of accepted) {
+    if (token.start > position) {
+      segments.push({ start: position, end: token.start, kind: null });
+    }
+    segments.push(token);
+    position = token.end;
+  }
+
+  if (position < length) {
+    segments.push({ start: position, end: length, kind: null });
+  }
+
+  return segments;
+}
+
+const queryTokenKindClass = {
+  field: 'text-primary',
+  operator: 'text-muted-foreground',
+  value: 'text-foreground',
+  negation: 'text-warning',
+  text: 'text-foreground',
+  error: 'text-danger underline decoration-wavy',
+} as const satisfies Record<QueryTokenKind, string>;
+
+const queryFieldSize = {
+  sm: { clearPad: 'pr-6', clear: 'right-1 size-3.5', clearIcon: 'size-3' },
+  md: { clearPad: 'pr-8', clear: 'right-2 size-4', clearIcon: 'size-3.5' },
+  lg: { clearPad: 'pr-10', clear: 'right-2.5 size-5', clearIcon: 'size-4' },
+} as const satisfies Record<Size, unknown>;
+
+export type QueryFieldProps = Omit<ComponentProps<'input'>, 'size'> & {
+  /** Ranges to highlight. Ranges outside the value, or overlapping an earlier
+   *  token, are ignored. Unclaimed spans render as plain text. */
+  tokens?: readonly QueryToken[];
+  /** Convenience over onChange for the common controlled case. */
+  onValueChange?: (value: string) => void;
+  /** Called when the clear button is pressed. Omit to hide the clear affordance. */
+  onClear?: () => void;
+  /** Accessible name for the clear button.
+   * @default 'Clear query' */
+  clearLabel?: string;
+  /** @default 'md' */
+  size?: Size;
+};
+
+/**
+ * A query input that paints caller-supplied token ranges over the raw text —
+ * field names, operators, values, negation, free text, malformed fragments —
+ * without knowing anything about the grammar itself. `QueryField` holds no
+ * parser and no operator vocabulary; the caller (a plugin that owns a query
+ * language) tokenizes and hands over ranges, `QueryField` only paints them.
+ *
+ * Built with the overlay-mirror technique: an `aria-hidden` mirror underneath
+ * paints the colored spans, and the real `<input>` sits on top with
+ * transparent text and a visible caret, so typing, selection, and IME
+ * composition all behave like a normal input. Both layers share the same
+ * `fieldSurface` box metrics and a monospace font so the painted text never
+ * drifts from the caret; a `scroll` listener keeps the mirror in sync when
+ * the value is wider than the field.
+ */
+export function QueryField({
+  className,
+  value,
+  type = 'text',
+  tokens,
+  onChange,
+  onValueChange,
+  onClear,
+  clearLabel = 'Clear query',
+  size = 'md',
+  ...props
+}: QueryFieldProps) {
+  const mirrorRef = useRef<HTMLDivElement>(null);
+  const text = typeof value === 'string' ? value : (value?.toString() ?? '');
+  const showClear = Boolean(onClear) && text.length > 0;
+  const sizing = queryFieldSize[size];
+  const segments = useMemo(() => normalizeQueryTokens(text, tokens), [text, tokens]);
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onChange?.(event);
+    onValueChange?.(event.target.value);
+  };
+
+  const handleScroll = (event: UIEvent<HTMLInputElement>) => {
+    if (mirrorRef.current) {
+      mirrorRef.current.scrollLeft = event.currentTarget.scrollLeft;
+    }
+  };
+
+  return (
+    // `flex items-center` carries no in-flow children here — every layer is
+    // absolutely positioned. It sets the *static position* of the clear
+    // button so it centers vertically without a `top`, the same way
+    // `SearchField` positions its own clear affordance.
+    <div
+      data-slot="query-field"
+      className={cn('relative flex w-full items-center', sizeHeight[size])}
+    >
+      <div
+        aria-hidden="true"
+        data-slot="query-field-mirror"
+        ref={mirrorRef}
+        className={cn(
+          fieldSurface({ size }),
+          // `items-center` is load-bearing: an input centers its single line of
+          // text vertically, a block box does not, so a block mirror paints the
+          // text several pixels above the caret. Centering with flex keeps the
+          // two layers aligned without hardcoding a line height per size.
+          'pointer-events-none absolute inset-0 flex items-center overflow-hidden border-transparent bg-transparent font-mono whitespace-pre shadow-none',
+          showClear && sizing.clearPad,
+        )}
+      >
+        {segments.map((segment) => (
+          <span
+            key={`${segment.start}-${segment.end}`}
+            className={segment.kind ? queryTokenKindClass[segment.kind] : undefined}
+          >
+            {text.slice(segment.start, segment.end)}
+          </span>
+        ))}
+      </div>
+      <input
+        type={type}
+        data-slot="query-field-input"
+        value={value}
+        onChange={handleChange}
+        onScroll={handleScroll}
+        className={cn(
+          fieldSurface({ size }),
+          'absolute inset-0 min-w-0 font-mono text-transparent caret-foreground selection:bg-primary/30',
+          showClear && sizing.clearPad,
+          className,
+        )}
+        {...props}
+      />
+      {showClear && (
+        <button
+          type="button"
+          data-slot="query-field-clear"
+          onClick={onClear}
+          aria-label={clearLabel}
+          className={cn(
+            'absolute inline-flex items-center justify-center rounded-sm text-muted-foreground hover:text-foreground',
+            sizing.clear,
+          )}
+        >
+          <X className={sizing.clearIcon} />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/toggle-group/toggle-group.tsx
+++ b/packages/ui/src/toggle-group/toggle-group.tsx
@@ -1,0 +1,68 @@
+import { ToggleGroup as ToggleGroupPrimitive } from '@base-ui/react/toggle-group';
+import { Toggle as TogglePrimitive } from '@base-ui/react/toggle';
+import { cn } from '../utils/cn';
+import type { Size } from '../tokens/size';
+
+const toggleGroupSize = {
+  sm: 'h-6 p-0.5',
+  md: 'h-8 p-1',
+  lg: 'h-10 p-1',
+} as const satisfies Record<Size, string>;
+
+const toggleGroupItemSize = {
+  sm: 'h-5 px-2 text-xs [&_svg]:size-3.5',
+  md: 'h-6 px-2.5 text-sm [&_svg]:size-4',
+  lg: 'h-8 px-3 text-base [&_svg]:size-5',
+} as const satisfies Record<Size, string>;
+
+export type ToggleGroupProps<Value extends string = string> = ToggleGroupPrimitive.Props<Value> & {
+  /** @default 'md' */
+  size?: Size;
+};
+
+function ToggleGroupRoot<Value extends string = string>({
+  className,
+  size = 'md',
+  ...props
+}: ToggleGroupProps<Value>) {
+  return (
+    <ToggleGroupPrimitive
+      data-slot="toggle-group"
+      className={cn(
+        'inline-flex items-center gap-1 rounded-md bg-muted text-muted-foreground',
+        toggleGroupSize[size],
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export type ToggleGroupItemProps<Value extends string = string> = TogglePrimitive.Props<Value> & {
+  /** @default 'md' */
+  size?: Size;
+};
+
+function ToggleGroupItem<Value extends string = string>({
+  className,
+  size = 'md',
+  ...props
+}: ToggleGroupItemProps<Value>) {
+  return (
+    <TogglePrimitive
+      data-slot="toggle-group-item"
+      className={cn(
+        'inline-flex items-center justify-center gap-1.5 rounded-sm font-medium whitespace-nowrap text-muted-foreground',
+        'outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        'data-[pressed]:bg-background data-[pressed]:text-foreground data-[pressed]:shadow-xs',
+        'disabled:pointer-events-none disabled:opacity-50',
+        toggleGroupItemSize[size],
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+/** A segmented control for one or more independent on/off facets. */
+export const ToggleGroup = Object.assign(ToggleGroupRoot, { Item: ToggleGroupItem });

--- a/packages/ui/src/virtualized-list/virtualized-list.test.tsx
+++ b/packages/ui/src/virtualized-list/virtualized-list.test.tsx
@@ -11,6 +11,8 @@ declare global {
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
+const virtuosoProps: Record<string, unknown>[] = [];
+
 vi.mock('react-virtuoso', async () => {
   const React = await import('react');
 
@@ -23,7 +25,18 @@ vi.mock('react-virtuoso', async () => {
       startReached,
       endReached,
       computeItemKey,
+      ...rest
     }: Record<string, any>) => {
+      virtuosoProps.push({
+        components,
+        context,
+        data,
+        itemContent,
+        startReached,
+        endReached,
+        computeItemKey,
+        ...rest,
+      });
       const List = components.List;
       const Item = components.Item;
       const EmptyPlaceholder = components.EmptyPlaceholder;
@@ -79,6 +92,7 @@ let root: Root | undefined;
 let container: HTMLDivElement | undefined;
 
 afterEach(() => {
+  virtuosoProps.length = 0;
   act(() => root?.unmount());
   container?.remove();
   root = undefined;
@@ -116,6 +130,22 @@ describe('VirtualizedList', () => {
     expect(rows[0]?.textContent).toBe('message-0');
     expect(view.querySelector('[role="list"]')?.getAttribute('aria-label')).toBe('Log entries');
     expect(rows[0]?.className).toContain('border-b border-border');
+  });
+
+  // Regression guard: Virtuoso reads initialTopMostItemIndex as
+  // `typeof v === 'number' ? v : v.index`, so passing an explicit `undefined`
+  // threw and the real list rendered no rows. jsdom computes no layout, so
+  // only the prop contract is checkable here.
+  it('omits initialTopMostItemIndex entirely unless a caller supplies one', () => {
+    renderList();
+
+    expect(virtuosoProps.at(-1)).not.toHaveProperty('initialTopMostItemIndex');
+  });
+
+  it('forwards initialTopMostItemIndex when a caller supplies one', () => {
+    renderList({ initialTopMostItemIndex: 12 });
+
+    expect(virtuosoProps.at(-1)?.initialTopMostItemIndex).toBe(12);
   });
 
   it('uses getItemTextValue for the accessible label when provided', () => {

--- a/packages/ui/src/virtualized-list/virtualized-list.test.tsx
+++ b/packages/ui/src/virtualized-list/virtualized-list.test.tsx
@@ -1,0 +1,192 @@
+// @vitest-environment jsdom
+
+import { act, type ComponentProps } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { VirtualizedList } from './virtualized-list';
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean | undefined;
+}
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('react-virtuoso', async () => {
+  const React = await import('react');
+
+  return {
+    Virtuoso: ({
+      components,
+      context,
+      data = [],
+      itemContent,
+      startReached,
+      endReached,
+      computeItemKey,
+    }: Record<string, any>) => {
+      const List = components.List;
+      const Item = components.Item;
+      const EmptyPlaceholder = components.EmptyPlaceholder;
+      // Mimic virtualization: only a small viewport window reaches the DOM.
+      const visibleItems = data.slice(0, 8);
+
+      return React.createElement(
+        'div',
+        { 'data-testid': 'virtuoso-mock' },
+        React.createElement(
+          'button',
+          { onClick: () => startReached?.(0), type: 'button' },
+          'reach start',
+        ),
+        React.createElement(
+          'button',
+          { onClick: () => endReached?.(data.length - 1), type: 'button' },
+          'reach end',
+        ),
+        React.createElement(
+          List,
+          { context },
+          visibleItems.length === 0
+            ? React.createElement(EmptyPlaceholder, { context })
+            : visibleItems.map((item: unknown, index: number) =>
+                React.createElement(
+                  Item,
+                  {
+                    context,
+                    item,
+                    key: computeItemKey ? computeItemKey(index, item) : index,
+                    'data-index': index,
+                    'data-item-index': index,
+                    'data-known-size': 20,
+                  },
+                  itemContent(index, item),
+                ),
+              ),
+        ),
+      );
+    },
+  };
+});
+
+type TestItem = { id: string; message: string };
+
+const data = Array.from({ length: 30 }, (_, index) => ({
+  id: `item-${index}`,
+  message: `message-${index}`,
+}));
+
+let root: Root | undefined;
+let container: HTMLDivElement | undefined;
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  root = undefined;
+  container = undefined;
+});
+
+const renderList = (props: Partial<ComponentProps<typeof VirtualizedList<TestItem>>> = {}) => {
+  container = document.createElement('div');
+  document.body.append(container);
+  root = createRoot(container);
+
+  act(() => {
+    root?.render(
+      <VirtualizedList
+        ariaLabel="Log entries"
+        data={data}
+        getItemKey={(item) => item.id}
+        renderItem={(item) => <div>{item.message}</div>}
+        {...props}
+      />,
+    );
+  });
+
+  return container;
+};
+
+describe('VirtualizedList', () => {
+  it('keeps rows bounded and renders content through renderItem with stable keys', () => {
+    const view = renderList();
+    const rows = view.querySelectorAll('[role="listitem"]');
+
+    expect(rows).toHaveLength(8);
+    expect(rows[0]?.getAttribute('data-index')).toBe('0');
+    expect(rows[0]?.getAttribute('aria-label')).toBe('item-0');
+    expect(rows[0]?.textContent).toBe('message-0');
+    expect(view.querySelector('[role="list"]')?.getAttribute('aria-label')).toBe('Log entries');
+    expect(rows[0]?.className).toContain('border-b border-border');
+  });
+
+  it('uses getItemTextValue for the accessible label when provided', () => {
+    const view = renderList({ getItemTextValue: (item) => `Row for ${item.message}` });
+    const firstRow = view.querySelector('[role="listitem"]');
+
+    expect(firstRow?.getAttribute('aria-label')).toBe('Row for message-0');
+  });
+
+  it('forwards both edge callbacks', () => {
+    const onStartReached = vi.fn();
+    const onEndReached = vi.fn();
+    const view = renderList({ onEndReached, onStartReached });
+    const buttons = view.querySelectorAll('button');
+
+    act(() => buttons[0].click());
+    act(() => buttons[1].click());
+
+    expect(onStartReached).toHaveBeenCalledExactlyOnceWith(0);
+    expect(onEndReached).toHaveBeenCalledExactlyOnceWith(29);
+  });
+
+  it('activates a row on click and on Enter/Space, and marks it keyboard-focusable', () => {
+    const onItemClick = vi.fn();
+    const view = renderList({ onItemClick });
+    const firstRow = view.querySelector('[role="listitem"]');
+
+    expect(firstRow?.getAttribute('tabindex')).toBe('0');
+    expect(firstRow?.className).toContain('cursor-pointer');
+
+    act(() => (firstRow as HTMLElement | null)?.click());
+    expect(onItemClick).toHaveBeenNthCalledWith(1, data[0]);
+
+    act(() =>
+      firstRow?.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'Enter' })),
+    );
+    expect(onItemClick).toHaveBeenNthCalledWith(2, data[0]);
+
+    act(() => firstRow?.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: ' ' })));
+    expect(onItemClick).toHaveBeenNthCalledWith(3, data[0]);
+    expect(onItemClick).toHaveBeenCalledTimes(3);
+  });
+
+  it('is not clickable or keyboard-focusable without onItemClick', () => {
+    const view = renderList();
+    const firstRow = view.querySelector('[role="listitem"]');
+
+    expect(firstRow?.getAttribute('tabindex')).toBeNull();
+    expect(firstRow?.className).not.toContain('cursor-pointer');
+  });
+
+  it('renders an accessible loading state', () => {
+    const view = renderList({ data: [], loading: true });
+
+    expect(view.textContent).toContain('Loading…');
+  });
+
+  it('renders the default empty state message when not loading', () => {
+    const view = renderList({ data: [], emptyMessage: 'Nothing to show.' });
+
+    expect(view.textContent).toContain('Nothing to show.');
+  });
+
+  it('prefers a custom renderEmptyState over the default empty/loading message', () => {
+    const view = renderList({
+      data: [],
+      loading: true,
+      renderEmptyState: () => <div>Custom empty state</div>,
+    });
+
+    expect(view.textContent).toContain('Custom empty state');
+    expect(view.textContent).not.toContain('Loading…');
+  });
+});

--- a/packages/ui/src/virtualized-list/virtualized-list.tsx
+++ b/packages/ui/src/virtualized-list/virtualized-list.tsx
@@ -1,0 +1,205 @@
+import { Virtuoso, type Components, type FollowOutput, type ItemProps } from 'react-virtuoso';
+import {
+  useCallback,
+  useMemo,
+  type CSSProperties,
+  type KeyboardEvent,
+  type ReactNode,
+} from 'react';
+import { cn } from '../utils/cn';
+
+const DEFAULT_SCROLL_CLASSNAME = 'h-full w-full overflow-auto';
+const DEFAULT_STYLE: CSSProperties = { height: 400 };
+
+export type VirtualizedListProps<TItem> = {
+  ariaLabel: string;
+  data: TItem[];
+  /** Renders one row. Rows may vary freely in height. */
+  renderItem: (item: TItem, index: number) => ReactNode;
+  /** Stable row key. Defaults to the index. */
+  getItemKey?: (item: TItem, index: number) => string;
+  /** Accessible label for a row. */
+  getItemTextValue?: (item: TItem, index: number) => string;
+  onItemClick?: (item: TItem) => void;
+  onStartReached?: (index: number) => void;
+  onEndReached?: (index: number) => void;
+  /**
+   * Pins the view to the newest row while items stream in, releasing when the
+   * user scrolls away. The affordance a live log tail needs.
+   * @default false
+   */
+  followOutput?: FollowOutput;
+  initialTopMostItemIndex?: number;
+  loading?: boolean;
+  emptyMessage?: string;
+  /** Overrides the default centered empty or loading rendering. */
+  renderEmptyState?: () => ReactNode;
+  /** Applied to the list element. */
+  className?: string;
+  /** Applied to each row. */
+  itemClassName?: string;
+  /** Applied to Virtuoso's scroll container. */
+  scrollClassName?: string;
+  style?: CSSProperties;
+};
+
+type VirtualizedListContext<TItem> = {
+  ariaLabel: string;
+  emptyMessage: string;
+  getItemKey?: (item: TItem, index: number) => string;
+  getItemTextValue?: (item: TItem, index: number) => string;
+  isLoading: boolean;
+  itemClassName?: string;
+  listClassName?: string;
+  onItemClick?: (item: TItem) => void;
+  renderEmptyState?: () => ReactNode;
+};
+
+type ListComponentProps = {
+  children?: ReactNode;
+  context: VirtualizedListContext<unknown>;
+  style?: CSSProperties;
+};
+
+type ListItemComponentProps = ItemProps<unknown> & {
+  context: VirtualizedListContext<unknown>;
+};
+
+const VirtualizedListElement = ({ children, context, style }: ListComponentProps) => (
+  <div
+    aria-label={context.ariaLabel}
+    className={cn(context.listClassName)}
+    role="list"
+    style={style}
+  >
+    {children}
+  </div>
+);
+
+const VirtualizedListRow = ({ children, context, item, ...props }: ListItemComponentProps) => {
+  const index = props['data-index'];
+  const isActionable = Boolean(context.onItemClick);
+
+  const activateItem = () => {
+    context.onItemClick?.(item);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (!isActionable || (event.key !== 'Enter' && event.key !== ' ')) {
+      return;
+    }
+
+    event.preventDefault();
+    activateItem();
+  };
+
+  const fallbackKey = context.getItemKey?.(item, index) ?? String(index);
+
+  return (
+    <div
+      {...props}
+      aria-label={context.getItemTextValue?.(item, index) ?? fallbackKey}
+      className={cn(
+        'border-b border-border last:border-0 transition-colors hover:bg-accent/50',
+        isActionable && 'cursor-pointer',
+        context.itemClassName,
+      )}
+      onClick={isActionable ? activateItem : undefined}
+      onKeyDown={handleKeyDown}
+      role="listitem"
+      tabIndex={isActionable ? 0 : undefined}
+    >
+      {children}
+    </div>
+  );
+};
+
+const VirtualizedListEmptyState = ({ context }: { context: VirtualizedListContext<unknown> }) => (
+  <>
+    {context.renderEmptyState?.() ?? (
+      <div className="flex min-h-56 w-full items-center justify-center px-4 py-10 text-center">
+        <span className="text-sm text-muted-foreground">
+          {context.isLoading ? 'Loading…' : context.emptyMessage}
+        </span>
+      </div>
+    )}
+  </>
+);
+
+// Virtuoso requires component definitions to remain stable between renders.
+// Dynamic behavior travels through its `context` prop instead.
+const virtualizedListComponents: Components<unknown, VirtualizedListContext<unknown>> = {
+  EmptyPlaceholder: VirtualizedListEmptyState,
+  Item: VirtualizedListRow,
+  List: VirtualizedListElement,
+};
+
+/** A virtualized list for large datasets of variable-height, freely-composed rows. */
+export const VirtualizedList = <TItem,>({
+  ariaLabel,
+  data,
+  renderItem,
+  getItemKey,
+  getItemTextValue,
+  onItemClick,
+  onStartReached,
+  onEndReached,
+  followOutput = false,
+  initialTopMostItemIndex,
+  loading = false,
+  emptyMessage = 'No data.',
+  renderEmptyState,
+  className,
+  itemClassName,
+  scrollClassName,
+  style,
+}: VirtualizedListProps<TItem>) => {
+  const context = useMemo<VirtualizedListContext<TItem>>(
+    () => ({
+      ariaLabel,
+      emptyMessage,
+      getItemKey,
+      getItemTextValue,
+      isLoading: loading,
+      itemClassName,
+      listClassName: className,
+      onItemClick,
+      renderEmptyState,
+    }),
+    [
+      ariaLabel,
+      className,
+      emptyMessage,
+      getItemKey,
+      getItemTextValue,
+      itemClassName,
+      loading,
+      onItemClick,
+      renderEmptyState,
+    ],
+  );
+  const itemContent = useCallback(
+    (index: number, item: TItem) => renderItem(item, index),
+    [renderItem],
+  );
+  const computeItemKey = useCallback(
+    (index: number, item: TItem) => getItemKey?.(item, index) ?? String(index),
+    [getItemKey],
+  );
+
+  return (
+    <Virtuoso<TItem, VirtualizedListContext<TItem>>
+      className={cn(DEFAULT_SCROLL_CLASSNAME, scrollClassName)}
+      components={virtualizedListComponents as Components<TItem, VirtualizedListContext<TItem>>}
+      computeItemKey={computeItemKey}
+      context={context}
+      data={data}
+      endReached={onEndReached}
+      followOutput={followOutput}
+      initialTopMostItemIndex={initialTopMostItemIndex}
+      itemContent={itemContent}
+      startReached={onStartReached}
+      style={style ? { ...DEFAULT_STYLE, ...style } : DEFAULT_STYLE}
+    />
+  );
+};

--- a/packages/ui/src/virtualized-list/virtualized-list.tsx
+++ b/packages/ui/src/virtualized-list/virtualized-list.tsx
@@ -5,6 +5,7 @@ import {
   type CSSProperties,
   type KeyboardEvent,
   type ReactNode,
+  type Ref,
 } from 'react';
 import { cn } from '../utils/cn';
 
@@ -58,6 +59,12 @@ type VirtualizedListContext<TItem> = {
 type ListComponentProps = {
   children?: ReactNode;
   context: VirtualizedListContext<unknown>;
+  /**
+   * Virtuoso measures the list through this ref (see `ListProps` in
+   * react-virtuoso). Dropping it leaves the list unmeasured: it collapses to
+   * a single probe row instead of filling the viewport.
+   */
+  ref?: Ref<HTMLDivElement>;
   style?: CSSProperties;
 };
 
@@ -65,10 +72,11 @@ type ListItemComponentProps = ItemProps<unknown> & {
   context: VirtualizedListContext<unknown>;
 };
 
-const VirtualizedListElement = ({ children, context, style }: ListComponentProps) => (
+const VirtualizedListElement = ({ children, context, ref, style }: ListComponentProps) => (
   <div
     aria-label={context.ariaLabel}
     className={cn(context.listClassName)}
+    ref={ref}
     role="list"
     style={style}
   >
@@ -196,7 +204,11 @@ export const VirtualizedList = <TItem,>({
       data={data}
       endReached={onEndReached}
       followOutput={followOutput}
-      initialTopMostItemIndex={initialTopMostItemIndex}
+      // Spread conditionally rather than passing `undefined`: Virtuoso reads
+      // this prop as `typeof value === 'number' ? value : value.index`, so an
+      // explicit `undefined` throws instead of falling back to its default,
+      // and the list renders no rows at all.
+      {...(initialTopMostItemIndex === undefined ? {} : { initialTopMostItemIndex })}
       itemContent={itemContent}
       startReached={onStartReached}
       style={style ? { ...DEFAULT_STYLE, ...style } : DEFAULT_STYLE}


### PR DESCRIPTION
## Description

Adds three `@rozenite/ui` primitives that a log or stream panel needs and the kit does not have yet. No plugin logic here — this is the UI groundwork only.

- **`ToggleGroup`** — a segmented control for filters where several options can be active at once (levels, tags, sources). Single or multiple selection, icon-only items, and the three control sizes. Built on `@base-ui/react/toggle-group` and styled to read as a sibling of `Tabs`.
- **`VirtualizedList`** — the non-tabular counterpart to `VirtualizedDataTable`, for large streams of freely-composed rows that vary in height. No measurement or fixed row height, and `followOutput` pins the view to the newest row while entries stream in, releasing as soon as the reader scrolls away.
- **`QueryField`** — a query input that highlights parts of a query as the reader types, and can mark malformed fragments so a typo is visible before the query runs.

Each ships with a Storybook story per behavior and unit tests.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Part of https://github.com/callstackincubator/rozenite/issues/427

## Context

**`QueryField` deliberately owns no grammar.** It holds no parser and no operator vocabulary: the caller tokenizes its own query language and passes `{ start, end, kind }` ranges, and the field paints them. A query grammar is plugin logic, not design-system logic, so keeping it out means any panel can bring its own syntax. `normalizeQueryTokens` clamps, drops, and gap-fills whatever ranges it is handed, so the painted text always reconstructs the value exactly regardless of what a caller passes in.

It uses the overlay-mirror technique — an `aria-hidden` mirror paints the colored spans, the real `<input>` sits on top with transparent text and a visible caret — so typing, selection, and IME composition stay native. Both layers share one `fieldSurface` call for their box metrics so those cannot drift apart. Two details there are load-bearing and commented as such: the mirror centers with flex because an `<input>` centers its single line vertically and a block box does not, and the wrapper is flex because that is what sets the static position of the absolutely-positioned clear button (the same reason `SearchField`'s wrapper is).

**`VirtualizedList` uses `Virtuoso`, not `TableVirtuoso`**, since rows are composed rather than tabular. Two things about the library contract are worth knowing for review: `initialTopMostItemIndex` must be omitted rather than passed as `undefined` (Virtuoso reads it as `typeof v === 'number' ? v : v.index`, so an explicit `undefined` throws during render), and a custom `List` component must attach the ref Virtuoso passes it, since that is how the list is measured. `VirtualizedDataTable` is unaffected by both: it never passes the prop, and `TableVirtuoso` puts its ref on the default `TableBody` rather than on a custom slot. Both are commented at the call site.

Worth flagging for the reviewer: the unit tests mock `react-virtuoso` away, following the existing `VirtualizedDataTable` test. That mock cannot catch either of the above — both were caught only by rendering in a browser. The prop contract now has a regression guard, but the ref requirement is not reachable from jsdom, which computes no layout.

One cosmetic behavior left as-is: on an overflowing query the text runs under the clear button. That is inherited from `SearchField`'s construction and the native `<input>` behaves identically, so fixing only the mirror would make the two layers diverge.

## Testing

Automated, from the repository root after `git fetch origin main`:

- `pnpm checks:affected` — typecheck, lint, and format clean
- `pnpm test:affected` — 59/59 tasks successful
- `pnpm --filter @rozenite/ui test` — 69 tests passed, including 29 new
- `pnpm release:plan` — version plan present

Manual verification, in Chromium against the Storybook stories, in both light and dark themes:

- `ToggleGroup` — pressed and unpressed items, icon-only, all three sizes.
- `VirtualizedList` — the default story renders 7 rows of a 7327px virtual list with variable row heights and no page errors; empty and clickable stories verified; `followOutput` verified against the streaming live-tail story.
- `QueryField` — token colors and vertical alignment at all three sizes; horizontal scroll sync measured directly with the caret at the end of an overflowing query (`input.scrollLeft === mirror.scrollLeft === 740`).

No page errors in either theme across the captured set.

---
_Generated by [Claude Code](https://claude.ai/code/session_016tQFgmYTXh312sSVfJjLmF)_