### PR TITLE
feat(middleware): expose complete React commit timeline

### DIFF
--- a/.changeset/react-commit-timeline.md
+++ b/.changeset/react-commit-timeline.md
@@ -1,0 +1,5 @@
+---
+'@rozenite/middleware': minor
+---
+
+Expose every captured React profiler commit from `stopProfiling` in chronological order, including render and effect timing, priority, rendered-fiber and updater counts, and change-description availability. The existing slow-commit summary remains unchanged for quick scouting.

--- a/packages/cli/docs/react.md
+++ b/packages/cli/docs/react.md
@@ -29,6 +29,12 @@ Search and inspect:
 Profile:
 `startProfiling` -> reproduce interaction -> `stopProfiling` -> `getRenderData`.
 
+`stopProfiling` returns every captured commit in an untruncated, chronological
+`commits` array with render/effect timing, priority, rendered-fiber and updater
+counts, and change-description availability. The duration-ranked,
+size-limited `topSlowCommits` list remains available for quickly finding the
+slowest commits before calling `getRenderData`.
+
 `getRenderData` rows carry `displayName` and timing by default. Add
 `--fields ...,changedKeys` for the exact changed prop, state, and context key
 names behind `changeTypeHints`, which attributes a re-render without a

--- a/packages/middleware/src/agent/runtime/react/__tests__/store.test.ts
+++ b/packages/middleware/src/agent/runtime/react/__tests__/store.test.ts
@@ -511,11 +511,22 @@ describe('React tree store getComponent', () => {
 
 type MockPhase = 'idle' | 'profiling' | 'processing';
 
+type MockCommitData = {
+  duration: number;
+  timestamp: number;
+  effectDuration?: number | null;
+  passiveEffectDuration?: number | null;
+  priorityLevel?: string | null;
+  fiberActualDurations?: Map<number, number>;
+  updaters?: Array<{ id: number }> | null;
+  changeDescriptions?: Map<number, unknown> | null;
+};
+
 const createConfigurableProfilingBridge = (options: {
   initialPhase?: MockPhase;
-  initialDataForRoots?: Map<number, { commitData: Array<{ duration: number; timestamp: number }> }>;
+  initialDataForRoots?: Map<number, { commitData: MockCommitData[] }>;
   drainAfterStatusCalls?: number;
-  dataOnDrain?: Map<number, { commitData: Array<{ duration: number; timestamp: number }> }>;
+  dataOnDrain?: Map<number, { commitData: MockCommitData[] }>;
 }) => {
   let phase: MockPhase = options.initialPhase ?? 'idle';
   let dataForRoots = options.initialDataForRoots ?? new Map();
@@ -619,6 +630,111 @@ describe('React stopProfiling guard', () => {
       session: { totalCommits: 1 },
       renders: { count: 1 },
     });
+  });
+
+  it('returns every commit chronologically with profiling metadata', async () => {
+    const initialDataForRoots = new Map([
+      [
+        2,
+        {
+          commitData: [
+            {
+              duration: 20,
+              timestamp: 300,
+              effectDuration: 4,
+              passiveEffectDuration: 2,
+              priorityLevel: 'Normal',
+              fiberActualDurations: new Map([
+                [20, 12],
+                [21, 8],
+              ]),
+              updaters: [{ id: 20 }],
+              changeDescriptions: new Map(),
+            },
+            {
+              duration: 5,
+              timestamp: 100,
+              effectDuration: null,
+              passiveEffectDuration: null,
+              priorityLevel: null,
+              fiberActualDurations: new Map([[22, 5]]),
+              updaters: null,
+              changeDescriptions: null,
+            },
+          ],
+        },
+      ],
+      [
+        1,
+        {
+          commitData: [
+            {
+              duration: 17,
+              timestamp: 100,
+              effectDuration: 1,
+              passiveEffectDuration: 3,
+              priorityLevel: 'UserBlocking',
+              fiberActualDurations: new Map([[10, 17]]),
+              updaters: [{ id: 10 }, { id: 11 }],
+              changeDescriptions: new Map(),
+            },
+          ],
+        },
+      ],
+    ]);
+    const bridge = createConfigurableProfilingBridge({
+      initialPhase: 'idle',
+      initialDataForRoots,
+    });
+    const store = createReactTreeStore({
+      createBridge: async () => bridge,
+    });
+    store.registerDevice(DEVICE_ID, { sendMessage: () => undefined });
+
+    const result = await store.stopProfiling(DEVICE_ID, {});
+
+    expect(result.commits).toEqual([
+      {
+        rootId: 1,
+        commitIndex: 0,
+        durationMs: 17,
+        effectDurationMs: 1,
+        passiveEffectDurationMs: 3,
+        timestampMs: 100,
+        priorityLevel: 'UserBlocking',
+        renderedFiberCount: 1,
+        updaterCount: 2,
+        hasChangeDescriptions: true,
+      },
+      {
+        rootId: 2,
+        commitIndex: 1,
+        durationMs: 5,
+        effectDurationMs: null,
+        passiveEffectDurationMs: null,
+        timestampMs: 100,
+        priorityLevel: null,
+        renderedFiberCount: 1,
+        updaterCount: 0,
+        hasChangeDescriptions: false,
+      },
+      {
+        rootId: 2,
+        commitIndex: 0,
+        durationMs: 20,
+        effectDurationMs: 4,
+        passiveEffectDurationMs: 2,
+        timestampMs: 300,
+        priorityLevel: 'Normal',
+        renderedFiberCount: 2,
+        updaterCount: 1,
+        hasChangeDescriptions: true,
+      },
+    ]);
+    expect(result.topSlowCommits).toEqual([
+      { rootId: 2, commitIndex: 0, durationMs: 20, timestampMs: 300 },
+      { rootId: 1, commitIndex: 0, durationMs: 17, timestampMs: 100 },
+    ]);
   });
 
   it('returns a real zero-commit measurement after start then stop with no re-renders', async () => {

--- a/packages/middleware/src/agent/runtime/react/store.ts
+++ b/packages/middleware/src/agent/runtime/react/store.ts
@@ -1,6 +1,7 @@
 import { hashFilters } from '../pagination/filters-hash.js';
 import type {
   ReactComponentSection,
+  ReactCommitSummary,
   ReactDevToolsBridgeMessage,
   ReactGetChildrenResult,
   ReactGetComponentResult,
@@ -935,15 +936,14 @@ export const createReactTreeStore = (options?: {
     const status = bridge.getProfilingStatus();
     const profilingData = bridge.getProfilingDataSnapshot() as {
       phase?: string;
-      dataForRoots?: Map<number, { commitData?: Array<{ duration: number; timestamp: number }> }>;
+      dataForRoots?: Map<number, { commitData?: ReactCommitData[] }>;
       conflictingRootIds?: Set<number>;
       participatingRendererIds?: Set<number>;
       pendingRendererIds?: Set<number>;
       receivedRendererIds?: Set<number>;
     } | null;
     const dataForRoots =
-      profilingData?.dataForRoots ??
-      new Map<number, { commitData?: Array<{ duration: number; timestamp: number }> }>();
+      profilingData?.dataForRoots ?? new Map<number, { commitData?: ReactCommitData[] }>();
     const conflictingRootCount = profilingData?.conflictingRootIds?.size ?? 0;
     const receivedRendererCount = profilingData?.receivedRendererIds?.size ?? 0;
     const pendingRendererCount = profilingData?.pendingRendererIds?.size ?? 0;
@@ -952,6 +952,7 @@ export const createReactTreeStore = (options?: {
     let totalCommits = 0;
     let totalRenderDurationMs = 0;
     let slowCount = 0;
+    const commits: ReactCommitSummary[] = [];
     const slowCommits: Array<{
       rootId: number;
       commitIndex: number;
@@ -965,19 +966,37 @@ export const createReactTreeStore = (options?: {
       for (let index = 0; index < commitData.length; index += 1) {
         const commit = commitData[index];
         const durationMs = Number(commit.duration) || 0;
+        const timestampMs = Number(commit.timestamp) || 0;
         totalRenderDurationMs += durationMs;
+        commits.push({
+          rootId,
+          commitIndex: index,
+          durationMs,
+          effectDurationMs: commit.effectDuration ?? null,
+          passiveEffectDurationMs: commit.passiveEffectDuration ?? null,
+          timestampMs,
+          priorityLevel: commit.priorityLevel ?? null,
+          renderedFiberCount:
+            commit.fiberActualDurations instanceof Map ? commit.fiberActualDurations.size : 0,
+          updaterCount: Array.isArray(commit.updaters) ? commit.updaters.length : 0,
+          hasChangeDescriptions: commit.changeDescriptions !== null,
+        });
         if (durationMs > slowRenderThresholdMs) {
           slowCount += 1;
           slowCommits.push({
             rootId,
             commitIndex: index,
             durationMs,
-            timestampMs: Number(commit.timestamp) || 0,
+            timestampMs,
           });
         }
       }
     });
 
+    commits.sort(
+      (a, b) =>
+        a.timestampMs - b.timestampMs || a.rootId - b.rootId || a.commitIndex - b.commitIndex,
+    );
     slowCommits.sort((a, b) => b.durationMs - a.durationMs || a.timestampMs - b.timestampMs);
     const truncated = slowCommits.length > TOP_SLOW_COMMITS_LIMIT;
     const partial =
@@ -997,6 +1016,7 @@ export const createReactTreeStore = (options?: {
         slowCount,
         slowThresholdMs: slowRenderThresholdMs,
       },
+      commits,
       topSlowCommits: slowCommits.slice(0, TOP_SLOW_COMMITS_LIMIT),
       truncated,
       ...(partial ? { partial: true } : {}),

--- a/packages/middleware/src/agent/runtime/react/types.ts
+++ b/packages/middleware/src/agent/runtime/react/types.ts
@@ -130,6 +130,15 @@ export interface ReactSlowCommitSummary {
   timestampMs: number;
 }
 
+export interface ReactCommitSummary extends ReactSlowCommitSummary {
+  effectDurationMs: number | null;
+  passiveEffectDurationMs: number | null;
+  priorityLevel: string | null;
+  renderedFiberCount: number;
+  updaterCount: number;
+  hasChangeDescriptions: boolean;
+}
+
 export interface ReactStopProfilingResult {
   session: {
     roots: number[];
@@ -141,6 +150,7 @@ export interface ReactStopProfilingResult {
     slowCount: number;
     slowThresholdMs: number;
   };
+  commits: ReactCommitSummary[];
   topSlowCommits: ReactSlowCommitSummary[];
   truncated: boolean;
   partial?: boolean;


### PR DESCRIPTION
## Description

Adds an additive `commits` field to the React agent `stopProfiling` result. The field contains every captured commit in chronological order with:

- root and commit identifiers
- render, effect, and passive-effect durations
- timestamp and priority
- rendered-fiber and updater counts
- change-description availability

The existing duration-ranked, size-limited `topSlowCommits` field remains unchanged for backward compatibility and quick scouting. The React agent documentation and middleware release plan are updated alongside the implementation.

## Related Issue

Closes https://github.com/callstackincubator/rozenite/issues/462

## Context

`stopProfiling` currently exposes only the slowest commits, even though the normalized React DevTools profile retains the full recording. Downstream performance analysis needs the complete timeline to correlate render bursts and post-process the same commit metadata available to profiler tooling.

The timeline is sorted by timestamp, then root id and commit index for deterministic ordering across roots. A regression test covers ordering, metadata, and preservation of the existing slow-commit summary.

## Testing

- `pnpm checks:affected`
- `pnpm test:affected`
- `pnpm release:plan`
- Pre-push repository-wide lint and typecheck hooks
