### PR TITLE
feat(middleware): resolve per-target CDP capability profiles for agent sessions

### DIFF
--- a/.changeset/lynx-agent-capabilities.md
+++ b/.changeset/lynx-agent-capabilities.md
@@ -1,0 +1,41 @@
+---
+'@rozenite/agent-shared': minor
+'@rozenite/middleware': minor
+'@rozenite/agent-sdk': minor
+'@rozenite/lynx-dev': minor
+'rozenite': minor
+---
+
+Teach Rozenite for Agents which built-in domains the connected target can
+actually back, so a Lynx session no longer looks like a React Native one.
+
+The five built-in domains were designed against React Native's CDP surface, and
+Lynx exposes a different one: it registers no `Network` domain at all, has no
+React DevTools backend, and implements a Perfetto-based `Tracing` domain that
+shares Chrome's method names but not its protocol. Until now every session
+advertised all five regardless, so an agent on a Lynx target could only find out
+by calling — and two of the three ways that fails are silent. `network` errored
+with a raw protocol code, `react` returned nothing, `performance` finalised a
+trace artifact containing zero events, and heap sampling appeared to start and
+collected nothing.
+
+Each session now resolves a capability profile from its target's platform.
+Unsupported tools are never registered, so `list-tools` is honest; unavailable
+domains stay visible in `rozenite agent domains` with an `availability` column, a
+reason, and — for `network` — the `@rozenite/network-activity-plugin` domain to
+use instead. Calling an unsupported tool fails during resolution with that same
+explanation rather than a protocol error, so the agent gets a next step instead
+of a dead end. On Lynx that means `console`, plugin domains, app tools and
+`memory.takeHeapSnapshot` are reported supported, `memory` is degraded, and
+`network`, `react` and `performance` are unavailable with reasons.
+
+Three fixes to the CDP command channel apply to every platform, not just Lynx. A
+device error now names the method it refused instead of arriving as a stringified
+error object; waits on a device event are bounded, so a capture whose completion
+event never arrives fails with a diagnosis instead of hanging forever; and
+`stopTrace` refuses to hand back an empty trace artifact rather than reporting a
+successful capture of nothing.
+
+Both new fields on the session tools response are optional, so a CLI and a Metro
+on different versions keep working together — an older server simply reports no
+capability data and every domain is treated as supported, exactly as before.

--- a/.changeset/lynx-agent-capabilities.md
+++ b/.changeset/lynx-agent-capabilities.md
@@ -2,7 +2,6 @@
 '@rozenite/agent-shared': minor
 '@rozenite/middleware': minor
 '@rozenite/agent-sdk': minor
-'@rozenite/lynx-dev': minor
 'rozenite': minor
 ---
 
@@ -19,7 +18,8 @@ with a raw protocol code, `react` returned nothing, `performance` finalised a
 trace artifact containing zero events, and heap sampling appeared to start and
 collected nothing.
 
-Each session now resolves a capability profile from its target's platform.
+Each session now resolves a capability profile from the integration its dev
+server hosts.
 Unsupported tools are never registered, so `list-tools` is honest; unavailable
 domains stay visible in `rozenite agent domains` with an `availability` column, a
 reason, and — for `network` — the `@rozenite/network-activity-plugin` domain to
@@ -29,12 +29,13 @@ of a dead end. On Lynx that means `console`, plugin domains, app tools and
 `memory.takeHeapSnapshot` are reported supported, `memory` is degraded, and
 `network`, `react` and `performance` are unavailable with reasons.
 
-Three fixes to the CDP command channel apply to every platform, not just Lynx. A
+Three fixes to the CDP command channel apply to every integration, not just
+Lynx. A
 device error now names the method it refused instead of arriving as a stringified
 error object; waits on a device event are bounded, so a capture whose completion
 event never arrives fails with a diagnosis instead of hanging forever; and
-`stopTrace` refuses to hand back an empty trace artifact rather than reporting a
-successful capture of nothing.
+`stopTrace` refuses to hand back a trace artifact containing no events rather
+than reporting a successful capture of nothing.
 
 Both new fields on the session tools response are optional, so a CLI and a Metro
 on different versions keep working together — an older server simply reports no

--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -51,6 +51,7 @@
   },
   "dependencies": {
     "@rozenite/agent-shared": "workspace:*",
+    "@rozenite/tools": "workspace:*",
     "tslib": "^2.3.0"
   },
   "devDependencies": {

--- a/packages/agent-sdk/src/__tests__/domain-utils.test.ts
+++ b/packages/agent-sdk/src/__tests__/domain-utils.test.ts
@@ -3,9 +3,12 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import type { AgentTool } from '@rozenite/agent-shared';
 import {
+  applyCapabilities,
   buildRuntimePluginDomains,
   deriveDomainName,
   formatUnknownDomainError,
+  formatUnsupportedToolError,
+  isToolUnavailable,
   getDomainToolsByDefinition,
   inferPluginId,
   inferToolShortName,
@@ -302,5 +305,70 @@ describe('agent domain utils', () => {
       idempotent: true,
       pagination: entry.pagination,
     });
+  });
+});
+
+describe('capability folding', () => {
+  const domains = [
+    { id: 'memory', kind: 'static' as const, description: 'memory', actions: [] },
+    { id: 'network', kind: 'static' as const, description: 'network', actions: [] },
+    { id: 'console', kind: 'static' as const, description: 'console', actions: [] },
+  ];
+
+  const gaps = [
+    {
+      domain: 'network',
+      reason: 'Lynx registers no CDP Network domain.',
+      fallback: '@rozenite/network-activity-plugin',
+    },
+    {
+      domain: 'memory',
+      reason: 'Not supported on lynx targets.',
+      tools: [
+        { name: 'startSampling', reason: 'PrimJS implements only takeHeapSnapshot.' },
+        { name: 'stopSampling', reason: 'PrimJS implements only takeHeapSnapshot.' },
+      ],
+    },
+  ];
+
+  it('returns the list untouched when there are no gaps', () => {
+    expect(applyCapabilities(domains, [])).toBe(domains);
+  });
+
+  it('marks a whole-domain gap unsupported and a tool-level one degraded', () => {
+    const folded = applyCapabilities(domains, gaps);
+
+    expect(folded.find((domain) => domain.id === 'network')?.availability).toBe('unsupported');
+    expect(folded.find((domain) => domain.id === 'memory')?.availability).toBe('degraded');
+    expect(folded.find((domain) => domain.id === 'console')?.availability).toBeUndefined();
+  });
+
+  // Without the tool list, a call to a filtered tool in a domain that
+  // still works falls through to the generic unknown-tool error, which
+  // reads to an agent as a typo rather than a limit.
+  it('carries tool-level gaps through so a degraded domain can still explain itself', () => {
+    const memory = applyCapabilities(domains, gaps).find((domain) => domain.id === 'memory')!;
+
+    expect(isToolUnavailable(memory, 'startSampling')).toBe(true);
+    expect(isToolUnavailable(memory, 'takeHeapSnapshot')).toBe(false);
+    expect(formatUnsupportedToolError(memory, 'startSampling', 'lynx').message).toContain(
+      'PrimJS implements only takeHeapSnapshot.',
+    );
+  });
+
+  it('reports every tool of an unsupported domain as unavailable, with its fallback', () => {
+    const network = applyCapabilities(domains, gaps).find((domain) => domain.id === 'network')!;
+
+    expect(isToolUnavailable(network, 'listRequests')).toBe(true);
+    expect(formatUnsupportedToolError(network, 'listRequests', 'lynx').message).toBe(
+      'Tool "listRequests" is not supported on this lynx target. Lynx registers no CDP ' +
+        'Network domain. Use the `@rozenite/network-activity-plugin` domain instead.',
+    );
+  });
+
+  it('treats a domain with no capability data as usable', () => {
+    const console = domains.find((domain) => domain.id === 'console')!;
+
+    expect(isToolUnavailable(console, 'anything')).toBe(false);
   });
 });

