### PR TITLE
fix(middleware): derive the debugger origin from Expo's dev server

### DIFF
--- a/.changeset/derive-debugger-origin-from-expo.md
+++ b/.changeset/derive-debugger-origin-from-expo.md
@@ -1,0 +1,8 @@
+---
+'@rozenite/middleware': patch
+---
+
+Fix Rozenite for Agents failing to connect with `CDP connection closed before
+bootstrap completed` on Expo dev servers whose configured host differs from the
+address the agent reached them through, such as when
+`REACT_NATIVE_PACKAGER_HOSTNAME` is set.

--- a/packages/middleware/src/__tests__/agent-debugger-origin.test.ts
+++ b/packages/middleware/src/__tests__/agent-debugger-origin.test.ts
@@ -1,0 +1,224 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  fetchExpoDebuggerOrigin,
+  getDebuggerWebSocketOrigin,
+  resolveDebuggerOrigin,
+} from '../agent/debugger-origin.js';
+
+type RequestRecord = {
+  url: string;
+  headers: IncomingMessage['headers'];
+};
+
+let server: Server | null = null;
+
+const startServer = async (
+  handler: (req: IncomingMessage, res: ServerResponse) => void,
+): Promise<{ port: number; requests: RequestRecord[] }> => {
+  const requests: RequestRecord[] = [];
+  const instance = createServer((req, res) => {
+    requests.push({ url: req.url ?? '', headers: req.headers });
+    handler(req, res);
+  });
+
+  server = instance;
+
+  await new Promise<void>((resolve) => instance.listen(0, '127.0.0.1', resolve));
+
+  const address = instance.address();
+  if (!address || typeof address !== 'object') {
+    throw new Error('Expected a TCP address');
+  }
+
+  return { port: address.port, requests };
+};
+
+/**
+ * Stands in for Expo's `/_expo/debugger`, including the part that matters:
+ * the route reports the debugger URL built from Expo's own
+ * `serverBaseUrl`, not from the host the request was addressed to.
+ */
+const expoDebuggerServer = (canonicalHost: string) =>
+  startServer((req, res) => {
+    if (!req.url?.startsWith('/_expo/debugger')) {
+      res.writeHead(404).end();
+      return;
+    }
+
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(
+      JSON.stringify({
+        appId: 'com.example.app',
+        webSocketDebuggerUrl: `ws://${canonicalHost}/inspector/debug?device=d&page=p`,
+      }),
+    );
+  });
+
+afterEach(async () => {
+  const instance = server;
+  server = null;
+  if (instance) {
+    await new Promise<void>((resolve) => instance.close(() => resolve()));
+  }
+});
+
+describe('getDebuggerWebSocketOrigin', () => {
+  it('derives an http origin from a ws URL', () => {
+    expect(getDebuggerWebSocketOrigin('ws://127.0.0.1:8081/inspector/debug?device=d')).toBe(
+      'http://127.0.0.1:8081',
+    );
+  });
+
+  it('derives an https origin from a wss URL', () => {
+    expect(getDebuggerWebSocketOrigin('wss://devtools.example.com:8443/debug')).toBe(
+      'https://devtools.example.com:8443',
+    );
+  });
+
+  it('preserves an IPv6 loopback host', () => {
+    expect(getDebuggerWebSocketOrigin('ws://[::1]:8081/debug')).toBe('http://[::1]:8081');
+  });
+});
+
+describe('fetchExpoDebuggerOrigin', () => {
+  it("returns Expo's canonical origin regardless of the host it is asked through", async () => {
+    const { port, requests } = await expoDebuggerServer('localhost:8081');
+
+    await expect(fetchExpoDebuggerOrigin('127.0.0.1', port, 'com.example.app')).resolves.toBe(
+      'http://localhost:8081',
+    );
+    expect(requests[0].url).toBe('/_expo/debugger?appId=com.example.app');
+  });
+
+  it("sends no Origin header, which is what gets it past Expo's own check", async () => {
+    const { port, requests } = await expoDebuggerServer('127.0.0.1:8081');
+
+    await fetchExpoDebuggerOrigin('127.0.0.1', port, 'com.example.app');
+
+    expect(requests[0].headers.origin).toBeUndefined();
+  });
+
+  it('encodes the app id', async () => {
+    const { port, requests } = await expoDebuggerServer('127.0.0.1:8081');
+
+    await fetchExpoDebuggerOrigin('127.0.0.1', port, 'com.example/app id');
+
+    expect(requests[0].url).toBe('/_expo/debugger?appId=com.example%2Fapp+id');
+  });
+
+  it('maps a wss debugger URL to an https origin', async () => {
+    const { port } = await startServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ webSocketDebuggerUrl: 'wss://tunnel.example.com/debug' }));
+    });
+
+    await expect(fetchExpoDebuggerOrigin('127.0.0.1', port, 'com.example.app')).resolves.toBe(
+      'https://tunnel.example.com',
+    );
+  });
+
+  it('returns null when the route is absent, as on a bare React Native dev server', async () => {
+    const { port } = await startServer((_req, res) => {
+      res.writeHead(404).end();
+    });
+
+    await expect(fetchExpoDebuggerOrigin('127.0.0.1', port, 'com.example.app')).resolves.toBeNull();
+  });
+
+  it('returns null when Expo rejects the request', async () => {
+    const { port } = await startServer((_req, res) => {
+      res.writeHead(403).end();
+    });
+
+    await expect(fetchExpoDebuggerOrigin('127.0.0.1', port, 'com.example.app')).resolves.toBeNull();
+  });
+
+  it('returns null on a malformed body', async () => {
+    const { port } = await startServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end('not json');
+    });
+
+    await expect(fetchExpoDebuggerOrigin('127.0.0.1', port, 'com.example.app')).resolves.toBeNull();
+  });
+
+  it('returns null when the payload carries no debugger URL', async () => {
+    const { port } = await startServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ appId: 'com.example.app' }));
+    });
+
+    await expect(fetchExpoDebuggerOrigin('127.0.0.1', port, 'com.example.app')).resolves.toBeNull();
+  });
+
+  it('returns null when the debugger URL is unparseable', async () => {
+    const { port } = await startServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ webSocketDebuggerUrl: 'not a url' }));
+    });
+
+    await expect(fetchExpoDebuggerOrigin('127.0.0.1', port, 'com.example.app')).resolves.toBeNull();
+  });
+
+  it('returns null when the dev server is unreachable', async () => {
+    const { port } = await startServer((_req, res) => res.end());
+    await new Promise<void>((resolve) => server?.close(() => resolve()));
+    server = null;
+
+    await expect(fetchExpoDebuggerOrigin('127.0.0.1', port, 'com.example.app')).resolves.toBeNull();
+  });
+
+  it('returns null without a target app id', async () => {
+    const { port, requests } = await expoDebuggerServer('127.0.0.1:8081');
+
+    await expect(fetchExpoDebuggerOrigin('127.0.0.1', port, '')).resolves.toBeNull();
+    expect(requests).toHaveLength(0);
+  });
+});
+
+describe('resolveDebuggerOrigin', () => {
+  it("prefers Expo's answer over the origin implied by the target URL", async () => {
+    const { port } = await expoDebuggerServer('localhost:8081');
+
+    await expect(
+      resolveDebuggerOrigin({
+        host: '127.0.0.1',
+        port,
+        appId: 'com.example.app',
+        webSocketDebuggerUrl: 'ws://127.0.0.1:8081/inspector/debug',
+      }),
+    ).resolves.toBe('http://localhost:8081');
+  });
+
+  it('falls back to the target URL when Expo does not answer', async () => {
+    const { port } = await startServer((_req, res) => {
+      res.writeHead(404).end();
+    });
+
+    await expect(
+      resolveDebuggerOrigin({
+        host: '127.0.0.1',
+        port,
+        appId: 'com.example.app',
+        webSocketDebuggerUrl: 'ws://127.0.0.1:8081/inspector/debug',
+      }),
+    ).resolves.toBe('http://127.0.0.1:8081');
+  });
+
+  it('preserves an explicitly configured remote debugger origin', async () => {
+    const { port } = await startServer((_req, res) => {
+      res.writeHead(404).end();
+    });
+
+    await expect(
+      resolveDebuggerOrigin({
+        host: '127.0.0.1',
+        port,
+        appId: 'com.example.app',
+        webSocketDebuggerUrl: 'wss://devtools.example.com:8443/debug',
+      }),
+    ).resolves.toBe('https://devtools.example.com:8443');
+  });
+});

