### PR TITLE
fix(middleware): negotiate loopback debugger origins

### DIFF
--- a/.changeset/normalize-loopback-debugger-origin.md
+++ b/.changeset/normalize-loopback-debugger-origin.md
@@ -1,0 +1,7 @@
+---
+'@rozenite/middleware': patch
+---
+
+Try the debugger URL's matching WebSocket Origin first, then retry loopback
+connections with the alternate localhost or 127.0.0.1 Origin when Metro rejects
+or terminates the initial connection.

--- a/packages/middleware/src/__tests__/agent-session.test.ts
+++ b/packages/middleware/src/__tests__/agent-session.test.ts
@@ -360,7 +360,7 @@ describe('agent session', () => {
     });
   });
 
-  it('preserves the debugger websocket host in the origin header', () => {
+  it('preserves an IPv4 loopback debugger host in the primary origin header', () => {
     const target = createTarget({
       webSocketDebuggerUrl: 'ws://127.0.0.1:8081/debug',
     });
@@ -371,6 +371,105 @@ describe('agent session', () => {
     expect(socket.options).toEqual({
       headers: {
         Origin: 'http://127.0.0.1:8081',
+      },
+    });
+  });
+
+  it('preserves an IPv6 loopback debugger host in the origin header', () => {
+    const target = createTarget({
+      webSocketDebuggerUrl: 'ws://[::1]:8081/debug',
+    });
+
+    const { socket } = createStartedSession({ target });
+
+    expect(socket.url).toBe(target.webSocketDebuggerUrl);
+    expect(socket.options).toEqual({
+      headers: {
+        Origin: 'http://[::1]:8081',
+      },
+    });
+  });
+
+  it('falls back to localhost when a numeric loopback origin is rejected', async () => {
+    const target = createTarget({
+      webSocketDebuggerUrl: 'ws://127.0.0.1:8081/debug',
+    });
+    const { startPromise, socket } = createStartedSession({ target });
+
+    socket.emit('error', new Error('Unexpected server response: 401'));
+    await flushMicrotasks();
+
+    const fallbackSocket = mocks.wsInstances[1];
+    expect(fallbackSocket.url).toBe(target.webSocketDebuggerUrl);
+    expect(fallbackSocket.options).toEqual({
+      headers: {
+        Origin: 'http://localhost:8081',
+      },
+    });
+
+    fallbackSocket.open();
+    await vi.advanceTimersByTimeAsync(500);
+    await flushMicrotasks();
+
+    await expect(startPromise).resolves.toBeUndefined();
+  });
+
+  it('falls back after Metro terminates an upgraded numeric-loopback session', async () => {
+    const target = createTarget({
+      webSocketDebuggerUrl: 'ws://127.0.0.1:8081/debug',
+    });
+    const { startPromise, socket } = createStartedSession({ target });
+
+    socket.open();
+    socket.close();
+    await flushMicrotasks();
+
+    const fallbackSocket = mocks.wsInstances[1];
+    expect(fallbackSocket.options).toEqual({
+      headers: {
+        Origin: 'http://localhost:8081',
+      },
+    });
+
+    fallbackSocket.open();
+    await vi.advanceTimersByTimeAsync(500);
+    await flushMicrotasks();
+
+    await expect(startPromise).resolves.toBeUndefined();
+  });
+
+  it('falls back from localhost to numeric loopback', async () => {
+    const { startPromise, socket } = createStartedSession();
+
+    socket.open();
+    socket.close();
+    await flushMicrotasks();
+
+    const fallbackSocket = mocks.wsInstances[1];
+    expect(fallbackSocket.options).toEqual({
+      headers: {
+        Origin: 'http://127.0.0.1:8081',
+      },
+    });
+
+    fallbackSocket.open();
+    await vi.advanceTimersByTimeAsync(500);
+    await flushMicrotasks();
+
+    await expect(startPromise).resolves.toBeUndefined();
+  });
+
+  it('preserves remote hosts and secure protocols in the origin header', () => {
+    const target = createTarget({
+      webSocketDebuggerUrl: 'wss://devtools.example.com:8443/debug',
+    });
+
+    const { socket } = createStartedSession({ target });
+
+    expect(socket.url).toBe(target.webSocketDebuggerUrl);
+    expect(socket.options).toEqual({
+      headers: {
+        Origin: 'https://devtools.example.com:8443',
       },
     });
   });
@@ -691,7 +790,11 @@ describe('agent session', () => {
   });
 
   it('rejects startup if the websocket closes before bootstrap completes', async () => {
-    const { socket, startPromise } = createStartedSession();
+    const { socket, startPromise } = createStartedSession({
+      target: createTarget({
+        webSocketDebuggerUrl: 'ws://metro.internal:8081/debug',
+      }),
+    });
 
     socket.open();
     await flushMicrotasks();

--- a/packages/middleware/src/agent/session.ts
+++ b/packages/middleware/src/agent/session.ts
@@ -43,11 +43,31 @@ const DEVTOOLS_TOOK_CONNECTION_REASON = '[NEW_DEBUGGER_OPENED]';
 const getCloseReason = (reason: unknown): string =>
   Buffer.isBuffer(reason) ? reason.toString() : String(reason ?? '');
 
-const getDebuggerWebSocketOrigin = (webSocketDebuggerUrl: string): string => {
+const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
+const LOOPBACK_FALLBACK_HOSTNAMES = ['127.0.0.1', 'localhost'];
+
+const getDebuggerWebSocketOrigins = (webSocketDebuggerUrl: string): string[] => {
   const url = new URL(webSocketDebuggerUrl);
   const protocol = url.protocol === 'wss:' ? 'https:' : 'http:';
+  const matchingOrigin = `${protocol}//${url.host}`;
 
-  return `${protocol}//${url.host}`;
+  if (!LOOPBACK_HOSTNAMES.has(url.hostname)) {
+    return [matchingOrigin];
+  }
+
+  // React Native dev-middleware requires an Origin during the upgrade and
+  // accepts common loopback hosts. Expo then applies a second, exact-host check
+  // after the upgrade and terminates mismatches as a 1006 close. Its configured
+  // host may be localhost or 127.0.0.1 depending on the launcher environment.
+  const origins = [matchingOrigin];
+  for (const hostname of LOOPBACK_FALLBACK_HOSTNAMES) {
+    url.hostname = hostname;
+    const fallbackOrigin = `${protocol}//${url.host}`;
+    if (!origins.includes(fallbackOrigin)) {
+      origins.push(fallbackOrigin);
+    }
+  }
+  return origins;
 };
 
 type PendingCommand = {
@@ -797,26 +817,62 @@ export const createAgentSession = (options: {
     }
   };
 
-  const connect = async (generation = connectionGeneration): Promise<void> => {
+  const connect = async (generation = connectionGeneration, originIndex = 0): Promise<void> => {
     status = 'connecting';
+    const origins = getDebuggerWebSocketOrigins(target.webSocketDebuggerUrl);
+    const origin = origins[originIndex] ?? origins[0];
 
     await new Promise<void>((resolve, reject) => {
       const socket = new WebSocket(target.webSocketDebuggerUrl, {
         headers: {
-          Origin: getDebuggerWebSocketOrigin(target.webSocketDebuggerUrl),
+          Origin: origin,
         },
       });
+      let opened = false;
       let settled = false;
+      let fallbackStarted = false;
       const attempt = ++socketAttempt;
       activeSocketAttempt = attempt;
       ws = socket;
+
+      const tryFallback = (): boolean => {
+        if (settled || fallbackStarted || originIndex >= origins.length - 1) {
+          return false;
+        }
+
+        fallbackStarted = true;
+        bindingName = null;
+        bootstrapped = false;
+        connectedAt = undefined;
+        if (opened) {
+          handler.disconnectDevice(options.target.id);
+          for (const service of localServices) {
+            service.onDisconnected();
+          }
+        }
+        for (const [commandId, pending] of pendingCommands.entries()) {
+          pendingCommands.delete(commandId);
+          pending.reject(new Error('CDP connection closed before bootstrap completed'));
+        }
+        clearBootstrapTimer();
+        clearPluginReadiness();
+        if (ws === socket) {
+          ws = null;
+        }
+        activeSocketAttempt += 1;
+        if (socket.readyState !== WebSocket.CLOSED) {
+          socket.close();
+        }
+        void connect(generation, originIndex + 1).then(resolve, reject);
+        return true;
+      };
 
       socket.once('open', () => {
         if (!isCurrentGeneration(generation) || ws !== socket || activeSocketAttempt !== attempt) {
           socket.close();
           return;
         }
-        settled = true;
+        opened = true;
         status = 'connecting';
         connectedAt = Date.now();
         lastError = undefined;
@@ -835,6 +891,7 @@ export const createAgentSession = (options: {
           try {
             await sendCommand('ReactNativeApplication.enable');
             await sendCommand('Runtime.enable');
+            settled = true;
             scheduleBootstrap();
             resolve();
           } catch (error) {
@@ -847,6 +904,9 @@ export const createAgentSession = (options: {
 
             lastError = startupError.message;
             clearBootstrapTimer();
+            if (fallbackStarted || tryFallback()) {
+              return;
+            }
             rejectStartReadiness(startupError);
             socket.close();
             reject(startupError);
@@ -874,17 +934,27 @@ export const createAgentSession = (options: {
           return;
         }
         lastError = error instanceof Error ? error.message : String(error);
-        if (!settled) {
+        if (!settled && !tryFallback()) {
           reject(error);
         }
       });
 
       socket.once('close', (_code: unknown, reason: unknown) => {
         if (ws !== socket || activeSocketAttempt !== attempt) return;
+        if (!settled && tryFallback()) {
+          return;
+        }
+
         ws = null;
         handleSocketClosed(getCloseReason(reason), generation);
         if (!settled) {
-          reject(new Error('CDP websocket closed before session initialization'));
+          reject(
+            new Error(
+              opened
+                ? 'CDP connection closed before bootstrap completed'
+                : 'CDP websocket closed before session initialization',
+            ),
+          );
         }
       });
     });


### PR DESCRIPTION
## Description

Negotiate the debugger WebSocket Origin for loopback Metro sessions instead of unconditionally rewriting numeric loopback addresses to `localhost`.

- Try the Origin matching `webSocketDebuggerUrl` first.
- Retry loopback connections with the alternate `localhost` or `127.0.0.1` Origin.
- Keep retry eligibility open until the initial `ReactNativeApplication.enable` and `Runtime.enable` CDP commands succeed, because an Expo Origin mismatch is terminated after the WebSocket upgrade.
- Preserve remote and secure debugger Origins without fallback.

## Related Issue

Closes https://github.com/callstackincubator/rozenite/issues/463

## Context

The React Native and Expo layers validate different stages of this connection:

- React Native dev-middleware requires an Origin during the WebSocket upgrade and rejects a missing header with HTTP 401. It accepts common loopback hostnames.
- Expo CLI performs a second exact-host check after the upgrade. If the Origin host differs from Expo's configured `serverBaseUrl`, Expo terminates the socket and the client sees close code 1006 even though the WebSocket emitted `open`.

Expo's configured hostname is environment-dependent. `REACT_NATIVE_PACKAGER_HOSTNAME=localhost` makes it expect `localhost`; with that variable unset, Expo's URL creator normalizes its localhost host type to `127.0.0.1`. Meanwhile, `/json/list` builds `webSocketDebuggerUrl` from the discovery request's Host header. The target URL therefore does not always identify the Origin Expo will accept.

That explains why a localhost-only rewrite can fix one Metro process while breaking another. The fallback must work in both directions and must cover post-upgrade termination, not only HTTP handshake rejection.

## Testing

- `pnpm release:plan`
- `pnpm checks:affected`
- `pnpm test:affected` — 173 middleware tests passed; all affected tasks passed
- `pnpm --config.verify-deps-before-run=warn --filter @rozenite/middleware exec vitest --run src/__tests__/agent-session.test.ts` — 31 tests passed
- Started the playground Metro server; all 14 plugins loaded and Metro reached `Waiting on http://localhost:8082`
- Registered a synthetic inspector page and verified both Expo configurations:
  - `REACT_NATIVE_PACKAGER_HOSTNAME=localhost`: numeric Origin upgraded and then closed with 1006; localhost remained connected.
  - variable unset: numeric Origin remained connected; localhost upgraded and then closed with 1006.
  - missing Origin was rejected with HTTP 401.
