### PR TITLE
feat(app): show a startup splash while connecting to the device

### DIFF
--- a/.changeset/app-startup-splash.md
+++ b/.changeset/app-startup-splash.md
@@ -1,0 +1,6 @@
+---
+'@rozenite/app': patch
+---
+
+Show a startup splash with the Rozenite loader while the standalone app
+connects to a device, fading it out once the handshake completes.

--- a/.changeset/rozenite-loader-speed.md
+++ b/.changeset/rozenite-loader-speed.md
@@ -1,0 +1,7 @@
+---
+'@rozenite/ui': patch
+---
+
+Speed up `RozeniteLoader`'s animation: the default `period` drops from 3600ms
+to 2000ms per loop, so it reads as active rather than sluggish. Pass `period`
+explicitly to keep the old pace.

--- a/apps/ui-storybook/src/stories/RozeniteLoader.stories.tsx
+++ b/apps/ui-storybook/src/stories/RozeniteLoader.stories.tsx
@@ -20,7 +20,7 @@ const meta = {
     },
     period: {
       control: { type: 'range', min: 800, max: 8000, step: 100 },
-      description: 'Loop duration in ms.',
+      description: 'Loop duration in ms — lower is faster.',
     },
     noise: {
       control: { type: 'range', min: 0, max: 1.4, step: 0.05 },
@@ -40,7 +40,7 @@ export const Playground: Story = {
   args: {
     size: 96,
     cols: 16,
-    period: 3600,
+    period: 2000,
     noise: 0.8,
   },
 };

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -132,6 +132,43 @@ describe('App', () => {
     expect(document.querySelector('iframe')).toBeNull();
   });
 
+  it('covers the connecting state with the splash, then fades it off once the shell mounts', async () => {
+    const { connection, setState } = createFakeConnection();
+
+    render(<App target={{ kind: 'connection', connection }} />);
+
+    const splash = () => document.querySelector('[data-slot="splash"]');
+    expect(splash()).toBeTruthy();
+    // Opaque and over everything while the handshake is in flight.
+    expect(splash()?.className).toMatch(/\bopacity-100\b/);
+    expect(splash()?.className).toMatch(/\bfixed\b/);
+    // Purely visual: the status underneath it is what AT announces.
+    expect(splash()?.getAttribute('aria-hidden')).toBe('true');
+
+    setState({ status: 'connected' });
+    await findPanelIframe();
+
+    // Fades out (`opacity-0`) before it unmounts, rather than popping off.
+    await waitFor(() => expect(splash()?.className).toMatch(/\bopacity-0\b/), { timeout: 3000 });
+    await waitFor(() => expect(splash()).toBeNull(), { timeout: 3000 });
+  });
+
+  it('keeps the splash up behind a pre-connection status dialog', async () => {
+    const { connection, setState } = createFakeConnection();
+
+    render(<App target={{ kind: 'connection', connection }} />);
+    expect(document.querySelector('[data-slot="splash"]')).toBeTruthy();
+
+    setState({ status: 'rozeniteMissing' });
+
+    expect(await screen.findByText(/rozenite isn't set up/i)).toBeTruthy();
+    const splash = document.querySelector('[data-slot="splash"]');
+    // Still there, still opaque — it's the backdrop the dialog sits on —
+    // and under `Dialog`'s own `z-50` so it can't cover it.
+    expect(splash?.className).toMatch(/\bopacity-100\b/);
+    expect(splash?.className).toMatch(/\bz-40\b/);
+  });
+
   it('mounts the shell and shows the target name once connected', async () => {
     const { connection, setState } = createFakeConnection({
       name: 'Pixel 8',

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -139,7 +139,6 @@ describe('App', () => {
 
     const splash = () => document.querySelector('[data-slot="splash"]');
     expect(splash()).toBeTruthy();
-    // Opaque and over everything while the handshake is in flight.
     expect(splash()?.className).toMatch(/\bopacity-100\b/);
     expect(splash()?.className).toMatch(/\bfixed\b/);
     // Purely visual: the status underneath it is what AT announces.
@@ -148,7 +147,7 @@ describe('App', () => {
     setState({ status: 'connected' });
     await findPanelIframe();
 
-    // Fades out (`opacity-0`) before it unmounts, rather than popping off.
+    // Fades out before it unmounts, rather than popping off.
     await waitFor(() => expect(splash()?.className).toMatch(/\bopacity-0\b/), { timeout: 3000 });
     await waitFor(() => expect(splash()).toBeNull(), { timeout: 3000 });
   });
@@ -162,9 +161,8 @@ describe('App', () => {
     setState({ status: 'rozeniteMissing' });
 
     expect(await screen.findByText(/rozenite isn't set up/i)).toBeTruthy();
+    // Still the backdrop the dialog sits on, and under `Dialog`'s `z-50`.
     const splash = document.querySelector('[data-slot="splash"]');
-    // Still there, still opaque — it's the backdrop the dialog sits on —
-    // and under `Dialog`'s own `z-50` so it can't cover it.
     expect(splash?.className).toMatch(/\bopacity-100\b/);
     expect(splash?.className).toMatch(/\bz-40\b/);
   });

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -229,9 +229,6 @@ function ConnectedApp({ connection }: { connection: DeviceConnection }) {
           sidebarHeaderClassName={getTitleBarRegionClassName()}
         />
       ) : (
-        // Everything the pre-shell window needs beyond the `Splash`
-        // covering it below: with the title bar hidden and no `Sidebar`
-        // yet to carry a drag region, the window couldn't be moved at all.
         <WindowDragHandle />
       )}
 
@@ -267,12 +264,8 @@ function ConnectedApp({ connection }: { connection: DeviceConnection }) {
         action={<Button onClick={() => connection.reconnect()}>Reconnect</Button>}
       />
 
-      {/* Last child, but `fixed`: it covers the whole window, footer
-          included, until the handshake lands. It stays up behind the
-          dialogs above — those are all pre-connection states, so there is
-          nothing else to show underneath them — and never comes back once
-          the shell is mounted, which is what `shellMounted` being a sticky
-          latch guarantees. */}
+      {/* `fixed`, so it covers the footer below too. Latched on
+          `shellMounted`, so it never returns over a mounted shell. */}
       <Splash visible={!shellMounted} />
 
       <Footer

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -13,6 +13,7 @@ import {
 import { createDeviceShellHost } from './shell-host';
 import { fetchConfig } from './config';
 import { loadPlugins } from './plugins';
+import { Splash } from './splash';
 import type { DeviceConnection, DeviceState } from './connection/device-connection';
 import { TargetUrlError } from './connection/target-from-url';
 import { getTitleBarRegionClassName, WindowDragHandle } from './window-controls';
@@ -228,19 +229,10 @@ function ConnectedApp({ connection }: { connection: DeviceConnection }) {
           sidebarHeaderClassName={getTitleBarRegionClassName()}
         />
       ) : (
-        !configFailed && (
-          <>
-            <WindowDragHandle />
-            <PluginShell.Body className="items-center justify-center">
-              <EmptyState
-                title={
-                  configState.status === 'loading' ? 'Loading plugins…' : 'Connecting to device…'
-                }
-                description={targetName || undefined}
-              />
-            </PluginShell.Body>
-          </>
-        )
+        // Everything the pre-shell window needs beyond the `Splash`
+        // covering it below: with the title bar hidden and no `Sidebar`
+        // yet to carry a drag region, the window couldn't be moved at all.
+        <WindowDragHandle />
       )}
 
       <StatusDialog
@@ -274,6 +266,14 @@ function ConnectedApp({ connection }: { connection: DeviceConnection }) {
         description="The connection to the device was lost. This can happen for a number of reasons; reconnect to try again."
         action={<Button onClick={() => connection.reconnect()}>Reconnect</Button>}
       />
+
+      {/* Last child, but `fixed`: it covers the whole window, footer
+          included, until the handshake lands. It stays up behind the
+          dialogs above — those are all pre-connection states, so there is
+          nothing else to show underneath them — and never comes back once
+          the shell is mounted, which is what `shellMounted` being a sticky
+          latch guarantees. */}
+      <Splash visible={!shellMounted} />
 
       <Footer
         deviceState={deviceState}

--- a/packages/app/src/splash.tsx
+++ b/packages/app/src/splash.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useRef, useState } from 'react';
+import { cn, RozeniteLoader } from '@rozenite/ui';
+
+/**
+ * How long the splash stays up at minimum, even once the handshake has
+ * completed. A device on the same machine can connect in a couple of
+ * hundred milliseconds, and a splash that blinks in and straight back out
+ * reads as a glitch rather than as loading.
+ */
+const MIN_VISIBLE_MS = 450;
+
+/** Must stay in sync with `duration-[400ms]` below, which has to be a
+ * literal for Tailwind's source scanner to see it. */
+const FADE_MS = 400;
+
+type Phase = 'hidden' | 'visible' | 'fading';
+
+export interface SplashProps {
+  visible: boolean;
+}
+
+/**
+ * The startup splash: the Rozenite loader centered on the app's own
+ * background, covering the window while the device handshake is in flight,
+ * then fading off once it lands.
+ *
+ * `aria-hidden` because it's a purely visual cover — what it hides (the
+ * "Connecting to device…" empty state, the footer's status badge) stays in
+ * the accessibility tree underneath and is what assistive tech announces,
+ * so the loader must not duplicate that as a second status.
+ *
+ * `z-40` keeps it under `Dialog`'s `z-50`, so a dialog that comes up
+ * mid-fade isn't covered by the tail of the animation.
+ */
+export function Splash({ visible }: SplashProps) {
+  const [phase, setPhase] = useState<Phase>(visible ? 'visible' : 'hidden');
+  const shownAtRef = useRef(Date.now());
+
+  useEffect(() => {
+    if (visible) {
+      shownAtRef.current = Date.now();
+      setPhase('visible');
+      return;
+    }
+
+    if (phase === 'hidden') {
+      return;
+    }
+
+    const holdMs = Math.max(0, MIN_VISIBLE_MS - (Date.now() - shownAtRef.current));
+    const fadeTimer = setTimeout(() => setPhase('fading'), holdMs);
+    const doneTimer = setTimeout(() => setPhase('hidden'), holdMs + FADE_MS);
+
+    return () => {
+      clearTimeout(fadeTimer);
+      clearTimeout(doneTimer);
+    };
+    // `phase` is a dependency so the `hidden` guard above sees the phase
+    // the timers put it in. Re-running on the `visible` → `fading` step is
+    // harmless: the hold has elapsed by then, so it only re-arms the
+    // unmount a full fade after the fade actually started.
+  }, [visible, phase]);
+
+  if (phase === 'hidden') {
+    return null;
+  }
+
+  return (
+    <div
+      aria-hidden
+      data-slot="splash"
+      className={cn(
+        'fixed inset-0 z-40 flex items-center justify-center bg-background',
+        'transition-opacity duration-[400ms] ease-out motion-reduce:transition-none',
+        phase === 'fading' ? 'pointer-events-none opacity-0' : 'opacity-100',
+      )}
+    >
+      <RozeniteLoader size={96} cols={26} label="" />
+    </div>
+  );
+}

--- a/packages/app/src/splash.tsx
+++ b/packages/app/src/splash.tsx
@@ -1,12 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
 import { cn, RozeniteLoader } from '@rozenite/ui';
 
-/**
- * How long the splash stays up at minimum, even once the handshake has
- * completed. A device on the same machine can connect in a couple of
- * hundred milliseconds, and a splash that blinks in and straight back out
- * reads as a glitch rather than as loading.
- */
+/** A device on the same machine can connect in a couple of hundred
+ * milliseconds, and a splash that blinks in and straight back out reads as
+ * a glitch rather than as loading. */
 const MIN_VISIBLE_MS = 450;
 
 /** Must stay in sync with `duration-[400ms]` below, which has to be a
@@ -20,17 +17,10 @@ export interface SplashProps {
 }
 
 /**
- * The startup splash: the Rozenite loader centered on the app's own
- * background, covering the window while the device handshake is in flight,
- * then fading off once it lands.
- *
- * `aria-hidden` because it's a purely visual cover — what it hides (the
- * "Connecting to device…" empty state, the footer's status badge) stays in
- * the accessibility tree underneath and is what assistive tech announces,
- * so the loader must not duplicate that as a second status.
- *
- * `z-40` keeps it under `Dialog`'s `z-50`, so a dialog that comes up
- * mid-fade isn't covered by the tail of the animation.
+ * `aria-hidden` because it's a purely visual cover: the footer's status
+ * badge stays in the accessibility tree underneath, so the loader must not
+ * duplicate it as a second status. `z-40` keeps it under `Dialog`'s
+ * `z-50`, which is what lets a status dialog sit on top of it.
  */
 export function Splash({ visible }: SplashProps) {
   const [phase, setPhase] = useState<Phase>(visible ? 'visible' : 'hidden');
@@ -55,10 +45,9 @@ export function Splash({ visible }: SplashProps) {
       clearTimeout(fadeTimer);
       clearTimeout(doneTimer);
     };
-    // `phase` is a dependency so the `hidden` guard above sees the phase
-    // the timers put it in. Re-running on the `visible` → `fading` step is
-    // harmless: the hold has elapsed by then, so it only re-arms the
-    // unmount a full fade after the fade actually started.
+    // `phase` is a dependency so the guard above sees what the timers set.
+    // Re-running on `visible` → `fading` only re-arms the unmount a full
+    // fade after the fade actually started, which is what we want anyway.
   }, [visible, phase]);
 
   if (phase === 'hidden') {

--- a/packages/ui/src/rozenite-loader/rozenite-loader.tsx
+++ b/packages/ui/src/rozenite-loader/rozenite-loader.tsx
@@ -6,9 +6,10 @@ export interface RozeniteLoaderProps {
   size?: number;
   /** Grid cells across the logo width. Default 16 (good for ≤64 px). */
   cols?: number;
-  /** Frames per loop. Default 48 (≈13 fps of visible flips). */
+  /** Frames per loop. Default 48 (≈24 fps of visible flips at the default
+   * `period`). */
   frames?: number;
-  /** Loop duration in ms. Default 3600. */
+  /** Loop duration in ms — lower is faster. Default 2000. */
   period?: number;
   /** Organic grain amount, 0–1.4. Default 0.8. */
   noise?: number;
@@ -82,7 +83,7 @@ export function RozeniteLoader({
   size = 48,
   cols = 16,
   frames = 48,
-  period = 3600,
+  period = 2000,
   noise = 0.8,
   fg = '#8232ff',
   bg = 'transparent',


### PR DESCRIPTION
## Description

Covers the standalone app's window with a startup splash — `RozeniteLoader` centered on the app's own `--background` — for as long as the device handshake is in flight, then fades it off once the shell mounts.

- New `Splash` component in `@rozenite/app` owning the whole show/fade/unmount sequence; `App` only tells it whether the shell is up yet.
- Replaces the bare "Connecting to device…" empty state that used to fill that time.
- The splash stays up *behind* the pre-connection status dialogs ("Can't reach the dev server", "Rozenite isn't set up in this app"), which now sit on it as their backdrop instead of on an empty window.
- Speeds up `RozeniteLoader` itself: the default `period` drops from 3600ms to 2000ms per loop (~24 fps of visible dither flips with the default `frames`, up from ~13). Callers can pass `period` to keep the old pace.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
No tracking issue — this is a follow-up to #446 (`RozeniteLoader`), which this puts to use in the standalone app.

## Context

- **Fade, then unmount.** The splash renders at `opacity-100`, transitions to `opacity-0`, and unmounts a full transition later, so it animates off rather than popping. Under `prefers-reduced-motion` the transition is dropped and it simply disappears at the end of that window.
- **Minimum visible time (450 ms).** A device on the same machine can connect in a couple of hundred milliseconds; without a floor, the splash blinks in and straight back out, which reads as a glitch. The cost is a short hold on the fastest connections.
- **`z-40`, under `Dialog`'s `z-50`.** That's what lets the dialogs render over the splash — and keeps a dialog that comes up mid-fade from being covered by the tail of the animation.
- **`aria-hidden`.** The splash is a purely visual cover; the footer's status badge and the dialogs stay in the accessibility tree underneath, so the loader must not duplicate them as a second status.
- **Never comes back.** Visibility is driven off the existing sticky `shellMounted` latch, so a mid-session disconnect shows its dialog over the still-mounted shell exactly as before, never over a re-shown splash.
- The pre-shell branch now renders only `WindowDragHandle`, which sits above the splash so the Electron window can still be moved while it's up.
- **Loader speed.** `period` is the only knob for it, and lower is faster; 2000ms keeps the sprite-strip cache and per-frame `drawImage` playback unchanged, so this costs nothing at runtime. It's a behavior change for anyone already using the component at its default, hence its own version plan.

## Testing

- `pnpm --filter @rozenite/app test` — 74 tests passed, including three new `App.test.tsx` cases: the splash covers the connecting state, fades (`opacity-0`) and then unmounts once the shell mounts, and stays opaque behind a `rozeniteMissing` dialog.
- `pnpm checks:affected` — typecheck, lint, and format clean across 102 tasks.
- `pnpm test:affected` — 63 tasks passing.

Note: the last two ran against an earlier revision, before the splash was switched to stay up behind the status dialogs and before the loader default changed; the app tests above are from the final state. Not verified manually against a real device.