--- a/packages/middleware/src/__tests__/agent-session.test.ts
+++ b/packages/middleware/src/__tests__/agent-session.test.ts
@@ -36,6 +36,7 @@ const mocks = vi.hoisted(() => {
     captureReactDevToolsMessage: vi.fn(),
   }));
   const wsInstances: MockWebSocket[] = [];
+  const resolveDebuggerOrigin = vi.fn();
   let bindingName = 'rozenite-binding';
   let stalledRuntimeExpression: string | null = null;
 
@@ -171,6 +172,7 @@ const mocks = vi.hoisted(() => {
     extractConsoleMessage: vi.fn(() => null),
     parseRozeniteBindingPayload: vi.fn(() => null),
     wsInstances,
+    resolveDebuggerOrigin,
     stallRuntimeEvaluationContaining: (expression: string) => {
       stalledRuntimeExpression = expression;
     },
@@ -196,6 +198,13 @@ const mocks = vi.hoisted(() => {
       bindingName = 'rozenite-binding';
       stalledRuntimeExpression = null;
       wsInstances.length = 0;
+      resolveDebuggerOrigin.mockReset();
+      resolveDebuggerOrigin.mockImplementation(
+        async ({ webSocketDebuggerUrl }: { webSocketDebuggerUrl: string }) => {
+          const url = new URL(webSocketDebuggerUrl);
+          return `${url.protocol === 'wss:' ? 'https:' : 'http:'}//${url.host}`;
+        },
+      );
     },
   };
 });