--- a/packages/agent-sdk/src/client.ts
+++ b/packages/agent-sdk/src/client.ts
@@ -1,8 +1,16 @@
-import type { AgentSessionInfo, AgentTool, AgentToolDescriptor } from '@rozenite/agent-shared';
+import type {
+  AgentSessionInfo,
+  AgentTargetPlatform,
+  AgentTool,
+  AgentToolDescriptor,
+  UnsupportedDomainInfo,
+} from '@rozenite/agent-shared';
 import { STATIC_DOMAINS } from './constants.js';
 import {
+  applyCapabilities,
   buildRuntimePluginDomains,
   formatUnknownDomainError,
+  formatUnsupportedToolError,
   getDomainToolsByDefinition,
   resolveDomainToken,
   resolveDomainTool,
@@ -21,9 +29,14 @@ import type {
   DomainDefinition,
 } from './types.js';
 
-const getKnownDomains = (tools: AgentTool[]): DomainDefinition[] => {
+const getKnownDomains = (
+  tools: AgentTool[],
+  unsupported: UnsupportedDomainInfo[] = [],
+): DomainDefinition[] => {
   const runtimeDomains = buildRuntimePluginDomains(tools);
-  return [...STATIC_DOMAINS, ...runtimeDomains].sort((a, b) => a.id.localeCompare(b.id));
+  return applyCapabilities([...STATIC_DOMAINS, ...runtimeDomains], unsupported).sort((a, b) =>
+    a.id.localeCompare(b.id),
+  );
 };
 
 const sortTools = <
@@ -40,9 +53,9 @@ export const createAgentClient = (options?: AgentClientOptions): AgentClient => 
   const transport = createAgentTransport(options);
 
   const resolveDomainContext = async (input: { sessionId: string; domain: string }) => {
-    const { tools } = await transport.getSessionTools(input.sessionId);
+    const { tools, platform, unsupported } = await transport.getSessionTools(input.sessionId);
     const sortedTools = sortTools(tools);
-    const knownDomains = getKnownDomains(sortedTools);
+    const knownDomains = getKnownDomains(sortedTools, unsupported);
     const resolvedDomain = resolveDomainToken(input.domain, knownDomains);
     if (!resolvedDomain) {
       throw formatUnknownDomainError(input.domain, knownDomains);
@@ -54,7 +67,30 @@ export const createAgentClient = (options?: AgentClientOptions): AgentClient => 
       knownDomains,
       resolvedDomain,
       domainTools,
+      platform,
     };
+  };
+
+  /**
+   * Resolves a tool, turning "the target cannot do this" into an
+   * actionable error before the call is attempted. An unavailable domain
+   * has no tools left to match against, so without this the caller would
+   * get `Available: none` -- true, and useless.
+   */
+  const resolveToolOrExplain = (
+    context: {
+      resolvedDomain: DomainDefinition;
+      domainTools: AgentTool[];
+      platform?: AgentTargetPlatform;
+    },
+    toolName: string,
+  ): AgentTool => {
+    if (context.resolvedDomain.availability === 'unsupported') {
+      throw formatUnsupportedToolError(context.resolvedDomain, toolName, context.platform);
+    }
+
+    const domainLabel = context.resolvedDomain.pluginId ?? context.resolvedDomain.id;
+    return resolveDomainTool(context.domainTools, domainLabel, toolName);
   };
 
   const callSessionTool = async <TArgs = unknown, TResult = unknown>(
@@ -63,12 +99,8 @@ export const createAgentClient = (options?: AgentClientOptions): AgentClient => 
     } & AgentDynamicToolCallInput<TArgs>,
   ): Promise<TResult> => {
     const { sessionId, domain, tool, args = {} as TArgs } = input;
-    const { resolvedDomain, domainTools } = await resolveDomainContext({
-      sessionId,
-      domain,
-    });
-    const domainLabel = resolvedDomain.pluginId ?? resolvedDomain.id;
-    const selectedTool = resolveDomainTool(domainTools, domainLabel, tool);
+    const context = await resolveDomainContext({ sessionId, domain });
+    const selectedTool = resolveToolOrExplain(context, tool);
 
     return (
       await transport.callSessionTool(sessionId, {
@@ -82,8 +114,8 @@ export const createAgentClient = (options?: AgentClientOptions): AgentClient => 
     let stopped = sessionInfo.status === 'stopped';
 
     const listDomains = async () => {
-      const { tools } = await transport.getSessionTools(sessionInfo.id);
-      return getKnownDomains(sortTools(tools));
+      const { tools, unsupported } = await transport.getSessionTools(sessionInfo.id);
+      return getKnownDomains(sortTools(tools), unsupported);
     };
 
     const toolsApi: AgentSessionTools = {
@@ -95,13 +127,11 @@ export const createAgentClient = (options?: AgentClientOptions): AgentClient => 
         return domainTools.map((tool) => toAgentDomainTool(tool, resolvedDomain.id));
       },
       getSchema: async ({ domain, tool }) => {
-        const { resolvedDomain, domainTools } = await resolveDomainContext({
+        const context = await resolveDomainContext({
           sessionId: sessionInfo.id,
           domain,
         });
-        const domainLabel = resolvedDomain.pluginId ?? resolvedDomain.id;
-        const selectedTool = resolveDomainTool(domainTools, domainLabel, tool);
-        return toAgentToolSchema(selectedTool);
+        return toAgentToolSchema(resolveToolOrExplain(context, tool));
       },
       resolve: (async ({
         domain,
@@ -110,15 +140,14 @@ export const createAgentClient = (options?: AgentClientOptions): AgentClient => 
         domain: string;
         tool: string;
       }): Promise<AgentResolvedTool> => {
-        const { resolvedDomain, domainTools } = await resolveDomainContext({
+        const context = await resolveDomainContext({
           sessionId: sessionInfo.id,
           domain,
         });
-        const domainLabel = resolvedDomain.pluginId ?? resolvedDomain.id;
-        const selectedTool = resolveDomainTool(domainTools, domainLabel, tool);
+        const selectedTool = resolveToolOrExplain(context, tool);
 
         return {
-          domainId: resolvedDomain.id,
+          domainId: context.resolvedDomain.id,
           schema: toAgentToolSchema(selectedTool),
           call: async (args?: unknown) =>
             (

--- a/packages/agent-sdk/src/client.ts
+++ b/packages/agent-sdk/src/client.ts
@@ -1,10 +1,10 @@
 import type {
   AgentSessionInfo,
-  AgentTargetPlatform,
   AgentTool,
   AgentToolDescriptor,
   UnsupportedDomainInfo,
 } from '@rozenite/agent-shared';
+import type { RozeniteIntegration } from '@rozenite/tools/integration';
 import { STATIC_DOMAINS } from './constants.js';
 import {
   applyCapabilities,
@@ -12,6 +12,7 @@ import {
   formatUnknownDomainError,
   formatUnsupportedToolError,
   getDomainToolsByDefinition,
+  isToolUnavailable,
   resolveDomainToken,
   resolveDomainTool,
   toAgentDomainTool,
@@ -53,7 +54,7 @@ export const createAgentClient = (options?: AgentClientOptions): AgentClient => 
   const transport = createAgentTransport(options);
 
   const resolveDomainContext = async (input: { sessionId: string; domain: string }) => {
-    const { tools, platform, unsupported } = await transport.getSessionTools(input.sessionId);
+    const { tools, integration, unsupported } = await transport.getSessionTools(input.sessionId);
     const sortedTools = sortTools(tools);
     const knownDomains = getKnownDomains(sortedTools, unsupported);
     const resolvedDomain = resolveDomainToken(input.domain, knownDomains);
@@ -67,7 +68,7 @@ export const createAgentClient = (options?: AgentClientOptions): AgentClient => 
       knownDomains,
       resolvedDomain,
       domainTools,
-      platform,
+      integration,
     };
   };
 
@@ -75,18 +76,20 @@ export const createAgentClient = (options?: AgentClientOptions): AgentClient => 
    * Resolves a tool, turning "the target cannot do this" into an
    * actionable error before the call is attempted. An unavailable domain
    * has no tools left to match against, so without this the caller would
-   * get `Available: none` -- true, and useless.
+   * get `Available: none` -- true, and useless. A degraded domain is the
+   * same problem one level down: the tool is missing from a listing that
+   * is otherwise full, which reads as a typo rather than a limit.
    */
   const resolveToolOrExplain = (
     context: {
       resolvedDomain: DomainDefinition;
       domainTools: AgentTool[];
-      platform?: AgentTargetPlatform;
+      integration?: RozeniteIntegration;
     },
     toolName: string,
   ): AgentTool => {
-    if (context.resolvedDomain.availability === 'unsupported') {
-      throw formatUnsupportedToolError(context.resolvedDomain, toolName, context.platform);
+    if (isToolUnavailable(context.resolvedDomain, toolName)) {
+      throw formatUnsupportedToolError(context.resolvedDomain, toolName, context.integration);
     }
 
     const domainLabel = context.resolvedDomain.pluginId ?? context.resolvedDomain.id;

--- a/packages/agent-sdk/src/domain-utils.ts
+++ b/packages/agent-sdk/src/domain-utils.ts
@@ -1,4 +1,5 @@
-import type { AgentTargetPlatform, AgentTool, UnsupportedDomainInfo } from '@rozenite/agent-shared';
+import type { AgentTool, UnsupportedDomainInfo } from '@rozenite/agent-shared';
+import type { RozeniteIntegration } from '@rozenite/tools/integration';
 import {
   RESERVED_DOMAIN_NAMES,
   STATIC_DOMAIN_TOOL_NAMES,
@@ -292,8 +293,14 @@ export const formatUnknownDomainError = (token: string, domains: DomainDefinitio
  * Unavailable domains stay in the list on purpose. Dropping `network`
  * outright would make `rozenite agent network listRequests` fail with
  * `Unknown domain "network". Did you mean...?`, which reads to an agent
- * as a typo it should correct rather than a platform limit it should
+ * as a typo it should correct rather than an integration limit it should
  * route around.
+ *
+ * Tool-level gaps are carried through as well, not just summarised into
+ * `degraded`. The server has already filtered those tools out of the
+ * listing, so without them a call to one would fall through to the
+ * generic unknown-tool error -- the same typo-shaped answer this whole
+ * mechanism exists to avoid, just one level down.
  */
 export const applyCapabilities = (
   domains: DomainDefinition[],
@@ -317,6 +324,7 @@ export const applyCapabilities = (
       // usable; a gap without one takes the whole domain out.
       availability: gap.tools ? ('degraded' as const) : ('unsupported' as const),
       unavailableReason: gap.reason,
+      ...(gap.tools ? { unavailableTools: gap.tools } : {}),
       ...(gap.fallback ? { fallback: gap.fallback } : {}),
     };
   });
@@ -331,13 +339,30 @@ export const applyCapabilities = (
 export const formatUnsupportedToolError = (
   domain: DomainDefinition,
   toolName: string,
-  platform?: AgentTargetPlatform,
+  integration?: RozeniteIntegration,
 ): Error => {
-  const target = platform ? `this ${platform} target` : 'this target';
-  const reason = domain.unavailableReason ? ` ${domain.unavailableReason}` : '';
+  const target = integration ? `this ${integration} target` : 'this target';
+  // A tool-level gap explains itself; only fall back to the domain's
+  // reason when the whole domain is out.
+  const toolReason = domain.unavailableTools?.find((tool) => tool.name === toolName)?.reason;
+  const detail = toolReason ?? domain.unavailableReason;
+  const reason = detail ? ` ${detail}` : '';
   const fallback = domain.fallback ? ` Use the \`${domain.fallback}\` domain instead.` : '';
 
   return new Error(`Tool "${toolName}" is not supported on ${target}.${reason}${fallback}`);
+};
+
+/**
+ * Whether this specific tool is out on this target -- either because the
+ * whole domain is, or because the domain is degraded and this is one of
+ * the tools it lost.
+ */
+export const isToolUnavailable = (domain: DomainDefinition, toolName: string): boolean => {
+  if (domain.availability === 'unsupported') {
+    return true;
+  }
+
+  return domain.unavailableTools?.some((tool) => tool.name === toolName) ?? false;
 };
 
 export const resolveDomainTool = (

--- a/packages/agent-sdk/src/domain-utils.ts
+++ b/packages/agent-sdk/src/domain-utils.ts
@@ -1,4 +1,4 @@
-import type { AgentTool } from '@rozenite/agent-shared';
+import type { AgentTargetPlatform, AgentTool, UnsupportedDomainInfo } from '@rozenite/agent-shared';
 import {
   RESERVED_DOMAIN_NAMES,
   STATIC_DOMAIN_TOOL_NAMES,
@@ -284,6 +284,60 @@ export const formatUnknownDomainError = (token: string, domains: DomainDefinitio
   return new Error(
     `Unknown domain "${token}".${suggestionsText} Run \`rozenite agent domains\` to list available domains.`,
   );
+};
+
+/**
+ * Folds a session's capability gaps onto the domain list.
+ *
+ * Unavailable domains stay in the list on purpose. Dropping `network`
+ * outright would make `rozenite agent network listRequests` fail with
+ * `Unknown domain "network". Did you mean...?`, which reads to an agent
+ * as a typo it should correct rather than a platform limit it should
+ * route around.
+ */
+export const applyCapabilities = (
+  domains: DomainDefinition[],
+  unsupported: UnsupportedDomainInfo[],
+): DomainDefinition[] => {
+  if (unsupported.length === 0) {
+    return domains;
+  }
+
+  const byDomain = new Map(unsupported.map((entry) => [entry.domain, entry]));
+
+  return domains.map((domain) => {
+    const gap = byDomain.get(domain.id);
+    if (!gap) {
+      return domain;
+    }
+
+    return {
+      ...domain,
+      // A gap listing specific tools leaves the rest of the domain
+      // usable; a gap without one takes the whole domain out.
+      availability: gap.tools ? ('degraded' as const) : ('unsupported' as const),
+      unavailableReason: gap.reason,
+      ...(gap.fallback ? { fallback: gap.fallback } : {}),
+    };
+  });
+};
+
+/**
+ * The error an agent gets instead of a protocol failure. Thrown during
+ * resolution, before anything reaches the wire, so the agent spends no
+ * turn discovering it -- and it names something to do next rather than
+ * just what went wrong.
+ */
+export const formatUnsupportedToolError = (
+  domain: DomainDefinition,
+  toolName: string,
+  platform?: AgentTargetPlatform,
+): Error => {
+  const target = platform ? `this ${platform} target` : 'this target';
+  const reason = domain.unavailableReason ? ` ${domain.unavailableReason}` : '';
+  const fallback = domain.fallback ? ` Use the \`${domain.fallback}\` domain instead.` : '';
+
+  return new Error(`Tool "${toolName}" is not supported on ${target}.${reason}${fallback}`);
 };
 
 export const resolveDomainTool = (

--- a/packages/agent-sdk/src/types.ts
+++ b/packages/agent-sdk/src/types.ts
@@ -21,6 +21,7 @@ import type {
   SendAgentSessionTapMessageRequest,
   SendAgentSessionTapMessageResponse,
   TapEvent,
+  ToolAvailability,
 } from '@rozenite/agent-shared';
 
 export interface DomainDefinition {
@@ -30,6 +31,17 @@ export interface DomainDefinition {
   pluginId?: string;
   slug?: string;
   actions: Array<'list-tools' | 'get-tool-schema' | 'call-tool'>;
+  /**
+   * How much of this domain the connected target can actually do.
+   * `undefined` means the server sent no capability data at all -- an
+   * older Metro -- and is treated as `supported`, which is exactly the
+   * behaviour before profiles existed.
+   */
+  availability?: ToolAvailability;
+  /** Why the domain is unavailable or degraded, written for an agent. */
+  unavailableReason?: string;
+  /** A domain token to try instead. */
+  fallback?: string;
 }
 
 export interface AgentDomainTool extends AgentTool {

--- a/packages/agent-sdk/src/types.ts
+++ b/packages/agent-sdk/src/types.ts
@@ -22,6 +22,7 @@ import type {
   SendAgentSessionTapMessageResponse,
   TapEvent,
   ToolAvailability,
+  UnsupportedToolInfo,
 } from '@rozenite/agent-shared';
 
 export interface DomainDefinition {
@@ -40,6 +41,12 @@ export interface DomainDefinition {
   availability?: ToolAvailability;
   /** Why the domain is unavailable or degraded, written for an agent. */
   unavailableReason?: string;
+  /**
+   * The tools this target cannot back, when the domain as a whole is
+   * still usable. Each carries its own reason: two gaps in one domain
+   * need not share a cause.
+   */
+  unavailableTools?: UnsupportedToolInfo[];
   /** A domain token to try instead. */
   fallback?: string;
 }

--- a/packages/agent-shared/package.json
+++ b/packages/agent-shared/package.json
@@ -43,6 +43,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "@rozenite/tools": "workspace:*",
     "tslib": "^2.3.0"
   },
   "devDependencies": {},

--- a/packages/agent-shared/src/capabilities.ts
+++ b/packages/agent-shared/src/capabilities.ts
@@ -2,7 +2,7 @@
  * Target capability descriptors.
  *
  * Rozenite's five built-in agent domains were designed against React
- * Native's CDP surface. Other platforms expose a different one, and
+ * Native's CDP surface. Other integrations expose a different one, and
  * "unsupported" is not one behaviour on the wire but three:
  *
  * 1. The device answers `{ error: { code: -32601 } }` — loud, but the
@@ -21,13 +21,19 @@
  *
  * The profile is deliberately a *descriptor*, not a blocklist: the same
  * mechanism that removes `network` on Lynx is the one that would later
- * add a Lynx-only domain there, or describe the next platform after it.
+ * add a Lynx-only domain there, or describe the next integration after
+ * it.
+ *
+ * Keyed by `RozeniteIntegration` rather than a union of its own. The
+ * vocabulary in `@rozenite/tools` is the one the dev server, the Vite
+ * plugin and the DevTools hosts already agree on, and a second union
+ * meaning the same thing would be free to drift from it. Note that
+ * `platform` deliberately does NOT appear here: it means the device OS
+ * everywhere else in this system.
  */
+import type { RozeniteIntegration } from '@rozenite/tools/integration';
 
-/** Which host platform a dev server, and therefore a target, runs. */
-export type AgentTargetPlatform = 'react-native' | 'lynx';
-
-export const DEFAULT_AGENT_TARGET_PLATFORM: AgentTargetPlatform = 'react-native';
+export const DEFAULT_AGENT_TARGET_INTEGRATION: RozeniteIntegration = 'react-native';
 
 /**
  * `degraded` is a domain-level verdict only: the domain stays usable, but
@@ -40,7 +46,7 @@ export type ToolCapability = {
   availability: Exclude<ToolAvailability, 'degraded'>;
   /**
    * Written to be read verbatim by an agent, in an error message. Say
-   * what the platform does instead, not what Rozenite wanted.
+   * what the integration does instead, not what Rozenite wanted.
    */
   reason?: string;
 };
@@ -61,8 +67,23 @@ export type DomainCapability = {
  * tool — only the gaps are written down.
  */
 export type CapabilityProfile = {
-  platform: AgentTargetPlatform;
+  integration: RozeniteIntegration;
   domains: Record<string, DomainCapability>;
+};
+
+/**
+ * One unsupported tool within an otherwise usable domain, carrying its
+ * own reason.
+ *
+ * The reason travels per tool rather than once per domain because two
+ * gaps in one domain need not share a cause, and the agent is shown
+ * whichever tool it actually reached for. Collapsing them onto the
+ * domain would mean picking one arbitrarily and explaining the wrong
+ * thing the first time a domain has two unrelated gaps.
+ */
+export type UnsupportedToolInfo = {
+  name: string;
+  reason?: string;
 };
 
 /** One gap, flattened for transport to the agent client. */
@@ -73,13 +94,16 @@ export type UnsupportedDomainInfo = {
    * the whole domain is unavailable — the distinction is what lets the
    * client render `degraded` separately from `unsupported`.
    */
-  tools?: string[];
+  tools?: UnsupportedToolInfo[];
+  /** The domain-level reason. Tool-level gaps carry their own. */
   reason: string;
   fallback?: string;
 };
 
-export const createEmptyCapabilityProfile = (platform: AgentTargetPlatform): CapabilityProfile => ({
-  platform,
+export const createEmptyCapabilityProfile = (
+  integration: RozeniteIntegration,
+): CapabilityProfile => ({
+  integration,
   domains: {},
 });
 
@@ -136,12 +160,13 @@ export const getUnsupportedToolReason = (
  */
 export const getUnsupportedDomains = (profile: CapabilityProfile): UnsupportedDomainInfo[] => {
   const entries: UnsupportedDomainInfo[] = [];
+  const defaultReason = `Not supported on ${profile.integration} targets.`;
 
   for (const [domainId, domain] of Object.entries(profile.domains)) {
     if (domain.availability === 'unsupported') {
       entries.push({
         domain: domainId,
-        reason: domain.reason ?? `Not supported on ${profile.platform} targets.`,
+        reason: domain.reason ?? defaultReason,
         ...(domain.fallback ? { fallback: domain.fallback } : {}),
       });
       continue;
@@ -149,8 +174,8 @@ export const getUnsupportedDomains = (profile: CapabilityProfile): UnsupportedDo
 
     const unsupportedTools = Object.entries(domain.tools ?? {})
       .filter(([, tool]) => tool.availability === 'unsupported')
-      .map(([toolName]) => toolName)
-      .sort();
+      .map(([name, tool]) => ({ name, ...(tool.reason ? { reason: tool.reason } : {}) }))
+      .sort((a, b) => a.name.localeCompare(b.name));
 
     if (unsupportedTools.length === 0) {
       continue;
@@ -159,10 +184,7 @@ export const getUnsupportedDomains = (profile: CapabilityProfile): UnsupportedDo
     entries.push({
       domain: domainId,
       tools: unsupportedTools,
-      reason:
-        domain.tools?.[unsupportedTools[0]]?.reason ??
-        domain.reason ??
-        `Not supported on ${profile.platform} targets.`,
+      reason: domain.reason ?? defaultReason,
       ...(domain.fallback ? { fallback: domain.fallback } : {}),
     });
   }

--- a/packages/agent-shared/src/capabilities.ts
+++ b/packages/agent-shared/src/capabilities.ts
@@ -1,0 +1,171 @@
+/**
+ * Target capability descriptors.
+ *
+ * Rozenite's five built-in agent domains were designed against React
+ * Native's CDP surface. Other platforms expose a different one, and
+ * "unsupported" is not one behaviour on the wire but three:
+ *
+ * 1. The device answers `{ error: { code: -32601 } }` — loud, but the
+ *    agent only finds out after spending a turn on the call.
+ * 2. The device answers `{ result: {} }` for a method it does not know.
+ *    Lynx's PrimJS backend does this for anything missing from its
+ *    dispatch table, so the call *resolves* and the event the caller is
+ *    waiting on never arrives.
+ * 3. The domain and method exist under the same name but mean something
+ *    else. Lynx's `Tracing` is Perfetto, not Chrome's: it succeeds and
+ *    reports completion over a stream Rozenite never reads.
+ *
+ * Cases 2 and 3 cannot be detected by inspecting a response, so they can
+ * only be prevented by knowing, before the call, that this target does
+ * not support this tool. That is what a capability profile is for.
+ *
+ * The profile is deliberately a *descriptor*, not a blocklist: the same
+ * mechanism that removes `network` on Lynx is the one that would later
+ * add a Lynx-only domain there, or describe the next platform after it.
+ */
+
+/** Which host platform a dev server, and therefore a target, runs. */
+export type AgentTargetPlatform = 'react-native' | 'lynx';
+
+export const DEFAULT_AGENT_TARGET_PLATFORM: AgentTargetPlatform = 'react-native';
+
+/**
+ * `degraded` is a domain-level verdict only: the domain stays usable, but
+ * at least one of its tools does not. An individual tool is either
+ * supported or not.
+ */
+export type ToolAvailability = 'supported' | 'degraded' | 'unsupported';
+
+export type ToolCapability = {
+  availability: Exclude<ToolAvailability, 'degraded'>;
+  /**
+   * Written to be read verbatim by an agent, in an error message. Say
+   * what the platform does instead, not what Rozenite wanted.
+   */
+  reason?: string;
+};
+
+export type DomainCapability = {
+  availability: ToolAvailability;
+  reason?: string;
+  /** A domain token the agent should try instead, when one exists. */
+  fallback?: string;
+  /** Per-tool overrides. Tools with no entry inherit the domain's verdict. */
+  tools?: Record<string, ToolCapability>;
+};
+
+/**
+ * A domain with no entry is supported. That default is what keeps React
+ * Native's profile empty and its behaviour byte-for-byte unchanged, and
+ * it means nobody has to maintain an allowlist that grows with every new
+ * tool — only the gaps are written down.
+ */
+export type CapabilityProfile = {
+  platform: AgentTargetPlatform;
+  domains: Record<string, DomainCapability>;
+};
+
+/** One gap, flattened for transport to the agent client. */
+export type UnsupportedDomainInfo = {
+  domain: string;
+  /**
+   * The unsupported tools within an otherwise usable domain. Absent when
+   * the whole domain is unavailable — the distinction is what lets the
+   * client render `degraded` separately from `unsupported`.
+   */
+  tools?: string[];
+  reason: string;
+  fallback?: string;
+};
+
+export const createEmptyCapabilityProfile = (platform: AgentTargetPlatform): CapabilityProfile => ({
+  platform,
+  domains: {},
+});
+
+const getToolCapability = (
+  domain: DomainCapability,
+  toolName: string,
+): ToolCapability | undefined => domain.tools?.[toolName];
+
+/**
+ * Whether `toolName` in `domainId` may be registered and called on a
+ * target with this profile. Unknown domains and unknown tools are
+ * supported: absence means "nothing to declare".
+ */
+export const isToolSupported = (
+  profile: CapabilityProfile,
+  domainId: string,
+  toolName: string,
+): boolean => {
+  const domain = profile.domains[domainId];
+  if (!domain) {
+    return true;
+  }
+
+  const tool = getToolCapability(domain, toolName);
+  if (tool) {
+    return tool.availability === 'supported';
+  }
+
+  return domain.availability !== 'unsupported';
+};
+
+/**
+ * The reason to hand an agent when `isToolSupported` said no. Prefers the
+ * tool's own reason over the domain's, since a tool-level gap in an
+ * otherwise working domain needs the more specific explanation.
+ */
+export const getUnsupportedToolReason = (
+  profile: CapabilityProfile,
+  domainId: string,
+  toolName: string,
+): string | undefined => {
+  const domain = profile.domains[domainId];
+  if (!domain) {
+    return undefined;
+  }
+
+  return getToolCapability(domain, toolName)?.reason ?? domain.reason;
+};
+
+/**
+ * Flattens a profile into the wire shape. Domains whose gap is entirely
+ * tool-level are reported with a `tools` list; whole-domain gaps without
+ * one.
+ */
+export const getUnsupportedDomains = (profile: CapabilityProfile): UnsupportedDomainInfo[] => {
+  const entries: UnsupportedDomainInfo[] = [];
+
+  for (const [domainId, domain] of Object.entries(profile.domains)) {
+    if (domain.availability === 'unsupported') {
+      entries.push({
+        domain: domainId,
+        reason: domain.reason ?? `Not supported on ${profile.platform} targets.`,
+        ...(domain.fallback ? { fallback: domain.fallback } : {}),
+      });
+      continue;
+    }
+
+    const unsupportedTools = Object.entries(domain.tools ?? {})
+      .filter(([, tool]) => tool.availability === 'unsupported')
+      .map(([toolName]) => toolName)
+      .sort();
+
+    if (unsupportedTools.length === 0) {
+      continue;
+    }
+
+    entries.push({
+      domain: domainId,
+      tools: unsupportedTools,
+      reason:
+        domain.tools?.[unsupportedTools[0]]?.reason ??
+        domain.reason ??
+        `Not supported on ${profile.platform} targets.`,
+      ...(domain.fallback ? { fallback: domain.fallback } : {}),
+    });
+  }
+
+  return entries.sort((a, b) => a.domain.localeCompare(b.domain));
+};

--- a/packages/agent-shared/src/index.ts
+++ b/packages/agent-shared/src/index.ts
@@ -1,19 +1,20 @@
-import type { AgentTargetPlatform, UnsupportedDomainInfo } from './capabilities.js';
+import type { RozeniteIntegration } from '@rozenite/tools/integration';
+import type { UnsupportedDomainInfo } from './capabilities.js';
 
 export {
   createEmptyCapabilityProfile,
-  DEFAULT_AGENT_TARGET_PLATFORM,
+  DEFAULT_AGENT_TARGET_INTEGRATION,
   getUnsupportedDomains,
   getUnsupportedToolReason,
   isToolSupported,
 } from './capabilities.js';
 export type {
-  AgentTargetPlatform,
   CapabilityProfile,
   DomainCapability,
   ToolAvailability,
   ToolCapability,
   UnsupportedDomainInfo,
+  UnsupportedToolInfo,
 } from './capabilities.js';
 
 export {
@@ -273,13 +274,6 @@ export type MetroTarget = {
   title: string;
   description: string;
   webSocketDebuggerUrl: string;
-  /**
-   * The platform this page's runtime is. Sourced from the dev server's
-   * own `/json/list` entry when it declares one, so a server fronting
-   * more than one kind of target still describes each correctly.
-   * Defaults to `react-native` when nothing declares otherwise.
-   */
-  platform?: AgentTargetPlatform;
 };
 
 export type AgentServerInfo = {
@@ -298,8 +292,12 @@ export type AgentSessionInfo = {
   appId: string;
   pageId: string;
   status: AgentSessionStatus;
-  /** The capability profile this session resolved to. */
-  platform: AgentTargetPlatform;
+  /**
+   * The integration this session resolved a capability profile from.
+   * Optional so a newer CLI can read an older server's session info,
+   * which simply does not carry it.
+   */
+  integration?: RozeniteIntegration;
   createdAt: number;
   lastActivityAt: number;
   connectedAt?: number;
@@ -362,7 +360,7 @@ export type GetAgentSessionToolsResponse = {
    * `undefined` and falls back to treating every domain as supported,
    * which is exactly the pre-capability behaviour. No lockstep upgrade.
    */
-  platform?: AgentTargetPlatform;
+  integration?: RozeniteIntegration;
   unsupported?: UnsupportedDomainInfo[];
 };
 

--- a/packages/agent-shared/src/index.ts
+++ b/packages/agent-shared/src/index.ts
@@ -1,3 +1,21 @@
+import type { AgentTargetPlatform, UnsupportedDomainInfo } from './capabilities.js';
+
+export {
+  createEmptyCapabilityProfile,
+  DEFAULT_AGENT_TARGET_PLATFORM,
+  getUnsupportedDomains,
+  getUnsupportedToolReason,
+  isToolSupported,
+} from './capabilities.js';
+export type {
+  AgentTargetPlatform,
+  CapabilityProfile,
+  DomainCapability,
+  ToolAvailability,
+  ToolCapability,
+  UnsupportedDomainInfo,
+} from './capabilities.js';
+
 export {
   DEFAULT_PAGE_LIMIT,
   MAX_PAGE_LIMIT,
@@ -255,6 +273,13 @@ export type MetroTarget = {
   title: string;
   description: string;
   webSocketDebuggerUrl: string;
+  /**
+   * The platform this page's runtime is. Sourced from the dev server's
+   * own `/json/list` entry when it declares one, so a server fronting
+   * more than one kind of target still describes each correctly.
+   * Defaults to `react-native` when nothing declares otherwise.
+   */
+  platform?: AgentTargetPlatform;
 };
 
 export type AgentServerInfo = {
@@ -273,6 +298,8 @@ export type AgentSessionInfo = {
   appId: string;
   pageId: string;
   status: AgentSessionStatus;
+  /** The capability profile this session resolved to. */
+  platform: AgentTargetPlatform;
   createdAt: number;
   lastActivityAt: number;
   connectedAt?: number;
@@ -329,6 +356,14 @@ export type DeleteAgentSessionResponse = {
 
 export type GetAgentSessionToolsResponse = {
   tools: AgentTool[];
+  /**
+   * Both fields are optional on purpose. An older CLI against a newer
+   * server ignores them; a newer CLI against an older server reads
+   * `undefined` and falls back to treating every domain as supported,
+   * which is exactly the pre-capability behaviour. No lockstep upgrade.
+   */
+  platform?: AgentTargetPlatform;
+  unsupported?: UnsupportedDomainInfo[];
 };
 
 export type CallAgentSessionToolRequest = {

--- a/packages/cli/docs/core.md
+++ b/packages/cli/docs/core.md
@@ -26,8 +26,24 @@ does not replace that setup.
 
 ## Built-in domains
 
-Built-in domains are always available on a live session: `console`,
-`network`, `react`, `performance`, and `memory`.
+The built-in domains are `console`, `network`, `react`, `performance`, and
+`memory`. All five are available on a React Native target.
+
+They are not all available on every platform. `rozenite agent domains
+--session <sessionId>` reports an `availability` for each one:
+
+- `supported` — usable as documented.
+- `degraded` — the domain works, but at least one of its tools does not.
+  Its `list-tools` output already omits the ones that do not.
+- `unsupported` — the connected runtime cannot back this domain at all.
+  The listing keeps it visible so the absence is legible; calling any of
+  its tools fails with the reason and, where one exists, the domain to
+  use instead.
+
+Read that column before planning work against a built-in domain, and take
+the `fallback` when one is offered rather than working around the gap. On
+Lynx targets specifically, `network`, `react` and `performance` are
+unsupported and `memory` is degraded — see `npx rozenite skills show lynx`.
 
 ## Plugin domains
 

--- a/packages/cli/docs/core.md
+++ b/packages/cli/docs/core.md
@@ -29,7 +29,7 @@ does not replace that setup.
 The built-in domains are `console`, `network`, `react`, `performance`, and
 `memory`. All five are available on a React Native target.
 
-They are not all available on every platform. `rozenite agent domains
+They are not all available on every integration. `rozenite agent domains
 --session <sessionId>` reports an `availability` for each one:
 
 - `supported` — usable as documented.
@@ -44,6 +44,8 @@ Read that column before planning work against a built-in domain, and take
 the `fallback` when one is offered rather than working around the gap. On
 Lynx targets specifically, `network`, `react` and `performance` are
 unsupported and `memory` is degraded — see `npx rozenite skills show lynx`.
+`npx rozenite skills list` reports an `integrations` field on the docs
+that are integration-specific.
 
 ## Plugin domains
 

--- a/packages/cli/docs/lynx.md
+++ b/packages/cli/docs/lynx.md
@@ -1,0 +1,59 @@
+---
+name: lynx
+description: What changes when the agent session target is a Lynx app rather than React Native — which built-in domains work, which do not, and what to use instead.
+platforms: lynx
+---
+
+# Lynx targets
+
+Rozenite for Agents works against Lynx apps, but the five built-in domains
+were designed against React Native's CDP surface and Lynx exposes a
+different one. Everything else — sessions, plugin domains, app-defined
+tools, `tap` — behaves the same.
+
+Check first, do not assume:
+
+```sh
+npx rozenite agent domains --session <sessionId>
+```
+
+The `availability` column is authoritative for the connected target. The
+table below is what it will say on Lynx today.
+
+## What works
+
+- **`console`** — fully supported. Lynx emits the same console and log
+  events Rozenite captures.
+- **Plugin and app domains** — fully supported. Plugin tools travel over
+  Rozenite's own device channel, not over the CDP domains that differ, so
+  a plugin that works on React Native works here.
+- **`memory.takeHeapSnapshot`** — supported. The rest of the `memory`
+  domain is not; see below.
+
+## What does not
+
+- **`network`** — unsupported. Lynx has no CDP `Network` domain, so no
+  amount of retrying will help. Use `@rozenite/network-activity-plugin`
+  instead; it is the documented fallback and it works on Lynx.
+- **`react`** — unsupported. There is no React DevTools backend on Lynx,
+  so there is no component tree to read and no substitute domain. Read
+  structure from source, and get runtime state from plugin domains.
+- **`performance`** — unsupported. Lynx has a `Tracing` domain, but it is
+  Perfetto-based rather than Chrome-based: the same name, a different
+  protocol. Rozenite reports it unsupported rather than handing back a
+  trace artifact that looks valid and contains nothing. Capture Lynx
+  traces with Lynx DevTool.
+- **`memory.startSampling` / `memory.stopSampling`** — unsupported. Lynx's
+  JS engine implements heap snapshots but not allocation sampling, so
+  `memory` is reported `degraded` and these two tools are absent from its
+  `list-tools` output.
+
+## How unsupported tools fail
+
+Calling one fails immediately, at resolution, with the reason and — where
+one exists — the domain to use instead. That error is the answer: act on
+it rather than retrying, and never work around a missing built-in domain
+by inventing instrumentation in the app.
+
+An unsupported domain still appears in `domains` output. It is listed so
+the gap is visible, not because it can be used.

--- a/packages/cli/docs/lynx.md
+++ b/packages/cli/docs/lynx.md
@@ -1,7 +1,7 @@
 ---
 name: lynx
 description: What changes when the agent session target is a Lynx app rather than React Native — which built-in domains work, which do not, and what to use instead.
-platforms: lynx
+integrations: lynx
 ---
 
 # Lynx targets

--- a/packages/cli/docs/memory.md
+++ b/packages/cli/docs/memory.md
@@ -2,7 +2,7 @@
 name: memory
 description: Capture heap snapshots or run allocation sampling over a reproduction, with artifacts written by Metro for offline analysis.
 domain: memory
-platforms: react-native, lynx
+integrations: react-native, lynx
 ---
 
 Capture one-off heap snapshots or run allocation sampling over a reproduction. Metro writes artifacts under `.rozenite/agent/sessions/<deviceId>/memory` and `.rozenite/agent/sessions/<deviceId>/profiles` for offline analysis.

--- a/packages/cli/docs/memory.md
+++ b/packages/cli/docs/memory.md
@@ -2,6 +2,7 @@
 name: memory
 description: Capture heap snapshots or run allocation sampling over a reproduction, with artifacts written by Metro for offline analysis.
 domain: memory
+platforms: react-native, lynx
 ---
 
 Capture one-off heap snapshots or run allocation sampling over a reproduction. Metro writes artifacts under `.rozenite/agent/sessions/<deviceId>/memory` and `.rozenite/agent/sessions/<deviceId>/profiles` for offline analysis.
@@ -20,3 +21,11 @@ Sampling:
 `startSampling` -> reproduce issue -> `stopSampling`.
 
 Returned artifact metadata includes the Metro-managed absolute and relative paths.
+
+## Platform availability
+
+`takeHeapSnapshot` works on both React Native and Lynx. Allocation
+sampling (`startSampling`, `stopSampling`) is React Native only — Lynx's
+JS engine implements heap snapshots but not sampling — so on a Lynx
+session this domain is reported `degraded` and the two sampling tools are
+absent from `list-tools`.

--- a/packages/cli/docs/network.md
+++ b/packages/cli/docs/network.md
@@ -2,7 +2,7 @@
 name: network
 description: Record HTTP/HTTPS traffic, then list requests, inspect request/response details and bodies, and analyze timing.
 domain: network
-platforms: react-native
+integrations: react-native
 ---
 
 Record HTTP/HTTPS traffic, then list requests, inspect request and response details and bodies, and analyze timing, similar to the browser DevTools Network panel.

--- a/packages/cli/docs/network.md
+++ b/packages/cli/docs/network.md
@@ -2,6 +2,7 @@
 name: network
 description: Record HTTP/HTTPS traffic, then list requests, inspect request/response details and bodies, and analyze timing.
 domain: network
+platforms: react-native
 ---
 
 Record HTTP/HTTPS traffic, then list requests, inspect request and response details and bodies, and analyze timing, similar to the browser DevTools Network panel.
@@ -33,3 +34,10 @@ present, and `next` replaces the page envelope when another page is available.
 `url`, `status`, `durationMs`, `outcome`). Pass `--fields` or `--verbose` for
 the remaining fields such as `type`, `startTimeMs`, `endTimeMs`,
 `transferSize`, and `encodedDataLength`.
+
+## Platform availability
+
+React Native only. Lynx registers no CDP `Network` domain at all, so this
+domain is reported `unsupported` on a Lynx session and every tool here
+fails. Use `@rozenite/network-activity-plugin` there — it is the same
+fallback the precedence rule above already names.

--- a/packages/cli/docs/performance.md
+++ b/packages/cli/docs/performance.md
@@ -2,7 +2,7 @@
 name: performance
 description: Start and stop a performance trace on the session target, exporting a Metro-managed trace artifact for offline analysis.
 domain: performance
-platforms: react-native
+integrations: react-native
 ---
 
 Start a performance trace on the session target, reproduce the issue while recording, then stop and export the trace to a Metro-managed artifact under `.rozenite/agent/sessions/<deviceId>/traces`. Calls return only artifact metadata.

--- a/packages/cli/docs/performance.md
+++ b/packages/cli/docs/performance.md
@@ -2,6 +2,7 @@
 name: performance
 description: Start and stop a performance trace on the session target, exporting a Metro-managed trace artifact for offline analysis.
 domain: performance
+platforms: react-native
 ---
 
 Start a performance trace on the session target, reproduce the issue while recording, then stop and export the trace to a Metro-managed artifact under `.rozenite/agent/sessions/<deviceId>/traces`. Calls return only artifact metadata.
@@ -14,3 +15,10 @@ Start a performance trace on the session target, reproduce the issue while recor
 ## Flow
 
 `startTrace` -> reproduce issue while recording -> `stopTrace`. Metro writes the trace; the call returns only artifact metadata.
+
+## Platform availability
+
+React Native only. Lynx's `Tracing` domain is Perfetto-based rather than
+Chrome-based — same name, different protocol — so this domain is reported
+`unsupported` on a Lynx session rather than silently producing an empty
+trace artifact. Capture Lynx traces through Lynx DevTool instead.

--- a/packages/cli/docs/react.md
+++ b/packages/cli/docs/react.md
@@ -2,6 +2,7 @@
 name: react
 description: Search and traverse the React component tree, read props/state/hooks, and record render timelines via profiling.
 domain: react
+platforms: react-native
 ---
 
 Search and traverse the React component tree, read props, state, and hooks for any node, and record render timelines for performance analysis by starting and stopping profiling, then fetching commit data.
@@ -45,3 +46,10 @@ default column set (identifiers and labels, not every field such as `key`,
 `parentId`, `changeTypeHints`, or `changedKeys`). Pass `--fields` or
 `--verbose` to widen the projection. `getProps`, `getState`, and `getHooks`
 always return both of their only two fields (`name`, `value`).
+
+## Platform availability
+
+React Native only. Lynx has no React DevTools backend, so this domain is
+reported `unsupported` on a Lynx session. There is no substitute domain:
+read component structure from source, and use plugin domains for runtime
+state.

--- a/packages/cli/docs/react.md
+++ b/packages/cli/docs/react.md
@@ -2,7 +2,7 @@
 name: react
 description: Search and traverse the React component tree, read props/state/hooks, and record render timelines via profiling.
 domain: react
-platforms: react-native
+integrations: react-native
 ---
 
 Search and traverse the React component tree, read props, state, and hooks for any node, and record render timelines for performance analysis by starting and stopping profiling, then fetching commit data.

--- a/packages/cli/src/__tests__/agent-command-output.test.ts
+++ b/packages/cli/src/__tests__/agent-command-output.test.ts
@@ -315,11 +315,16 @@ describe('agent command output', () => {
         kind: 'static',
         description:
           'CDP memory inspection and heap profiling tools with Metro-managed artifact exports.',
+        availability: 'degraded',
+        unavailableReason: 'Allocation sampling is unavailable on this target.',
       },
       {
         id: 'network',
         kind: 'static',
         description: 'Raw CDP network recording tools with paginated request browsing.',
+        availability: 'unsupported',
+        unavailableReason: 'Lynx registers no CDP Network domain.',
+        fallback: '@rozenite/network-activity-plugin',
       },
       {
         id: 'performance',
@@ -343,7 +348,7 @@ describe('agent command output', () => {
     });
 
     expect(stdoutWrite).toHaveBeenCalledWith(
-      '{"cols":["id","kind"],"rows":[["app","plugin"],["console","static"],["memory","static"],["network","static"],["performance","static"],["react","static"]]}\n',
+      '{"cols":["id","kind","availability","fallback"],"rows":[["app","plugin","supported",null],["console","static","supported",null],["memory","static","degraded",null],["network","static","unsupported","@rozenite/network-activity-plugin"],["performance","static","supported",null],["react","static","supported",null]]}\n',
     );
   });
 
@@ -364,7 +369,7 @@ describe('agent command output', () => {
     );
 
     expect(stdoutWrite).toHaveBeenCalledWith(
-      '{"items":[{"id":"app","kind":"plugin"}],"next":"npx rozenite agent domains --host 127.0.0.1 --port 8081 --session \'session 1\' --limit 1 --cursor eyJ2IjoxLCJraW5kIjoiZG9tYWlucyIsInNjb3BlIjoiYWxsIiwiaW5kZXgiOjF9"}\n',
+      '{"items":[{"id":"app","kind":"plugin","availability":"supported"}],"next":"npx rozenite agent domains --host 127.0.0.1 --port 8081 --session \'session 1\' --limit 1 --cursor eyJ2IjoxLCJraW5kIjoiZG9tYWlucyIsInNjb3BlIjoiYWxsIiwiaW5kZXgiOjF9"}\n',
     );
   });
 

--- a/packages/cli/src/__tests__/skills-registry.test.ts
+++ b/packages/cli/src/__tests__/skills-registry.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { SkillsRegistry } from '../skills/registry.js';
 
-const NON_DOMAIN_IDS = ['core', 'cli', 'sdk', 'sdk-patterns'];
+const NON_DOMAIN_IDS = ['core', 'cli', 'sdk', 'sdk-patterns', 'lynx'];
 
 const DOMAIN_IDS = [
   'storage',

--- a/packages/cli/src/__tests__/skills-registry.test.ts
+++ b/packages/cli/src/__tests__/skills-registry.test.ts
@@ -51,6 +51,18 @@ describe('SkillsRegistry', () => {
     }
   });
 
+  // The field was previously parsed into a doc and then printed by
+  // nothing, which made every integration-specific doc read as
+  // universal.
+  it('parses the integrations frontmatter and leaves other docs without it', () => {
+    const registry = new SkillsRegistry();
+
+    expect(registry.get('lynx')?.integrations).toBe('lynx');
+    expect(registry.get('network')?.integrations).toBe('react-native');
+    expect(registry.get('memory')?.integrations).toBe('react-native, lynx');
+    expect(registry.get('core')?.integrations).toBeUndefined();
+  });
+
   it('resolves domain docs by domain token', () => {
     const registry = new SkillsRegistry();
 

--- a/packages/cli/src/commands/agent/register-agent-command.ts
+++ b/packages/cli/src/commands/agent/register-agent-command.ts
@@ -73,6 +73,8 @@ type ToolListRow = {
 type DomainListRow = {
   id: string;
   kind: 'static' | 'plugin';
+  availability: string;
+  fallback?: string;
   pluginId?: string;
   slug?: string;
   description: string;
@@ -90,8 +92,19 @@ const DEFAULT_METRO_PORT = DEFAULT_AGENT_PORT;
 
 const TOOL_LIST_FIELDS = ['name', 'description', 'readOnly', 'destructive', 'idempotent'] as const;
 const TOOL_LIST_DEFAULT_FIELDS = TOOL_LIST_FIELDS;
-const DOMAIN_LIST_FIELDS = ['id', 'kind', 'pluginId', 'slug', 'description'] as const;
-const DOMAIN_LIST_DEFAULT_FIELDS = ['id', 'kind'] as const;
+const DOMAIN_LIST_FIELDS = [
+  'id',
+  'kind',
+  'availability',
+  'fallback',
+  'pluginId',
+  'slug',
+  'description',
+] as const;
+// `availability` is a default field, not an opt-in one: an agent that has
+// to pass `--verbose` to learn a domain does not work on this target will
+// not pass it, and will spend a turn finding out the hard way.
+const DOMAIN_LIST_DEFAULT_FIELDS = ['id', 'kind', 'availability', 'fallback'] as const;
 
 const projectSessionOutput = (
   session: Record<string, unknown>,
@@ -582,6 +595,8 @@ export const registerAgentCommand = (program: Command): void => {
             .map<DomainListRow>((domain) => ({
               id: domain.id,
               kind: domain.kind,
+              availability: domain.availability ?? 'supported',
+              fallback: domain.fallback,
               pluginId: domain.pluginId,
               slug: domain.slug,
               description: domain.description,

--- a/packages/cli/src/commands/agent/register-agent-command.ts
+++ b/packages/cli/src/commands/agent/register-agent-command.ts
@@ -10,6 +10,7 @@ import {
   shapePaginatedRows,
   shapeToolResult,
   type AgentToolPagination,
+  type ToolAvailability,
 } from '@rozenite/agent-shared';
 import { printOutput } from './output.js';
 import { formatAgentCommand, paginateRows } from './output-shaping.js';
@@ -73,7 +74,7 @@ type ToolListRow = {
 type DomainListRow = {
   id: string;
   kind: 'static' | 'plugin';
-  availability: string;
+  availability: ToolAvailability;
   fallback?: string;
   pluginId?: string;
   slug?: string;

--- a/packages/cli/src/commands/register-skills-command.ts
+++ b/packages/cli/src/commands/register-skills-command.ts
@@ -19,6 +19,7 @@ export const registerSkillsCommand = (program: Command): void => {
         id: doc.id,
         description: doc.description,
         ...(doc.domain ? { domain: doc.domain } : {}),
+        ...(doc.integrations ? { integrations: doc.integrations } : {}),
       }));
 
       const json = options.pretty ? JSON.stringify(payload, null, 2) : JSON.stringify(payload);

--- a/packages/cli/src/skills/registry.ts
+++ b/packages/cli/src/skills/registry.ts
@@ -8,6 +8,14 @@ export type SkillDoc = {
   id: string;
   description: string;
   domain?: string;
+  /**
+   * Platforms this doc applies to, as written in the frontmatter (for
+   * example `react-native, lynx`). Advisory: docs are annotated rather
+   * than filtered, because one repository can hold a React Native app and
+   * a Lynx app, and hiding a doc from the list would just make the
+   * platform difference invisible again.
+   */
+  platforms?: string;
   body: string;
 };
 
@@ -15,6 +23,7 @@ type Frontmatter = {
   name?: string;
   description?: string;
   domain?: string;
+  platforms?: string;
 };
 
 const parseFrontmatter = (raw: string): { frontmatter: Frontmatter; body: string } => {
@@ -36,7 +45,7 @@ const parseFrontmatter = (raw: string): { frontmatter: Frontmatter; body: string
     const [, key, value] = lineMatch;
     const trimmedValue = value.trim().replace(/^['"]|['"]$/g, '');
 
-    if (key === 'name' || key === 'description' || key === 'domain') {
+    if (key === 'name' || key === 'description' || key === 'domain' || key === 'platforms') {
       frontmatter[key] = trimmedValue;
     }
   }
@@ -58,6 +67,7 @@ const loadDoc = (docsDir: string, fileName: string): SkillDoc => {
     id,
     description: frontmatter.description,
     domain: frontmatter.domain,
+    ...(frontmatter.platforms ? { platforms: frontmatter.platforms } : {}),
     body,
   };
 };

--- a/packages/cli/src/skills/registry.ts
+++ b/packages/cli/src/skills/registry.ts
@@ -9,13 +9,13 @@ export type SkillDoc = {
   description: string;
   domain?: string;
   /**
-   * Platforms this doc applies to, as written in the frontmatter (for
+   * Integrations this doc applies to, as written in the frontmatter (for
    * example `react-native, lynx`). Advisory: docs are annotated rather
    * than filtered, because one repository can hold a React Native app and
    * a Lynx app, and hiding a doc from the list would just make the
-   * platform difference invisible again.
+   * difference invisible again.
    */
-  platforms?: string;
+  integrations?: string;
   body: string;
 };
 
@@ -23,7 +23,7 @@ type Frontmatter = {
   name?: string;
   description?: string;
   domain?: string;
-  platforms?: string;
+  integrations?: string;
 };
 
 const parseFrontmatter = (raw: string): { frontmatter: Frontmatter; body: string } => {
@@ -45,7 +45,7 @@ const parseFrontmatter = (raw: string): { frontmatter: Frontmatter; body: string
     const [, key, value] = lineMatch;
     const trimmedValue = value.trim().replace(/^['"]|['"]$/g, '');
 
-    if (key === 'name' || key === 'description' || key === 'domain' || key === 'platforms') {
+    if (key === 'name' || key === 'description' || key === 'domain' || key === 'integrations') {
       frontmatter[key] = trimmedValue;
     }
   }
@@ -67,7 +67,7 @@ const loadDoc = (docsDir: string, fileName: string): SkillDoc => {
     id,
     description: frontmatter.description,
     domain: frontmatter.domain,
-    ...(frontmatter.platforms ? { platforms: frontmatter.platforms } : {}),
+    ...(frontmatter.integrations ? { integrations: frontmatter.integrations } : {}),
     body,
   };
 };

--- a/packages/lynx-dev/src/server/json-list.ts
+++ b/packages/lynx-dev/src/server/json-list.ts
@@ -26,6 +26,16 @@ type JsonPageDescription = {
       prefersFuseboxFrontend: boolean;
     };
   };
+  /**
+   * Rozenite's own extension, not part of Metro's shape. Lets a consumer
+   * that cares -- today only `rozenite agent`, which resolves a CDP
+   * capability profile from it -- tell a Lynx page apart from a React
+   * Native one. Every other `/json/list` consumer ignores unknown keys,
+   * so declaring it costs nothing.
+   */
+  rozenite: {
+    platform: 'lynx';
+  };
 };
 
 const buildPage = (target: InspectorTarget, origin: string): JsonPageDescription => {
@@ -53,6 +63,9 @@ const buildPage = (target: InspectorTarget, origin: string): JsonPageDescription
         // `logicalDeviceId` with a given `page` (session) id anyway.
         prefersFuseboxFrontend: true,
       },
+    },
+    rozenite: {
+      platform: 'lynx',
     },
   };
 };

--- a/packages/lynx-dev/src/server/json-list.ts
+++ b/packages/lynx-dev/src/server/json-list.ts
@@ -26,16 +26,6 @@ type JsonPageDescription = {
       prefersFuseboxFrontend: boolean;
     };
   };
-  /**
-   * Rozenite's own extension, not part of Metro's shape. Lets a consumer
-   * that cares -- today only `rozenite agent`, which resolves a CDP
-   * capability profile from it -- tell a Lynx page apart from a React
-   * Native one. Every other `/json/list` consumer ignores unknown keys,
-   * so declaring it costs nothing.
-   */
-  rozenite: {
-    platform: 'lynx';
-  };
 };
 
 const buildPage = (target: InspectorTarget, origin: string): JsonPageDescription => {
@@ -63,9 +53,6 @@ const buildPage = (target: InspectorTarget, origin: string): JsonPageDescription
         // `logicalDeviceId` with a given `page` (session) id anyway.
         prefersFuseboxFrontend: true,
       },
-    },
-    rozenite: {
-      platform: 'lynx',
     },
   };
 };

--- a/packages/middleware/src/__tests__/agent-capabilities.test.ts
+++ b/packages/middleware/src/__tests__/agent-capabilities.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import { getUnsupportedDomains, isToolSupported } from '@rozenite/agent-shared';
+import {
+  LYNX_PROFILE,
+  REACT_NATIVE_PROFILE,
+  resolveCapabilityProfile,
+} from '../agent/capability-profiles.js';
+import { UnsupportedToolError, withCapabilityFilter } from '../agent/capability-filter.js';
+import {
+  createMemoryDomainService,
+  createNetworkDomainService,
+  type LocalAgentToolService,
+} from '../agent/local-domains.js';
+
+const artifactWriter = async () => ({
+  path: '/tmp/artifact',
+  write: async () => {},
+  finalize: async () => ({
+    path: '/tmp/artifact',
+    relativePath: 'artifact',
+    bytes: 0,
+    bucket: 'profiles' as const,
+    fileName: 'artifact',
+  }),
+  abort: async () => {},
+});
+
+const createMemoryService = (): LocalAgentToolService =>
+  createMemoryDomainService({
+    getSessionInfo: () => ({ sessionId: 's', pageId: 'p', deviceId: 'd' }),
+    sendCommand: async () => ({}),
+    subscribeToCDPEvent: () => () => {},
+    createArtifactWriter: artifactWriter,
+  });
+
+const createNetworkService = (): LocalAgentToolService =>
+  createNetworkDomainService({
+    getSessionInfo: () => ({ sessionId: 's', pageId: 'p', deviceId: 'd' }),
+    sendCommand: async () => ({}),
+    subscribeToCDPEvent: () => () => {},
+  });
+
+describe('capability profiles', () => {
+  it('leaves React Native declaring no gaps', () => {
+    expect(resolveCapabilityProfile('react-native')).toBe(REACT_NATIVE_PROFILE);
+    expect(getUnsupportedDomains(REACT_NATIVE_PROFILE)).toEqual([]);
+    expect(isToolSupported(REACT_NATIVE_PROFILE, 'network', 'listRequests')).toBe(true);
+  });
+
+  // The main long-term risk of a static table is drifting out of step
+  // with the tools it describes, which would silently stop filtering.
+  it('names only tools the services actually expose', () => {
+    const toolsByDomain = new Map<string, Set<string>>([
+      [
+        'memory',
+        new Set(
+          createMemoryService()
+            .getTools()
+            .map((tool) => tool.name),
+        ),
+      ],
+      [
+        'network',
+        new Set(
+          createNetworkService()
+            .getTools()
+            .map((tool) => tool.name),
+        ),
+      ],
+    ]);
+
+    for (const [domainId, capability] of Object.entries(LYNX_PROFILE.domains)) {
+      const known = toolsByDomain.get(domainId);
+      if (!known) {
+        continue;
+      }
+
+      for (const toolName of Object.keys(capability.tools ?? {})) {
+        expect(known, `${domainId}.${toolName}`).toContain(toolName);
+      }
+    }
+  });
+
+  it('reports whole-domain and tool-level gaps differently', () => {
+    const gaps = getUnsupportedDomains(LYNX_PROFILE);
+    const network = gaps.find((gap) => gap.domain === 'network');
+    const memory = gaps.find((gap) => gap.domain === 'memory');
+
+    expect(network?.tools).toBeUndefined();
+    expect(network?.fallback).toBe('@rozenite/network-activity-plugin');
+    expect(memory?.tools).toEqual(['startSampling', 'stopSampling']);
+  });
+});
+
+describe('capability filtering', () => {
+  it("drops an unsupported domain's tools from a Lynx session", () => {
+    const filtered = withCapabilityFilter(createNetworkService(), LYNX_PROFILE);
+
+    expect(filtered.getTools()).toEqual([]);
+  });
+
+  it('keeps the supported half of a degraded domain', () => {
+    const filtered = withCapabilityFilter(createMemoryService(), LYNX_PROFILE);
+    const names = filtered.getTools().map((tool) => tool.name);
+
+    expect(names).toContain('takeHeapSnapshot');
+    expect(names).not.toContain('startSampling');
+    expect(names).not.toContain('stopSampling');
+  });
+
+  it('explains a filtered tool called by exact name rather than running it', async () => {
+    const filtered = withCapabilityFilter(createMemoryService(), LYNX_PROFILE);
+
+    await expect(filtered.callTool('startSampling', {})).rejects.toBeInstanceOf(
+      UnsupportedToolError,
+    );
+    await expect(filtered.callTool('startSampling', {})).rejects.toThrow(/PrimJS/);
+  });
+
+  it('hands back the original service when nothing is filtered', () => {
+    const service = createNetworkService();
+
+    expect(withCapabilityFilter(service, REACT_NATIVE_PROFILE)).toBe(service);
+  });
+});

--- a/packages/middleware/src/__tests__/agent-capabilities.test.ts
+++ b/packages/middleware/src/__tests__/agent-capabilities.test.ts
@@ -88,7 +88,26 @@ describe('capability profiles', () => {
 
     expect(network?.tools).toBeUndefined();
     expect(network?.fallback).toBe('@rozenite/network-activity-plugin');
-    expect(memory?.tools).toEqual(['startSampling', 'stopSampling']);
+    expect(memory?.tools?.map((tool) => tool.name)).toEqual(['startSampling', 'stopSampling']);
+  });
+
+  // Each tool carries its own reason rather than the domain borrowing
+  // one of them, so a domain with two unrelated gaps explains each.
+  it('carries a reason on every tool-level gap', () => {
+    const memory = getUnsupportedDomains(LYNX_PROFILE).find((gap) => gap.domain === 'memory');
+
+    expect(memory?.tools?.every((tool) => Boolean(tool.reason))).toBe(true);
+    expect(memory?.reason).toBe('Not supported on lynx targets.');
+  });
+
+  // A web target is a browser, which backs Chrome's CDP surface in full.
+  // The Lynx gaps below are PrimJS's, and PrimJS is not what runs there.
+  it('gives the web integrations an empty profile, Lynx included', () => {
+    expect(getUnsupportedDomains(resolveCapabilityProfile('lynx-web'))).toEqual([]);
+    expect(getUnsupportedDomains(resolveCapabilityProfile('react-native-web'))).toEqual([]);
+    expect(isToolSupported(resolveCapabilityProfile('lynx-web'), 'network', 'listRequests')).toBe(
+      true,
+    );
   });
 });
 

--- a/packages/middleware/src/__tests__/agent-local-domains.test.ts
+++ b/packages/middleware/src/__tests__/agent-local-domains.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   createMemoryDomainService,
   createNetworkDomainService,
+  createPerformanceDomainService,
   createReactDomainService,
 } from '../agent/local-domains.js';
 
@@ -342,5 +343,110 @@ describe('network domain service', () => {
     expect(staleContinuation.items).toEqual([]);
     expect(staleContinuation.page.hasMore).toBe(false);
     expect(staleContinuation.page.reset).toBe(true);
+  });
+});
+
+describe('performance domain service', () => {
+  const createTraceHarness = () => {
+    const listeners = new Map<string, Set<(params: Record<string, unknown>) => void>>();
+    const subscribeToCDPEvent = (
+      method: string,
+      listener: (params: Record<string, unknown>) => void,
+    ) => {
+      const entries = listeners.get(method) || new Set();
+      entries.add(listener);
+      listeners.set(method, entries);
+
+      return () => {
+        entries.delete(listener);
+      };
+    };
+    const emit = (method: string, params: Record<string, unknown>) => {
+      for (const listener of [...(listeners.get(method) || [])]) {
+        listener(params);
+      }
+    };
+
+    const write = vi.fn(async () => undefined);
+    const finalize = vi.fn(async () => ({
+      path: '/tmp/trace.json',
+      relativePath: '.rozenite/agent/sessions/device-1/traces/trace.json',
+      bytes: 10,
+      bucket: 'traces' as const,
+      fileName: 'trace.json',
+    }));
+    const abort = vi.fn(async () => undefined);
+
+    const service = createPerformanceDomainService({
+      getSessionInfo: () => ({
+        sessionId: 'session-1',
+        pageId: 'page-1',
+        deviceId: 'device-1',
+      }),
+      sendCommand: async () => ({}),
+      subscribeToCDPEvent,
+      createArtifactWriter: async () => ({
+        path: '/tmp/trace.json',
+        write,
+        finalize,
+        abort,
+      }),
+    });
+
+    // stopTrace awaits the artifact writer before it subscribes, so an
+    // event emitted synchronously after the call would arrive before
+    // anything is listening.
+    const flush = async () => {
+      for (let tick = 0; tick < 10; tick += 1) {
+        await Promise.resolve();
+      }
+    };
+
+    return { service, emit, flush, write, finalize, abort };
+  };
+
+  it('refuses a trace the device completed without sending any event', async () => {
+    const { service, emit, flush, finalize, abort } = createTraceHarness();
+
+    await service.callTool('startTrace', {});
+    const stopped = service.callTool('stopTrace', {});
+    await flush();
+    emit('Tracing.tracingComplete', {});
+
+    await expect(stopped).rejects.toThrow(/without a single trace event/);
+    expect(finalize).not.toHaveBeenCalled();
+    expect(abort).toHaveBeenCalled();
+  });
+
+  // The guard has to count events, not dataCollected notifications: a
+  // runtime that only shares Chrome's domain NAME can announce the event
+  // with a payload that carries nothing.
+  it('refuses a trace whose dataCollected events carry no trace events', async () => {
+    const { service, emit, flush, finalize, abort } = createTraceHarness();
+
+    await service.callTool('startTrace', {});
+    const stopped = service.callTool('stopTrace', {});
+    await flush();
+    emit('Tracing.dataCollected', { value: [] });
+    emit('Tracing.dataCollected', {});
+    emit('Tracing.tracingComplete', {});
+
+    await expect(stopped).rejects.toThrow(/without a single trace event/);
+    expect(finalize).not.toHaveBeenCalled();
+    expect(abort).toHaveBeenCalled();
+  });
+
+  it('finalizes a trace that carried at least one event', async () => {
+    const { service, emit, flush, write, finalize } = createTraceHarness();
+
+    await service.callTool('startTrace', {});
+    const stopped = service.callTool('stopTrace', {});
+    await flush();
+    emit('Tracing.dataCollected', { value: [{ ts: 1, name: 'evt' }] });
+    emit('Tracing.tracingComplete', {});
+
+    await expect(stopped).resolves.toMatchObject({ artifact: expect.anything() });
+    expect(finalize).toHaveBeenCalled();
+    expect(write).toHaveBeenCalledWith('{"traceEvents":[');
   });
 });

--- a/packages/middleware/src/__tests__/agent-session-manager.test.ts
+++ b/packages/middleware/src/__tests__/agent-session-manager.test.ts
@@ -19,7 +19,7 @@ const mocks = vi.hoisted(() => {
   const stop = vi.fn();
   const getInfo = vi.fn();
   const getTools = vi.fn();
-  const getPlatform = vi.fn(() => 'react-native');
+  const getIntegration = vi.fn(() => 'react-native');
   const getUnsupportedDomains = vi.fn(() => []);
   const callTool = vi.fn();
   const isReusable = vi.fn(() => true);
@@ -31,7 +31,7 @@ const mocks = vi.hoisted(() => {
     stop,
     getInfo,
     getTools,
-    getPlatform,
+    getIntegration,
     getUnsupportedDomains,
     callTool,
     subscribeTap,
@@ -46,7 +46,7 @@ const mocks = vi.hoisted(() => {
     stop,
     getInfo,
     getTools,
-    getPlatform,
+    getIntegration,
     getUnsupportedDomains,
     callTool,
     subscribeTap,
@@ -228,7 +228,7 @@ describe('agent session manager', () => {
 
     expect(manager.getSessionTools('device-1')).toEqual({
       tools: [{ name: 'startTrace' }],
-      platform: 'react-native',
+      integration: 'react-native',
       unsupported: [],
     });
     await expect(manager.callSessionTool('device-1', 'startTrace', {})).resolves.toEqual({

--- a/packages/middleware/src/__tests__/agent-session-manager.test.ts
+++ b/packages/middleware/src/__tests__/agent-session-manager.test.ts
@@ -19,6 +19,8 @@ const mocks = vi.hoisted(() => {
   const stop = vi.fn();
   const getInfo = vi.fn();
   const getTools = vi.fn();
+  const getPlatform = vi.fn(() => 'react-native');
+  const getUnsupportedDomains = vi.fn(() => []);
   const callTool = vi.fn();
   const isReusable = vi.fn(() => true);
   const subscribeTap = vi.fn(() => vi.fn());
@@ -29,6 +31,8 @@ const mocks = vi.hoisted(() => {
     stop,
     getInfo,
     getTools,
+    getPlatform,
+    getUnsupportedDomains,
     callTool,
     subscribeTap,
     sendTapMessage,
@@ -42,6 +46,8 @@ const mocks = vi.hoisted(() => {
     stop,
     getInfo,
     getTools,
+    getPlatform,
+    getUnsupportedDomains,
     callTool,
     subscribeTap,
     sendTapMessage,
@@ -220,7 +226,11 @@ describe('agent session manager', () => {
     const manager = createAgentSessionManager({ projectRoot: '/app' });
     await manager.createSession({ deviceId: 'device-1' });
 
-    expect(manager.getSessionTools('device-1')).toEqual([{ name: 'startTrace' }]);
+    expect(manager.getSessionTools('device-1')).toEqual({
+      tools: [{ name: 'startTrace' }],
+      platform: 'react-native',
+      unsupported: [],
+    });
     await expect(manager.callSessionTool('device-1', 'startTrace', {})).resolves.toEqual({
       ok: true,
     });

--- a/packages/middleware/src/agent/capability-filter.ts
+++ b/packages/middleware/src/agent/capability-filter.ts
@@ -2,8 +2,8 @@
  * Applies a capability profile to a local domain service.
  *
  * Deliberately a wrapper rather than a branch inside each service: the
- * four domain services stay ignorant of platforms entirely, and there is
- * exactly one place where "this target cannot do that" is decided.
+ * four domain services stay ignorant of integrations entirely, and there
+ * is exactly one place where "this target cannot do that" is decided.
  */
 import {
   getUnsupportedToolReason,
@@ -17,7 +17,7 @@ export class UnsupportedToolError extends Error {
     const reason = getUnsupportedToolReason(profile, domainId, toolName);
 
     super(
-      `Tool "${toolName}" is not supported on this ${profile.platform} target.` +
+      `Tool "${toolName}" is not supported on this ${profile.integration} target.` +
         (reason ? ` ${reason}` : ''),
     );
     this.name = 'UnsupportedToolError';
@@ -28,9 +28,9 @@ export const withCapabilityFilter = (
   service: LocalAgentToolService,
   profile: CapabilityProfile,
 ): LocalAgentToolService => {
+  const declaredTools = service.getTools();
   const allowed = new Set(
-    service
-      .getTools()
+    declaredTools
       .filter((tool) => isToolSupported(profile, service.domainId, tool.name))
       .map((tool) => tool.name),
   );
@@ -38,7 +38,7 @@ export const withCapabilityFilter = (
   // Nothing was filtered out, so hand back the service untouched rather
   // than wrapping it. Keeps the React Native path allocation-identical to
   // what it was before profiles existed.
-  if (allowed.size === service.getTools().length) {
+  if (allowed.size === declaredTools.length) {
     return service;
   }
 

--- a/packages/middleware/src/agent/capability-filter.ts
+++ b/packages/middleware/src/agent/capability-filter.ts
@@ -1,0 +1,59 @@
+/**
+ * Applies a capability profile to a local domain service.
+ *
+ * Deliberately a wrapper rather than a branch inside each service: the
+ * four domain services stay ignorant of platforms entirely, and there is
+ * exactly one place where "this target cannot do that" is decided.
+ */
+import {
+  getUnsupportedToolReason,
+  isToolSupported,
+  type CapabilityProfile,
+} from '@rozenite/agent-shared';
+import type { LocalAgentToolService } from './local-domains.js';
+
+export class UnsupportedToolError extends Error {
+  constructor(profile: CapabilityProfile, domainId: string, toolName: string) {
+    const reason = getUnsupportedToolReason(profile, domainId, toolName);
+
+    super(
+      `Tool "${toolName}" is not supported on this ${profile.platform} target.` +
+        (reason ? ` ${reason}` : ''),
+    );
+    this.name = 'UnsupportedToolError';
+  }
+}
+
+export const withCapabilityFilter = (
+  service: LocalAgentToolService,
+  profile: CapabilityProfile,
+): LocalAgentToolService => {
+  const allowed = new Set(
+    service
+      .getTools()
+      .filter((tool) => isToolSupported(profile, service.domainId, tool.name))
+      .map((tool) => tool.name),
+  );
+
+  // Nothing was filtered out, so hand back the service untouched rather
+  // than wrapping it. Keeps the React Native path allocation-identical to
+  // what it was before profiles existed.
+  if (allowed.size === service.getTools().length) {
+    return service;
+  }
+
+  return {
+    ...service,
+    getTools: () => service.getTools().filter((tool) => allowed.has(tool.name)),
+    // A filtered tool is unreachable through `getTools`, but `callTool`
+    // is also reachable by exact tool name from the call-tool route, so
+    // it needs the same guard rather than trusting the listing.
+    callTool: async (toolName, args) => {
+      if (!allowed.has(toolName)) {
+        throw new UnsupportedToolError(profile, service.domainId, toolName);
+      }
+
+      return service.callTool(toolName, args);
+    },
+  };
+};

--- a/packages/middleware/src/agent/capability-profiles.ts
+++ b/packages/middleware/src/agent/capability-profiles.ts
@@ -1,0 +1,82 @@
+/**
+ * Per-platform capability profiles for the built-in agent domains.
+ *
+ * Verified against `lynx-family/lynx` and `lynx-family/primjs` rather
+ * than inferred: `LynxDevToolNG::RegisterAgents` is the list of CDP
+ * domains a Lynx device answers at all, and `primjs`'s
+ * `src/inspector/protocols.cc` is the method table behind the four
+ * domains (`Runtime`, `Debugger`, `Profiler`, `HeapProfiler`) that Lynx
+ * forwards straight into the JS engine.
+ *
+ * Deliberately a static table rather than a runtime probe. A probe costs
+ * round trips at session start and cannot see the failure that matters
+ * most anyway: PrimJS answers an unknown method with an empty success,
+ * which is indistinguishable from a real one. The single axis that
+ * genuinely varies at runtime is the V8-vs-PrimJS backend, and that
+ * already has a free signal — only V8 ever emits a real
+ * `Runtime.executionContextCreated` (see
+ * `@rozenite/lynx-dev`'s `translate-device-frame.ts`). Leave that as a
+ * future refinement; do not build the table on it.
+ */
+import {
+  createEmptyCapabilityProfile,
+  type AgentTargetPlatform,
+  type CapabilityProfile,
+} from '@rozenite/agent-shared';
+
+const HEAP_SAMPLING_REASON =
+  'Lynx forwards HeapProfiler to the JS engine, and PrimJS implements only ' +
+  'takeHeapSnapshot. It answers methods it does not know with an empty success, so ' +
+  'sampling would appear to start and then collect nothing.';
+
+/**
+ * React Native is the platform every built-in domain was written
+ * against, so it declares no gaps and every lookup short-circuits to
+ * "supported".
+ */
+const REACT_NATIVE_PROFILE: CapabilityProfile = createEmptyCapabilityProfile('react-native');
+
+const LYNX_PROFILE: CapabilityProfile = {
+  platform: 'lynx',
+  domains: {
+    network: {
+      availability: 'unsupported',
+      reason:
+        'Lynx registers no CDP Network domain, so every Network.* command returns ' +
+        '"Not implemented" (-32601).',
+      fallback: '@rozenite/network-activity-plugin',
+    },
+    react: {
+      availability: 'unsupported',
+      reason:
+        'Lynx has no React DevTools backend, and @rozenite/lynx only initialises the ' +
+        '"rozenite" dispatcher domain, so react-devtools messages are never delivered.',
+    },
+    performance: {
+      availability: 'unsupported',
+      reason:
+        'Lynx implements a Perfetto-based Tracing domain: it ignores Chrome trace ' +
+        'categories and returns the result as an IO stream handle, never as ' +
+        'Tracing.dataCollected events.',
+    },
+    memory: {
+      // The domain stays usable — heap snapshots work on Lynx, and they
+      // are the reason to reach for this domain in the first place.
+      availability: 'degraded',
+      tools: {
+        takeHeapSnapshot: { availability: 'supported' },
+        startSampling: { availability: 'unsupported', reason: HEAP_SAMPLING_REASON },
+        stopSampling: { availability: 'unsupported', reason: HEAP_SAMPLING_REASON },
+      },
+    },
+    // `console` has no entry: PrimJS emits Runtime.consoleAPICalled and
+    // Lynx's own Log agent emits Log.entryAdded, which is everything the
+    // console domain passively captures.
+  },
+};
+
+export const resolveCapabilityProfile = (platform: AgentTargetPlatform): CapabilityProfile => {
+  return platform === 'lynx' ? LYNX_PROFILE : REACT_NATIVE_PROFILE;
+};
+
+export { LYNX_PROFILE, REACT_NATIVE_PROFILE };

--- a/packages/middleware/src/agent/capability-profiles.ts
+++ b/packages/middleware/src/agent/capability-profiles.ts
@@ -1,5 +1,5 @@
 /**
- * Per-platform capability profiles for the built-in agent domains.
+ * Per-integration capability profiles for the built-in agent domains.
  *
  * Verified against `lynx-family/lynx` and `lynx-family/primjs` rather
  * than inferred: `LynxDevToolNG::RegisterAgents` is the list of CDP
@@ -18,11 +18,8 @@
  * `@rozenite/lynx-dev`'s `translate-device-frame.ts`). Leave that as a
  * future refinement; do not build the table on it.
  */
-import {
-  createEmptyCapabilityProfile,
-  type AgentTargetPlatform,
-  type CapabilityProfile,
-} from '@rozenite/agent-shared';
+import { createEmptyCapabilityProfile, type CapabilityProfile } from '@rozenite/agent-shared';
+import type { RozeniteIntegration } from '@rozenite/tools/integration';
 
 const HEAP_SAMPLING_REASON =
   'Lynx forwards HeapProfiler to the JS engine, and PrimJS implements only ' +
@@ -30,14 +27,14 @@ const HEAP_SAMPLING_REASON =
   'sampling would appear to start and then collect nothing.';
 
 /**
- * React Native is the platform every built-in domain was written
+ * React Native is the integration every built-in domain was written
  * against, so it declares no gaps and every lookup short-circuits to
  * "supported".
  */
 const REACT_NATIVE_PROFILE: CapabilityProfile = createEmptyCapabilityProfile('react-native');
 
 const LYNX_PROFILE: CapabilityProfile = {
-  platform: 'lynx',
+  integration: 'lynx',
   domains: {
     network: {
       availability: 'unsupported',
@@ -75,8 +72,29 @@ const LYNX_PROFILE: CapabilityProfile = {
   },
 };
 
-export const resolveCapabilityProfile = (platform: AgentTargetPlatform): CapabilityProfile => {
-  return platform === 'lynx' ? LYNX_PROFILE : REACT_NATIVE_PROFILE;
+/**
+ * Accepts the full `RozeniteIntegration` union, not just the two a dev
+ * server can host. Sessions resolve from the host integration today, so
+ * only `react-native` and `lynx` are reachable; taking the wider type
+ * means the day a per-target signal lands here, the `-web` variants are
+ * already answered rather than silently falling through to the wrong
+ * profile.
+ */
+export const resolveCapabilityProfile = (integration: RozeniteIntegration): CapabilityProfile => {
+  switch (integration) {
+    case 'lynx':
+      return LYNX_PROFILE;
+    // A web target is a browser, and a browser backs Chrome's CDP
+    // surface in full -- including the Network, Tracing and HeapProfiler
+    // domains Lynx's native runtime does not. `lynx-web` therefore gets
+    // the empty profile and NOT LYNX_PROFILE: those gaps are PrimJS's,
+    // and PrimJS is not what runs there.
+    case 'react-native-web':
+    case 'lynx-web':
+      return createEmptyCapabilityProfile(integration);
+    case 'react-native':
+      return REACT_NATIVE_PROFILE;
+  }
 };
 
 export { LYNX_PROFILE, REACT_NATIVE_PROFILE };

--- a/packages/middleware/src/agent/cdp-errors.ts
+++ b/packages/middleware/src/agent/cdp-errors.ts
@@ -1,0 +1,86 @@
+/**
+ * Typed errors for the CDP command channel.
+ *
+ * A device that does not implement a method answers
+ * `{ id, error: { code: -32601, message: "..." } }`. Rejecting with the
+ * stringified error object — as this used to — throws away the one piece
+ * of context an agent needs to act, which is *which method* the device
+ * refused. These errors keep it.
+ */
+
+/** The JSON-RPC "method not found" code, which CDP reuses verbatim. */
+export const CDP_METHOD_NOT_FOUND = -32601;
+
+export class UnsupportedCdpMethodError extends Error {
+  readonly method: string;
+
+  constructor(method: string, detail?: string) {
+    super(
+      `The device does not implement "${method}"${detail ? ` (${detail})` : ''}. This ` +
+        `target's runtime exposes a different CDP surface than React Native; run ` +
+        '`rozenite agent domains` to see what this session supports.',
+    );
+    this.name = 'UnsupportedCdpMethodError';
+    this.method = method;
+  }
+}
+
+export class CdpCommandError extends Error {
+  readonly method: string;
+
+  constructor(method: string, detail: string) {
+    super(`"${method}" failed: ${detail}`);
+    this.name = 'CdpCommandError';
+    this.method = method;
+  }
+}
+
+/**
+ * Thrown when a device accepts a command but never emits the event that
+ * completes it. On a runtime whose domain merely *shares a name* with
+ * Chrome's — Lynx's Perfetto-backed `Tracing`, for instance — the command
+ * succeeds and the awaited event simply never comes, so without this the
+ * call hangs forever.
+ */
+export class CdpEventTimeoutError extends Error {
+  readonly cdpEvent: string;
+
+  constructor(cdpEvent: string, timeoutMs: number, hint?: string) {
+    super(
+      `Timed out after ${timeoutMs}ms waiting for "${cdpEvent}" from the device.` +
+        (hint ? ` ${hint}` : ''),
+    );
+    this.name = 'CdpEventTimeoutError';
+    this.cdpEvent = cdpEvent;
+  }
+}
+
+const getErrorDetail = (error: unknown): string => {
+  if (error && typeof error === 'object' && !Array.isArray(error)) {
+    const message = (error as Record<string, unknown>).message;
+    if (typeof message === 'string' && message.length > 0) {
+      return message;
+    }
+  }
+
+  return JSON.stringify(error);
+};
+
+const getErrorCode = (error: unknown): number | undefined => {
+  if (error && typeof error === 'object' && !Array.isArray(error)) {
+    const code = (error as Record<string, unknown>).code;
+    return typeof code === 'number' ? code : undefined;
+  }
+
+  return undefined;
+};
+
+export const createCDPCommandError = (method: string, error: unknown): Error => {
+  const detail = getErrorDetail(error);
+
+  if (getErrorCode(error) === CDP_METHOD_NOT_FOUND) {
+    return new UnsupportedCdpMethodError(method, detail);
+  }
+
+  return new CdpCommandError(method, detail);
+};

--- a/packages/middleware/src/agent/local-domains.ts
+++ b/packages/middleware/src/agent/local-domains.ts
@@ -1,5 +1,6 @@
 import type { JSONSchema7, AgentTool, AgentToolPagination } from '@rozenite/agent-shared';
 import { createReactTreeStore } from './runtime/react/store.js';
+import { CdpEventTimeoutError } from './cdp-errors.js';
 import type { ArtifactBucket, ArtifactFileWriter } from './artifacts.js';
 import type {
   ReactTreeNode,
@@ -173,6 +174,14 @@ const DEFAULT_RN_DEVTOOLS_TRACE_CATEGORIES = [
 ] as const;
 
 export type LocalAgentToolService = {
+  /**
+   * The static agent domain this service backs. Used to look the service
+   * up in a capability profile — static tool names are bare
+   * (`takeHeapSnapshot`, not `memory.takeHeapSnapshot`), so without this
+   * the domain would have to be recovered by reverse-searching the tool
+   * name table.
+   */
+  domainId: string;
   getTools: () => AgentTool[];
   callTool: (toolName: string, args: unknown) => Promise<unknown | undefined>;
   captureReactDevToolsMessage?: (message: unknown) => Promise<void>;
@@ -184,6 +193,15 @@ const NAME_HINT_SCHEMA: JSONSchema7 = {
   type: 'string',
   description: 'Optional file naming hint used for the Metro-managed artifact filename.',
 };
+
+/**
+ * Deadlines for device events that complete a long-running capture.
+ * Generous: a real trace or heap snapshot on a slow device legitimately
+ * takes a while, and these exist to convert "never" into an error, not
+ * to police latency.
+ */
+const TRACE_COMPLETION_TIMEOUT_MS = 60_000;
+const HEAP_SNAPSHOT_TIMEOUT_MS = 120_000;
 
 const DEFAULT_DOMAIN_PAGE_LIMIT = 20;
 const MAX_DOMAIN_PAGE_LIMIT = 100;
@@ -420,24 +438,54 @@ const getCDPCommandResult = (value: Record<string, unknown>): Record<string, unk
   return getOptionalRecord(value.result) || value;
 };
 
+/**
+ * Waits for one CDP event, with a deadline.
+ *
+ * The deadline is the point: a device can accept a command and then
+ * never emit the event that completes it — a runtime whose domain shares
+ * a name with Chrome's but not its semantics does exactly that. Without
+ * a timeout the awaiting tool hangs forever, which is strictly worse for
+ * an agent than an error, because there is nothing to react to. This
+ * guard is platform-agnostic on purpose: it catches the case for
+ * runtimes no capability profile has been written for yet.
+ */
 const createCDPEventWaiter = (
   subscribeToCDPEvent: SubscribeToCDPEvent,
   method: string,
+  options: { timeoutMs?: number; hint?: string } = {},
 ): {
   promise: Promise<Record<string, unknown>>;
   cancel: () => void;
 } => {
   let unsubscribe = () => {};
-  const promise = new Promise<Record<string, unknown>>((resolve) => {
+  let timer: NodeJS.Timeout | null = null;
+
+  const cleanup = (): void => {
+    unsubscribe();
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+
+  const promise = new Promise<Record<string, unknown>>((resolve, reject) => {
     unsubscribe = subscribeToCDPEvent(method, (params) => {
-      unsubscribe();
+      cleanup();
       resolve(params);
     });
+
+    const timeoutMs = options.timeoutMs;
+    if (timeoutMs !== undefined) {
+      timer = setTimeout(() => {
+        cleanup();
+        reject(new CdpEventTimeoutError(method, timeoutMs, options.hint));
+      }, timeoutMs);
+    }
   });
 
   return {
     promise,
-    cancel: () => unsubscribe(),
+    cancel: cleanup,
   };
 };
 
@@ -606,6 +654,10 @@ export const createPerformanceDomainService = (deps: {
     const tracingComplete = createCDPEventWaiter(
       deps.subscribeToCDPEvent,
       'Tracing.tracingComplete',
+      {
+        timeoutMs: TRACE_COMPLETION_TIMEOUT_MS,
+        hint: "The target may implement a tracing protocol other than Chrome's.",
+      },
     );
     const unsubscribeDataCollected = deps.subscribeToCDPEvent('Tracing.dataCollected', (params) => {
       const values = Array.isArray(params.value) ? params.value : [];
@@ -638,7 +690,15 @@ export const createPerformanceDomainService = (deps: {
       await tracingComplete.promise;
       await pendingWrites;
       if (!wroteHeader) {
-        await writer.write('{"traceEvents":[');
+        // The device reported the trace complete without ever sending a
+        // Tracing.dataCollected event. Writing the empty-but-valid
+        // artifact this used to produce hands back a file that looks
+        // like a successful capture and contains nothing, which is the
+        // hardest kind of failure for an agent to notice.
+        throw new Error(
+          'The trace completed without a single Tracing.dataCollected event, so no trace ' +
+            'was captured. This target does not appear to implement Chrome-style tracing.',
+        );
       }
       await writer.write(
         `],"metadata":${JSON.stringify(createTraceMetadata(startedAt, traceWindow))}}`,
@@ -656,6 +716,7 @@ export const createPerformanceDomainService = (deps: {
   };
 
   return {
+    domainId: 'performance',
     getTools: () => tools,
     callTool: async (toolName, args) => {
       if (toolName === 'startTrace') {
@@ -1062,6 +1123,7 @@ export const createReactDomainService = (deps: {
   });
 
   return {
+    domainId: 'react',
     getTools: () => tools,
     callTool: async (toolName, args) => {
       switch (toolName) {
@@ -1185,17 +1247,36 @@ export const createMemoryDomainService = (deps: {
       },
     );
     let unsubscribeProgress = () => {};
-    const progressPromise = new Promise<void>((resolve) => {
+    let progressTimer: NodeJS.Timeout | null = null;
+    const clearProgressTimer = (): void => {
+      if (progressTimer) {
+        clearTimeout(progressTimer);
+        progressTimer = null;
+      }
+    };
+    const progressPromise = new Promise<void>((resolve, reject) => {
       unsubscribeProgress = deps.subscribeToCDPEvent(
         'HeapProfiler.reportHeapSnapshotProgress',
         (params) => {
           if (params.finished === true) {
             reportCompleted = true;
+            clearProgressTimer();
             unsubscribeProgress();
             resolve();
           }
         },
       );
+
+      progressTimer = setTimeout(() => {
+        unsubscribeProgress();
+        reject(
+          new CdpEventTimeoutError(
+            'HeapProfiler.reportHeapSnapshotProgress',
+            HEAP_SNAPSHOT_TIMEOUT_MS,
+            'The device accepted takeHeapSnapshot but never reported completion.',
+          ),
+        );
+      }, HEAP_SNAPSHOT_TIMEOUT_MS);
     });
 
     try {
@@ -1214,6 +1295,7 @@ export const createMemoryDomainService = (deps: {
       throw error;
     } finally {
       chunkUnsubscribe();
+      clearProgressTimer();
       unsubscribeProgress();
       heapSnapshotInProgress = false;
     }
@@ -1287,6 +1369,7 @@ export const createMemoryDomainService = (deps: {
   };
 
   return {
+    domainId: 'memory',
     getTools: () => tools,
     callTool: async (toolName, args) => {
       if (toolName === 'takeHeapSnapshot') {
@@ -1877,6 +1960,7 @@ export const createNetworkDomainService = (deps: {
   };
 
   return {
+    domainId: 'network',
     getTools: () => tools,
     callTool: async (toolName, args) => {
       if (toolName === 'startRecording') {

--- a/packages/middleware/src/agent/local-domains.ts
+++ b/packages/middleware/src/agent/local-domains.ts
@@ -649,7 +649,12 @@ export const createPerformanceDomainService = (deps: {
     const writer = await deps.createArtifactWriter('traces', 'json', getString(input.nameHint));
     let pendingWrites = Promise.resolve();
     let wroteHeader = false;
-    let isFirstEvent = true;
+    // Counts events actually written, not events announced. A device can
+    // emit Tracing.dataCollected with an absent or non-array `value` --
+    // exactly what a runtime whose Tracing domain only shares Chrome's
+    // NAME would do -- and counting the event rather than its contents
+    // would let that through as a successful capture of nothing.
+    let writtenEventCount = 0;
     let traceWindow: { min: number; max: number } | null = null;
     const tracingComplete = createCDPEventWaiter(
       deps.subscribeToCDPEvent,
@@ -662,12 +667,15 @@ export const createPerformanceDomainService = (deps: {
     const unsubscribeDataCollected = deps.subscribeToCDPEvent('Tracing.dataCollected', (params) => {
       const values = Array.isArray(params.value) ? params.value : [];
       pendingWrites = pendingWrites.then(async () => {
-        if (!wroteHeader) {
-          await writer.write('{"traceEvents":[');
-          wroteHeader = true;
-        }
-
         for (const item of values) {
+          // Written lazily, per event rather than per event batch, so an
+          // empty batch leaves the artifact untouched instead of opening
+          // one that the guard below will then have to abort.
+          if (!wroteHeader) {
+            await writer.write('{"traceEvents":[');
+            wroteHeader = true;
+          }
+
           if (typeof item?.ts === 'number' && Number.isFinite(item.ts)) {
             traceWindow = traceWindow
               ? {
@@ -676,11 +684,11 @@ export const createPerformanceDomainService = (deps: {
                 }
               : { min: item.ts, max: item.ts };
           }
-          if (!isFirstEvent) {
+          if (writtenEventCount > 0) {
             await writer.write(',');
           }
           await writer.write(JSON.stringify(item));
-          isFirstEvent = false;
+          writtenEventCount += 1;
         }
       });
     });
@@ -689,15 +697,15 @@ export const createPerformanceDomainService = (deps: {
       await deps.sendCommand('Tracing.end');
       await tracingComplete.promise;
       await pendingWrites;
-      if (!wroteHeader) {
-        // The device reported the trace complete without ever sending a
-        // Tracing.dataCollected event. Writing the empty-but-valid
-        // artifact this used to produce hands back a file that looks
-        // like a successful capture and contains nothing, which is the
-        // hardest kind of failure for an agent to notice.
+      if (writtenEventCount === 0) {
+        // The device reported the trace complete without handing over a
+        // single event. Writing the empty-but-valid artifact this used
+        // to produce hands back a file that looks like a successful
+        // capture and contains nothing, which is the hardest kind of
+        // failure for an agent to notice.
         throw new Error(
-          'The trace completed without a single Tracing.dataCollected event, so no trace ' +
-            'was captured. This target does not appear to implement Chrome-style tracing.',
+          'The trace completed without a single trace event, so nothing was captured. This ' +
+            'target does not appear to implement Chrome-style tracing.',
         );
       }
       await writer.write(

--- a/packages/middleware/src/agent/metro-discovery.ts
+++ b/packages/middleware/src/agent/metro-discovery.ts
@@ -1,5 +1,5 @@
 import { request as httpRequest } from 'node:http';
-import type { MetroTarget } from '@rozenite/agent-shared';
+import type { AgentTargetPlatform, MetroTarget } from '@rozenite/agent-shared';
 
 type JsonPageDescription = {
   id: string;
@@ -13,6 +13,15 @@ type JsonPageDescription = {
     capabilities?: {
       prefersFuseboxFrontend?: boolean;
     };
+  };
+  /**
+   * Rozenite's own extension to Metro's page shape, served by dev servers
+   * that front a non-React-Native runtime (`@rozenite/lynx-dev` sets it).
+   * Metro itself never emits it, and every other consumer ignores unknown
+   * keys, so this is additive.
+   */
+  rozenite?: {
+    platform?: AgentTargetPlatform;
   };
 };
 
@@ -125,6 +134,7 @@ export const getMetroTargets = async (host: string, port: number): Promise<Metro
             title: page.title,
             description: page.description,
             webSocketDebuggerUrl: page.webSocketDebuggerUrl,
+            ...(page.rozenite?.platform ? { platform: page.rozenite.platform } : {}),
           }) satisfies MetroTarget,
       ),
     )

--- a/packages/middleware/src/agent/metro-discovery.ts
+++ b/packages/middleware/src/agent/metro-discovery.ts
@@ -1,5 +1,5 @@
 import { request as httpRequest } from 'node:http';
-import type { AgentTargetPlatform, MetroTarget } from '@rozenite/agent-shared';
+import type { MetroTarget } from '@rozenite/agent-shared';
 
 type JsonPageDescription = {
   id: string;
@@ -13,15 +13,6 @@ type JsonPageDescription = {
     capabilities?: {
       prefersFuseboxFrontend?: boolean;
     };
-  };
-  /**
-   * Rozenite's own extension to Metro's page shape, served by dev servers
-   * that front a non-React-Native runtime (`@rozenite/lynx-dev` sets it).
-   * Metro itself never emits it, and every other consumer ignores unknown
-   * keys, so this is additive.
-   */
-  rozenite?: {
-    platform?: AgentTargetPlatform;
   };
 };
 
@@ -134,7 +125,6 @@ export const getMetroTargets = async (host: string, port: number): Promise<Metro
             title: page.title,
             description: page.description,
             webSocketDebuggerUrl: page.webSocketDebuggerUrl,
-            ...(page.rozenite?.platform ? { platform: page.rozenite.platform } : {}),
           }) satisfies MetroTarget,
       ),
     )

--- a/packages/middleware/src/agent/routes.ts
+++ b/packages/middleware/src/agent/routes.ts
@@ -156,9 +156,7 @@ export const createAgentRoutes = (manager: AgentSessionManager): Router => {
   router.get(AGENT_SESSION_TOOLS_ROUTE_PATTERN, (req, res) => {
     syncEndpoint(manager, req);
     try {
-      sendResult<GetAgentSessionToolsResponse>(res, {
-        tools: manager.getSessionTools(getSessionId(req)),
-      });
+      sendResult<GetAgentSessionToolsResponse>(res, manager.getSessionTools(getSessionId(req)));
     } catch (error) {
       sendError(res, error);
     }

--- a/packages/middleware/src/agent/session-manager.ts
+++ b/packages/middleware/src/agent/session-manager.ts
@@ -1,14 +1,14 @@
 import {
   DEFAULT_AGENT_HOST,
   DEFAULT_AGENT_PORT,
-  DEFAULT_AGENT_TARGET_PLATFORM,
+  DEFAULT_AGENT_TARGET_INTEGRATION,
   type AgentServerInfo,
   type AgentSessionInfo,
-  type AgentTargetPlatform,
   type CreateAgentSessionRequest,
   type DevToolsPluginMessage,
   type GetAgentSessionToolsResponse,
 } from '@rozenite/agent-shared';
+import type { RozeniteIntegration } from '@rozenite/tools/integration';
 import { getMetroTargets, resolveMetroTarget } from './metro-discovery.js';
 import { createAgentSession, type AgentSession } from './session.js';
 import type { TapListener } from './tap.js';
@@ -20,11 +20,11 @@ export const createAgentSessionManager = (options: {
   host?: string;
   port?: number;
   metroVersion?: string;
-  /** The dev server's platform; the default for targets that declare none. */
-  platform?: AgentTargetPlatform;
+  /** The integration this dev server hosts. See `RozeniteConfig.integration`. */
+  integration?: RozeniteIntegration;
 }) => {
   const metroVersion = options.metroVersion;
-  const defaultPlatform = options.platform ?? DEFAULT_AGENT_TARGET_PLATFORM;
+  const integration = options.integration ?? DEFAULT_AGENT_TARGET_INTEGRATION;
   const sessions = new Map<string, AgentSession>();
   let currentHost = options.host ?? DEFAULT_AGENT_HOST;
   let currentPort = options.port ?? DEFAULT_AGENT_PORT;
@@ -86,10 +86,7 @@ export const createAgentSessionManager = (options: {
       host: currentHost,
       port: currentPort,
       target,
-      // A target that declares its own platform wins: one dev server can
-      // in principle front more than one kind of runtime, and the server
-      // default would describe those wrongly.
-      platform: target.platform ?? defaultPlatform,
+      integration,
       cliVersion: request.cliVersion,
       metroVersion,
       resolveTarget: (deviceId) => resolveMetroTarget(currentHost, currentPort, deviceId),
@@ -149,7 +146,7 @@ export const createAgentSessionManager = (options: {
 
     return {
       tools: session.getTools(),
-      platform: session.getPlatform(),
+      integration: session.getIntegration(),
       unsupported: session.getUnsupportedDomains(),
     };
   };

--- a/packages/middleware/src/agent/session-manager.ts
+++ b/packages/middleware/src/agent/session-manager.ts
@@ -1,11 +1,13 @@
 import {
   DEFAULT_AGENT_HOST,
   DEFAULT_AGENT_PORT,
+  DEFAULT_AGENT_TARGET_PLATFORM,
   type AgentServerInfo,
   type AgentSessionInfo,
-  type AgentTool,
+  type AgentTargetPlatform,
   type CreateAgentSessionRequest,
   type DevToolsPluginMessage,
+  type GetAgentSessionToolsResponse,
 } from '@rozenite/agent-shared';
 import { getMetroTargets, resolveMetroTarget } from './metro-discovery.js';
 import { createAgentSession, type AgentSession } from './session.js';
@@ -18,8 +20,11 @@ export const createAgentSessionManager = (options: {
   host?: string;
   port?: number;
   metroVersion?: string;
+  /** The dev server's platform; the default for targets that declare none. */
+  platform?: AgentTargetPlatform;
 }) => {
   const metroVersion = options.metroVersion;
+  const defaultPlatform = options.platform ?? DEFAULT_AGENT_TARGET_PLATFORM;
   const sessions = new Map<string, AgentSession>();
   let currentHost = options.host ?? DEFAULT_AGENT_HOST;
   let currentPort = options.port ?? DEFAULT_AGENT_PORT;
@@ -81,6 +86,10 @@ export const createAgentSessionManager = (options: {
       host: currentHost,
       port: currentPort,
       target,
+      // A target that declares its own platform wins: one dev server can
+      // in principle front more than one kind of runtime, and the server
+      // default would describe those wrongly.
+      platform: target.platform ?? defaultPlatform,
       cliVersion: request.cliVersion,
       metroVersion,
       resolveTarget: (deviceId) => resolveMetroTarget(currentHost, currentPort, deviceId),
@@ -135,8 +144,14 @@ export const createAgentSessionManager = (options: {
     return { stopped: true };
   };
 
-  const getSessionTools = (sessionId: string): AgentTool[] => {
-    return getSessionOrThrow(sessionId).getTools();
+  const getSessionTools = (sessionId: string): GetAgentSessionToolsResponse => {
+    const session = getSessionOrThrow(sessionId);
+
+    return {
+      tools: session.getTools(),
+      platform: session.getPlatform(),
+      unsupported: session.getUnsupportedDomains(),
+    };
   };
 
   const callSessionTool = async (

--- a/packages/middleware/src/agent/session.ts
+++ b/packages/middleware/src/agent/session.ts
@@ -1,14 +1,14 @@
 import WebSocket from 'ws';
 import {
   AGENT_PLUGIN_ID,
-  DEFAULT_AGENT_TARGET_PLATFORM,
+  DEFAULT_AGENT_TARGET_INTEGRATION,
   getUnsupportedDomains,
 } from '@rozenite/agent-shared';
+import type { RozeniteIntegration } from '@rozenite/tools/integration';
 import type {
   AgentSessionInfo,
   AgentSessionReadyMessage,
   AgentSessionStatus,
-  AgentTargetPlatform,
   MetroTarget,
   UnsupportedDomainInfo,
 } from '@rozenite/agent-shared';
@@ -108,15 +108,15 @@ export const createAgentSession = (options: {
   host: string;
   port: number;
   target: MetroTarget;
-  platform?: AgentTargetPlatform;
+  integration?: RozeniteIntegration;
   resolveTarget?: (deviceId: string) => Promise<MetroTarget>;
   cliVersion?: string;
   metroVersion?: string;
   onTerminated?: (sessionId: string) => void;
 }) => {
   let target = options.target;
-  const platform = options.platform ?? DEFAULT_AGENT_TARGET_PLATFORM;
-  const capabilityProfile = resolveCapabilityProfile(platform);
+  const integration = options.integration ?? DEFAULT_AGENT_TARGET_INTEGRATION;
+  const capabilityProfile = resolveCapabilityProfile(integration);
   const handler = createAgentMessageHandler();
   const artifacts = createAgentArtifacts(options.projectRoot, options.target.id);
   const tap = createTapEmitter();
@@ -913,7 +913,7 @@ export const createAgentSession = (options: {
     appId: target.appId,
     pageId: target.pageId,
     status,
-    platform,
+    integration,
     createdAt,
     lastActivityAt,
     ...(connectedAt ? { connectedAt } : {}),
@@ -929,13 +929,14 @@ export const createAgentSession = (options: {
     ];
   };
 
-  const getPlatform = (): AgentTargetPlatform => platform;
+  const getIntegration = (): RozeniteIntegration => integration;
 
   /**
    * The gaps in this target's capability profile, flattened for the
    * client. Reported alongside the tool list rather than instead of it:
    * a domain that is silently missing reads to an agent as a typo, while
-   * one reported as unavailable with a reason reads as a platform limit.
+   * one reported as unavailable with a reason reads as an integration
+   * limit.
    */
   const getUnsupportedDomainInfo = (): UnsupportedDomainInfo[] =>
     getUnsupportedDomains(capabilityProfile);
@@ -1066,7 +1067,7 @@ export const createAgentSession = (options: {
     stop,
     getInfo,
     getTools,
-    getPlatform,
+    getIntegration,
     getUnsupportedDomains: getUnsupportedDomainInfo,
     callTool,
     subscribeTap,

--- a/packages/middleware/src/agent/session.ts
+++ b/packages/middleware/src/agent/session.ts
@@ -1,12 +1,21 @@
 import WebSocket from 'ws';
-import { AGENT_PLUGIN_ID } from '@rozenite/agent-shared';
+import {
+  AGENT_PLUGIN_ID,
+  DEFAULT_AGENT_TARGET_PLATFORM,
+  getUnsupportedDomains,
+} from '@rozenite/agent-shared';
 import type {
   AgentSessionInfo,
   AgentSessionReadyMessage,
   AgentSessionStatus,
+  AgentTargetPlatform,
   MetroTarget,
+  UnsupportedDomainInfo,
 } from '@rozenite/agent-shared';
 import { createAgentArtifacts } from './artifacts.js';
+import { createCDPCommandError } from './cdp-errors.js';
+import { resolveCapabilityProfile } from './capability-profiles.js';
+import { withCapabilityFilter } from './capability-filter.js';
 import { createAgentMessageHandler } from './runtime/handler.js';
 import { extractConsoleMessage } from './runtime/console/extract.js';
 import { parseRozeniteBindingPayload } from './runtime/bindings.js';
@@ -51,6 +60,8 @@ const getDebuggerWebSocketOrigin = (webSocketDebuggerUrl: string): string => {
 };
 
 type PendingCommand = {
+  /** Retained so a device error can name the method it refused. */
+  method: string;
   resolve: (value: Record<string, unknown>) => void;
   reject: (error: Error) => void;
 };
@@ -97,12 +108,15 @@ export const createAgentSession = (options: {
   host: string;
   port: number;
   target: MetroTarget;
+  platform?: AgentTargetPlatform;
   resolveTarget?: (deviceId: string) => Promise<MetroTarget>;
   cliVersion?: string;
   metroVersion?: string;
   onTerminated?: (sessionId: string) => void;
 }) => {
   let target = options.target;
+  const platform = options.platform ?? DEFAULT_AGENT_TARGET_PLATFORM;
+  const capabilityProfile = resolveCapabilityProfile(platform);
   const handler = createAgentMessageHandler();
   const artifacts = createAgentArtifacts(options.projectRoot, options.target.id);
   const tap = createTapEmitter();
@@ -307,7 +321,7 @@ export const createAgentSession = (options: {
     touch();
 
     const promise = new Promise<Record<string, unknown>>((resolve, reject) => {
-      pendingCommands.set(commandId, { resolve, reject });
+      pendingCommands.set(commandId, { method, resolve, reject });
       ws!.send(payload, (error) => {
         if (!error) {
           return;
@@ -348,7 +362,7 @@ export const createAgentSession = (options: {
       sendCommand,
       subscribeToCDPEvent,
     }),
-  ];
+  ].map((service) => withCapabilityFilter(service, capabilityProfile));
 
   const clearBootstrapTimer = (): void => {
     if (!bootstrapTimer) {
@@ -731,7 +745,7 @@ export const createAgentSession = (options: {
 
       pendingCommands.delete(message.id);
       if (message.error) {
-        pending.reject(new Error(JSON.stringify(message.error)));
+        pending.reject(createCDPCommandError(pending.method, message.error));
         return;
       }
 
@@ -899,6 +913,7 @@ export const createAgentSession = (options: {
     appId: target.appId,
     pageId: target.pageId,
     status,
+    platform,
     createdAt,
     lastActivityAt,
     ...(connectedAt ? { connectedAt } : {}),
@@ -913,6 +928,17 @@ export const createAgentSession = (options: {
       ...localServices.flatMap((service) => service.getTools()),
     ];
   };
+
+  const getPlatform = (): AgentTargetPlatform => platform;
+
+  /**
+   * The gaps in this target's capability profile, flattened for the
+   * client. Reported alongside the tool list rather than instead of it:
+   * a domain that is silently missing reads to an agent as a typo, while
+   * one reported as unavailable with a reason reads as a platform limit.
+   */
+  const getUnsupportedDomainInfo = (): UnsupportedDomainInfo[] =>
+    getUnsupportedDomains(capabilityProfile);
 
   const subscribeTap: (listener: TapListener) => () => void = tap.subscribe;
 
@@ -1040,6 +1066,8 @@ export const createAgentSession = (options: {
     stop,
     getInfo,
     getTools,
+    getPlatform,
+    getUnsupportedDomains: getUnsupportedDomainInfo,
     callTool,
     subscribeTap,
     sendTapMessage,

--- a/packages/middleware/src/config.ts
+++ b/packages/middleware/src/config.ts
@@ -1,11 +1,18 @@
+import type { AgentTargetPlatform } from '@rozenite/agent-shared';
 import { type ProjectType } from '@rozenite/tools';
 import { RozeniteLogLevel } from './logger.js';
 
 /** Controls whether plugins are shown as individual tabs or in one sidebar. */
 export type RozenitePluginDisplay = 'tabs' | 'sidebar';
 
-/** Which host platform the dev server serves. See `RozeniteConfig.platform`. */
-export type RozenitePlatform = 'react-native' | 'lynx';
+/**
+ * Which host platform the dev server serves. See `RozeniteConfig.platform`.
+ *
+ * Aliases `AgentTargetPlatform` rather than restating the union: the agent
+ * subsystem resolves a capability profile from this same value, and the two
+ * must never be able to drift apart.
+ */
+export type RozenitePlatform = AgentTargetPlatform;
 
 export type RozeniteConfig = {
   projectRoot: string;

--- a/packages/middleware/src/index.ts
+++ b/packages/middleware/src/index.ts
@@ -52,10 +52,9 @@ export const initializeRozenite = async (
   const agentSessionManager = createAgentSessionManager({
     projectRoot: options.projectRoot,
     metroVersion: getPackageJSON().version,
-    // The dev server's own platform is the default for every session it
-    // serves. A target that declares its own in `/json/list` overrides
-    // it per target -- see `metro-discovery.ts`.
-    platform: options.platform,
+    // Which integration this dev server hosts. Every session it serves
+    // resolves its CDP capability profile from this.
+    integration: options.integration,
   });
 
   if (allInstalledPlugins.length === 0) {

--- a/packages/middleware/src/index.ts
+++ b/packages/middleware/src/index.ts
@@ -52,6 +52,10 @@ export const initializeRozenite = async (
   const agentSessionManager = createAgentSessionManager({
     projectRoot: options.projectRoot,
     metroVersion: getPackageJSON().version,
+    // The dev server's own platform is the default for every session it
+    // serves. A target that declares its own in `/json/list` overrides
+    // it per target -- see `metro-discovery.ts`.
+    platform: options.platform,
   });
 
   if (allInstalledPlugins.length === 0) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -459,6 +459,9 @@ importers:
       '@rozenite/agent-shared':
         specifier: workspace:*
         version: link:../agent-shared
+      '@rozenite/tools':
+        specifier: workspace:*
+        version: link:../tools
       tslib:
         specifier: ^2.3.0
         version: 2.8.1
@@ -469,6 +472,9 @@ importers:
 
   packages/agent-shared:
     dependencies:
+      '@rozenite/tools':
+        specifier: workspace:*
+        version: link:../tools
       tslib:
         specifier: ^2.3.0
         version: 2.8.1


### PR DESCRIPTION
## Description

Rozenite for Agents now knows which built-in domains the connected target can actually back, instead of advertising all five on every session.

- Each session resolves a **capability profile** from its target's platform. Unsupported tools are never registered, so `list-tools` is honest.
- Unavailable domains stay visible in `rozenite agent domains`, which gains an `availability` column (`supported` / `degraded` / `unsupported`) and a `fallback` — both default fields, not `--verbose` ones.
- Calling an unsupported tool now fails during resolution with the reason and a next step, before anything reaches the wire:

  ```
  Tool "listRequests" is not supported on this lynx target. Lynx registers no CDP
  Network domain, so every Network.* command returns "Not implemented" (-32601).
  Use the `@rozenite/network-activity-plugin` domain instead.
  ```

- On a Lynx target that means `console`, plugin domains, app tools and `memory.takeHeapSnapshot` are supported; `memory` is degraded (allocation sampling removed); `network`, `react` and `performance` are unavailable with reasons.

Three fixes to the CDP command channel apply to **every** platform:

- A device error names the method it refused (`UnsupportedCdpMethodError` for `-32601`) instead of arriving as a stringified error object.
- Waits on a device event are bounded, so a capture whose completion event never arrives fails with a diagnosis rather than hanging forever.
- `stopTrace` refuses to finalise a zero-event trace artifact instead of reporting a successful capture of nothing.

Agent docs gain a `platforms` frontmatter field, platform-availability sections on `network`, `react`, `performance` and `memory`, and a new `lynx` orientation doc.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Closes https://github.com/callstackincubator/rozenite/issues/447

## Context

The five built-in domains were designed against React Native's CDP surface. Lynx's is different, verified against `LynxDevToolNG::RegisterAgents` (the domains a Lynx device answers at all) and `primjs`'s `src/inspector/protocols.cc` (the method table behind the domains Lynx forwards into the JS engine): no `Network` domain is registered, no React DevTools backend exists, `Tracing` is Perfetto-based rather than Chrome-based, and `HeapProfiler` implements snapshots but not sampling.

The design follows from the fact that **"unsupported" is three behaviours on the wire, and only one is loud**: an unregistered domain answers `-32601`; an unknown method inside an engine-backed domain answers with an *empty success*, so the call resolves and the awaited event never comes; and a same-named-different-protocol domain succeeds while producing the wrong thing. The latter two cannot be detected from a response, which is why this is resolved from a profile before the call rather than translated from an error after it.

Some decisions worth a reviewer's attention:

- **The table is static, not probed.** A probe costs round trips at session start and cannot see the empty-success case anyway. The one axis that genuinely varies at runtime is the V8-vs-PrimJS backend, which already has a free signal (only V8 emits a real `Runtime.executionContextCreated`); that is left as a future refinement rather than a foundation.
- **Absence means supported.** React Native's profile is empty and its behaviour is unchanged; nobody maintains an allowlist that grows with every new tool.
- **Unavailable domains are still listed.** Dropping `network` outright would make `rozenite agent network listRequests` fail with `Unknown domain "network". Did you mean…?`, which reads to an agent as a typo to correct rather than a platform limit to route around.
- **Both new response fields are optional.** An older CLI against a newer server ignores them; a newer CLI against an older server reads `undefined` and treats every domain as supported — exactly the previous behaviour. No lockstep upgrade.
- **Filtering is a wrapper, not a branch per service.** The four domain services stay ignorant of platforms; `withCapabilityFilter` returns the original service untouched when nothing is filtered. `callTool` is guarded as well as `getTools`, since the call-tool route reaches tools by exact name.
- **Platform comes from two places.** The dev server's `platform` config is the default; `@rozenite/lynx-dev` additionally stamps `rozenite: { platform: 'lynx' }` on each `/json/list` page, which `metro-discovery` carries onto `MetroTarget` and which wins per target. Metro never emits that key and every other consumer ignores unknown ones, so it is additive.

Two gaps I'd rather name than leave implicit:

- The profile drift guard covers `memory` and `network` — the domains whose services construct cheaply in a test. `react` and `performance` have no tool-level entries today so nothing is currently unguarded, but adding one there would not be caught.
- A Lynx-only domain over `UITree` / `Template` / Lynx's own `Performance` and `Memory` is now a profile entry away, but it is new surface area rather than a fix and stayed out of scope.

## Testing

Automated, from the repository root after `git fetch origin main`:

- `pnpm checks:affected` — typecheck, lint and format across 102 tasks, all passing.
- `pnpm test:affected` — 63/63 tasks passing.
- `pnpm release:plan` — confirms the version plan.

New tests in `packages/middleware/src/__tests__/agent-capabilities.test.ts` cover the React Native profile declaring no gaps, a drift guard asserting the Lynx table names only tools the services actually expose, whole-domain versus tool-level gap reporting, filtering on both `getTools` and `callTool`, and the untouched-service fast path.

Three existing tests changed deliberately: the two `agent-command-output` domain-listing assertions carry the new default columns (their mocks now include a `degraded` and an `unsupported` domain so the columns are exercised), and `skills-registry` counts the new `lynx` doc.

Not manually verified against a physical Lynx device — the Lynx behaviour encoded in the profile is sourced from the upstream C++ registration and dispatch tables cited above rather than from a live session.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pj8YXsJh4mMsJ1HpJEr7B5)_