@@ -227,6 +236,10 @@ vi.mock('../agent/runtime/bindings.js', () => ({
   parseRozeniteBindingPayload: mocks.parseRozeniteBindingPayload,
 }));
 
+vi.mock('../agent/debugger-origin.js', () => ({
+  resolveDebuggerOrigin: mocks.resolveDebuggerOrigin,
+}));
+
 vi.mock('../logger.js', () => ({
   logger: {
     info: mocks.loggerInfo,
@@ -256,7 +269,7 @@ const flushMicrotasks = async () => {
   await Promise.resolve();
 };
 
-const createStartedSession = (
+const createStartedSession = async (
   overrides?: Partial<{
     cliVersion: string;
     metroVersion: string;
@@ -273,6 +286,9 @@ const createStartedSession = (
   });
 
   const startPromise = session.start();
+  // The debugger `Origin` is resolved over HTTP before the socket opens,
+  // so the socket only exists once that has settled.
+  await flushMicrotasks();
   const socket = mocks.wsInstances[0];
 
   return { session, socket, startPromise };
@@ -285,7 +301,7 @@ const startSession = async (
     resolveTarget: (deviceId: string) => Promise<MetroTarget>;
   }>,
 ) => {
-  const started = createStartedSession(overrides);
+  const started = await createStartedSession(overrides);
   started.socket.open();
   await vi.advanceTimersByTimeAsync(500);
   await emitRozeniteBindingPayload(started.socket, {
@@ -349,9 +365,15 @@ describe('agent session', () => {
     vi.useRealTimers();
   });
 
-  it('sets an origin header derived from the debugger websocket URL', () => {
-    const { socket } = createStartedSession();
+  it('sets the origin header to the resolved debugger origin', async () => {
+    const { socket } = await createStartedSession();
 
+    expect(mocks.resolveDebuggerOrigin).toHaveBeenCalledWith({
+      host: 'localhost',
+      port: 8081,
+      appId: TARGET.appId,
+      webSocketDebuggerUrl: TARGET.webSocketDebuggerUrl,
+    });
     expect(socket.url).toBe(TARGET.webSocketDebuggerUrl);
     expect(socket.options).toEqual({
       headers: {
@@ -360,12 +382,12 @@ describe('agent session', () => {
     });
   });
 
-  it('preserves the debugger websocket host in the origin header', () => {
+  it('falls back to the debugger websocket host when Expo does not answer', async () => {
     const target = createTarget({
       webSocketDebuggerUrl: 'ws://127.0.0.1:8081/debug',
     });
 
-    const { socket } = createStartedSession({ target });
+    const { socket } = await createStartedSession({ target });
 
     expect(socket.url).toBe(target.webSocketDebuggerUrl);
     expect(socket.options).toEqual({
@@ -375,8 +397,24 @@ describe('agent session', () => {
     });
   });
 
+  it("uses Expo's origin even when it disagrees with the debugger websocket host", async () => {
+    // Expo terminates the socket after the upgrade unless the Origin host
+    // matches its own `serverBaseUrl`, which need not be the host the
+    // target URL was discovered through.
+    mocks.resolveDebuggerOrigin.mockResolvedValue('http://127.0.0.1:8081');
+
+    const { socket } = await createStartedSession();
+
+    expect(socket.url).toBe(TARGET.webSocketDebuggerUrl);
+    expect(socket.options).toEqual({
+      headers: {
+        Origin: 'http://127.0.0.1:8081',
+      },
+    });
+  });
+
   it('does not resolve start before the bootstrap delay elapses', async () => {
-    const { socket, startPromise } = createStartedSession();
+    const { socket, startPromise } = await createStartedSession();
     const onResolved = vi.fn();
     startPromise.then(onResolved);
 
@@ -396,7 +434,7 @@ describe('agent session', () => {
   });
 
   it('resolves start after bootstrap and plugin readiness settles', async () => {
-    const { startPromise, socket } = createStartedSession();
+    const { startPromise, socket } = await createStartedSession();
     const onResolved = vi.fn();
     startPromise.then(onResolved, () => undefined);
 
@@ -416,7 +454,7 @@ describe('agent session', () => {
   });
 
   it('extends plugin readiness wait when activity arrives', async () => {
-    const { startPromise, socket } = createStartedSession();
+    const { startPromise, socket } = await createStartedSession();
     const onResolved = vi.fn();
     startPromise.then(onResolved, () => undefined);
 
@@ -438,7 +476,7 @@ describe('agent session', () => {
   });
 
   it('starts built-in-only sessions without plugin registration', async () => {
-    const { startPromise, socket } = createStartedSession();
+    const { startPromise, socket } = await createStartedSession();
     const onResolved = vi.fn();
     startPromise.then(onResolved);
 
@@ -533,7 +571,7 @@ describe('agent session', () => {
 
   it('heals PAGE_NOT_FOUND before the initial socket opens', async () => {
     const replacementTarget = createTarget({ pageId: 'page-2' });
-    const { startPromise, socket } = createStartedSession({
+    const { startPromise, socket } = await createStartedSession({
       resolveTarget: vi.fn().mockResolvedValue(replacementTarget),
     });
     void startPromise.catch(() => undefined);
@@ -691,7 +729,7 @@ describe('agent session', () => {
   });
 
   it('rejects startup if the websocket closes before bootstrap completes', async () => {
-    const { socket, startPromise } = createStartedSession();
+    const { socket, startPromise } = await createStartedSession();
 
     socket.open();
     await flushMicrotasks();
@@ -816,7 +854,7 @@ describe('agent session', () => {
     });
 
     it('rejects sendTapMessage when the session is not connected', async () => {
-      const { session } = createStartedSession();
+      const { session } = await createStartedSession();
 
       await expect(
         session.sendTapMessage({ pluginId: 'plugin', type: 'type', payload: {} }),

--- a/packages/middleware/src/agent/debugger-origin.ts
+++ b/packages/middleware/src/agent/debugger-origin.ts
@@ -1,0 +1,132 @@
+import { request as httpRequest } from 'node:http';
+
+/**
+ * How long to wait for Expo's debugger endpoint before giving up and
+ * falling back. It is a request to the dev server we are already talking
+ * to, so anything slower than this means the endpoint is not there.
+ */
+const EXPO_DEBUGGER_TIMEOUT_MS = 2000;
+
+const formatHost = (host: string): string =>
+  host.includes(':') && !host.startsWith('[') ? `[${host}]` : host;
+
+/**
+ * The `Origin` a debugger WebSocket must present, derived from the URL it
+ * connects to.
+ *
+ * This is only ever right by coincidence for Expo (see
+ * `fetchExpoDebuggerOrigin`), because `/json/list` builds
+ * `webSocketDebuggerUrl` from the *requester's* `Host` header — ask it as
+ * `localhost` and it answers `localhost`, ask it as `127.0.0.1` and it
+ * answers `127.0.0.1`. It is still the right fallback: it preserves an
+ * explicitly configured remote or `wss:` dev server, and React Native's
+ * own middleware accepts any loopback spelling.
+ */
+export const getDebuggerWebSocketOrigin = (webSocketDebuggerUrl: string): string => {
+  const url = new URL(webSocketDebuggerUrl);
+  const protocol = url.protocol === 'wss:' ? 'https:' : 'http:';
+
+  return `${protocol}//${url.host}`;
+};
+
+type ExpoInspectorApp = {
+  webSocketDebuggerUrl?: unknown;
+};
+
+const requestExpoInspectorApp = (
+  host: string,
+  port: number,
+  appId: string,
+): Promise<ExpoInspectorApp | null> => {
+  const url = new URL(`http://${formatHost(host)}:${port}/_expo/debugger`);
+  url.searchParams.set('appId', appId);
+
+  return new Promise<ExpoInspectorApp | null>((resolve) => {
+    // Deliberately no `Origin` header: Expo guards this route with the
+    // same exact-host check it applies to the debugger socket, and that
+    // check passes a request with no `Origin` at all. Sending one would
+    // require already knowing the answer we are asking for.
+    const req = httpRequest(url, { method: 'GET' }, (res) => {
+      if (res.statusCode !== 200) {
+        res.resume();
+        resolve(null);
+        return;
+      }
+
+      let data = '';
+      res.setEncoding('utf8');
+      res.on('data', (chunk) => {
+        data += chunk;
+      });
+      res.on('end', () => {
+        try {
+          resolve(JSON.parse(data) as ExpoInspectorApp);
+        } catch {
+          resolve(null);
+        }
+      });
+    });
+
+    req.setTimeout(EXPO_DEBUGGER_TIMEOUT_MS, () => req.destroy());
+    req.once('error', () => resolve(null));
+    req.end();
+  });
+};
+
+/**
+ * The `Origin` Expo will accept for a debugger WebSocket, or `null` when
+ * the dev server is not Expo (or cannot answer).
+ *
+ * React Native's dev-middleware accepts any loopback spelling during the
+ * upgrade, but Expo adds a second check *after* it and terminates the
+ * socket unless the `Origin` host matches its own `serverBaseUrl`
+ * exactly. That host is environment-dependent — `127.0.0.1` normally,
+ * `REACT_NATIVE_PACKAGER_HOSTNAME` when set — so it cannot be guessed
+ * from the address we happen to be using.
+ *
+ * `/_expo/debugger` resolves its target by querying `/json/list` through
+ * `serverBaseUrl` itself, so the `webSocketDebuggerUrl` it returns always
+ * carries Expo's canonical host regardless of how this request is
+ * addressed. That makes it an authoritative answer rather than another
+ * guess.
+ *
+ * Used for the `Origin` only. The route reports a single app and filters
+ * to pages that support native reloads, so it is not a substitute for
+ * target discovery.
+ */
+export const fetchExpoDebuggerOrigin = async (
+  host: string,
+  port: number,
+  appId: string,
+): Promise<string | null> => {
+  if (!appId) {
+    return null;
+  }
+
+  const app = await requestExpoInspectorApp(host, port, appId);
+
+  if (!app || typeof app.webSocketDebuggerUrl !== 'string') {
+    return null;
+  }
+
+  try {
+    return getDebuggerWebSocketOrigin(app.webSocketDebuggerUrl);
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * The `Origin` to present when opening a debugger WebSocket: Expo's own
+ * answer when it has one, otherwise the origin implied by the target URL.
+ */
+export const resolveDebuggerOrigin = async (options: {
+  host: string;
+  port: number;
+  appId: string;
+  webSocketDebuggerUrl: string;
+}): Promise<string> => {
+  const expoOrigin = await fetchExpoDebuggerOrigin(options.host, options.port, options.appId);
+
+  return expoOrigin ?? getDebuggerWebSocketOrigin(options.webSocketDebuggerUrl);
+};

--- a/packages/middleware/src/agent/session.ts
+++ b/packages/middleware/src/agent/session.ts
@@ -28,6 +28,7 @@ import {
   createReactDomainService,
   type LocalAgentToolService,
 } from './local-domains.js';
+import { resolveDebuggerOrigin } from './debugger-origin.js';
 import { logger } from '../logger.js';
 
 type AgentMessageHandler = ReturnType<typeof createAgentMessageHandler>;
@@ -51,13 +52,6 @@ const DEVTOOLS_TOOK_CONNECTION_REASON = '[NEW_DEBUGGER_OPENED]';
 
 const getCloseReason = (reason: unknown): string =>
   Buffer.isBuffer(reason) ? reason.toString() : String(reason ?? '');
-
-const getDebuggerWebSocketOrigin = (webSocketDebuggerUrl: string): string => {
-  const url = new URL(webSocketDebuggerUrl);
-  const protocol = url.protocol === 'wss:' ? 'https:' : 'http:';
-
-  return `${protocol}//${url.host}`;
-};
 
 type PendingCommand = {
   /** Retained so a device error can name the method it refused. */
@@ -814,10 +808,17 @@ export const createAgentSession = (options: {
   const connect = async (generation = connectionGeneration): Promise<void> => {
     status = 'connecting';
 
+    const origin = await resolveDebuggerOrigin({
+      host: options.host,
+      port: options.port,
+      appId: target.appId,
+      webSocketDebuggerUrl: target.webSocketDebuggerUrl,
+    });
+
     await new Promise<void>((resolve, reject) => {
       const socket = new WebSocket(target.webSocketDebuggerUrl, {
         headers: {
-          Origin: getDebuggerWebSocketOrigin(target.webSocketDebuggerUrl),
+          Origin: origin,
         },
       });
       let settled = false;


### PR DESCRIPTION
## Description

Derives the debugger WebSocket `Origin` from Expo's own dev server instead of from the address the agent happened to reach it through.

- Add `fetchExpoDebuggerOrigin()`, which asks Expo for the origin it will accept, and returns `null` when the dev server cannot answer.
- Add `resolveDebuggerOrigin()`, which uses that answer when present and otherwise falls back to the origin implied by the target URL.
- Open the agent's CDP socket with the resolved origin.

## Related Issue

Closes https://github.com/callstackincubator/rozenite/issues/463

## Context

Rozenite derived the `Origin` from the `webSocketDebuggerUrl` returned by `/json/list`. React Native's dev-middleware builds that URL from the **requester's** `Host` header, so the value is a mirror of however the agent addressed the server — ask as `localhost` and it answers `localhost`, ask as `127.0.0.1` and it answers `127.0.0.1`:

```
/json/list  Host: 127.0.0.1  ->  ws://127.0.0.1:8099/inspector/debug?...
/json/list  Host: localhost  ->  ws://localhost:8099/inspector/debug?...
```

The two dev servers validate that header at different stages:

- **React Native** checks it during the WebSocket upgrade. A missing `Origin` is rejected with HTTP 401; otherwise any of `localhost`, `127.0.0.1`, `0.0.0.0`, `[::]` is accepted, as is an exact match with `serverBaseUrl`.
- **Expo** adds a second, exact-host check *after* the upgrade and terminates a mismatch, which the client sees as close code 1006 even though the socket emitted `open`.

Expo's expected host is environment-dependent: `127.0.0.1` normally, because its URL creator normalizes the localhost host type, and `REACT_NATIVE_PACKAGER_HOSTNAME` when that is set. Intersecting the two checks leaves exactly one acceptable value — `serverBaseUrl.origin` — so it cannot be guessed from the address in hand, and a candidate list of loopback spellings cannot cover a custom `REACT_NATIVE_PACKAGER_HOSTNAME`.

`/_expo/debugger` answers the question directly. It resolves its target by querying `/json/list` through `serverBaseUrl` itself, so the debugger URL it returns carries Expo's canonical host regardless of how the request is addressed:

```
/_expo/debugger  Host: 127.0.0.1  ->  ws://localhost:8100/inspector/debug?...
/_expo/debugger  Host: localhost  ->  ws://localhost:8100/inspector/debug?...
```

The request deliberately sends no `Origin` header, which is what passes Expo's guard on that route — its origin check treats an absent header as trusted, and sending one would require already knowing the answer being asked for.

This keeps the connection deterministic on the first attempt. There is no retry, so a failure that is not about the origin — `[PAGE_NOT_FOUND]`, `[CONNECTION_LOST]`, `[NEW_DEBUGGER_OPENED]` — still reaches the existing close-reason handling untouched, and no doomed attempt takes over and drops a debugger connection the user already has open.

When the route is absent, as on a bare React Native dev server, resolution falls back to the origin implied by the target URL. React Native accepts that unconditionally for loopback, and it preserves an explicitly configured remote or `wss:` host.

## Testing

- `pnpm checks:affected` — 70/70 tasks, formatting clean
- `pnpm test:affected` — 34/34 tasks
- `pnpm --filter @rozenite/middleware exec vitest --run src/__tests__/agent-debugger-origin.test.ts` — 17 tests passed, driven against a real `node:http` server, including an assertion that the request carries no `Origin` header
- `pnpm --filter @rozenite/middleware exec vitest --run src/__tests__/agent-session.test.ts` — 27 tests passed

Verified against two live Expo dev servers started from `apps/playground`, each with a synthetic inspector target registered:

| dev server | discovered target URL | resolved origin | result |
| --- | --- | --- | --- |
| default | `ws://127.0.0.1:8099/...` | `http://127.0.0.1:8099` | connected |
| `REACT_NATIVE_PACKAGER_HOSTNAME=localhost` | `ws://127.0.0.1:8100/...` | `http://localhost:8100` | connected |

In the second case the discovered URL and the accepted origin disagree, which is the failure this fixes; connecting with `http://127.0.0.1:8100` there is terminated with 1006, and with `http://localhost:8099` on the first server likewise.
