### PR TITLE
fix(middleware): let a capability-filtered domain decline tools it does not own

### DIFF
--- a/.changeset/agent-capability-filter-probe.md
+++ b/.changeset/agent-capability-filter-probe.md
@@ -1,0 +1,5 @@
+---
+'@rozenite/middleware': patch
+---
+
+Fix Rozenite for Agents failing every tool call on Lynx targets. A capability-filtered domain answered for tools it did not own, which aborted the dispatch walk on its first step and reported the React domain's reason whatever domain was asked for.

--- a/packages/middleware/src/__tests__/agent-capabilities.test.ts
+++ b/packages/middleware/src/__tests__/agent-capabilities.test.ts
@@ -9,6 +9,7 @@ import { UnsupportedToolError, withCapabilityFilter } from '../agent/capability-
 import {
   createMemoryDomainService,
   createNetworkDomainService,
+  createReactDomainService,
   type LocalAgentToolService,
 } from '../agent/local-domains.js';
 
@@ -39,6 +40,30 @@ const createNetworkService = (): LocalAgentToolService =>
     sendCommand: async () => ({}),
     subscribeToCDPEvent: () => () => {},
   });
+
+const createReactService = (): LocalAgentToolService =>
+  createReactDomainService({
+    sessionId: 's',
+    sendReactDevToolsMessage: () => {},
+  });
+
+/**
+ * The dispatch `session.ts` performs: offer the call to each service in
+ * turn and take the first answer that is not `undefined`.
+ */
+const dispatch = async (
+  services: LocalAgentToolService[],
+  toolName: string,
+): Promise<unknown | undefined> => {
+  for (const service of services) {
+    const result = await service.callTool(toolName, {});
+    if (result !== undefined) {
+      return result;
+    }
+  }
+
+  return undefined;
+};
 
 describe('capability profiles', () => {
   it('leaves React Native declaring no gaps', () => {
@@ -140,5 +165,29 @@ describe('capability filtering', () => {
     const service = createNetworkService();
 
     expect(withCapabilityFilter(service, REACT_NATIVE_PROFILE)).toBe(service);
+  });
+
+  // A wrapped service is still asked about tools belonging to other
+  // domains, because that is how the session finds the owner. Answering
+  // anything but `undefined` there claims a tool it does not own.
+  it('declines a tool it does not declare instead of claiming it', async () => {
+    const filtered = withCapabilityFilter(createReactService(), LYNX_PROFILE);
+
+    await expect(filtered.callTool('takeHeapSnapshot', {})).resolves.toBeUndefined();
+  });
+
+  // The regression this guards: React is first in `localServices`, and on
+  // Lynx it keeps no tools at all. A wrapper that threw for every unknown
+  // name aborted the walk on its first step, so every call on a Lynx
+  // target failed -- reporting React's reason whatever domain was asked
+  // for.
+  it('lets the dispatch walk reach a later service on a fully unsupported first domain', async () => {
+    const services = [
+      withCapabilityFilter(createReactService(), LYNX_PROFILE),
+      withCapabilityFilter(createMemoryService(), LYNX_PROFILE),
+    ];
+
+    expect(services[0].getTools()).toEqual([]);
+    await expect(dispatch(services, 'startSampling')).rejects.toThrow(/PrimJS/);
   });
 });

--- a/packages/middleware/src/agent/capability-filter.ts
+++ b/packages/middleware/src/agent/capability-filter.ts
@@ -42,6 +42,8 @@ export const withCapabilityFilter = (
     return service;
   }
 
+  const declared = new Set(declaredTools.map((tool) => tool.name));
+
   return {
     ...service,
     getTools: () => service.getTools().filter((tool) => allowed.has(tool.name)),
@@ -49,6 +51,19 @@ export const withCapabilityFilter = (
     // is also reachable by exact tool name from the call-tool route, so
     // it needs the same guard rather than trusting the listing.
     callTool: async (toolName, args) => {
+      // The session dispatches a call by offering it to every local
+      // service in turn and taking the first one that does not answer
+      // `undefined` (see `localServices` in `session.ts`). Returning
+      // `undefined` is how a service says "not mine"; throwing is how it
+      // says "mine, and you cannot have it". A wrapper that threw for
+      // every unknown name would answer for tools it does not own and
+      // abort that walk on its first step -- and because the React
+      // domain is first in the list, an integration that loses React
+      // entirely (Lynx) would fail every call, whatever its domain.
+      if (!declared.has(toolName)) {
+        return undefined;
+      }
+
       if (!allowed.has(toolName)) {
         throw new UnsupportedToolError(profile, service.domainId, toolName);
       }


### PR DESCRIPTION
## Description

Fixes Rozenite for Agents failing **every** tool call on a Lynx target.

`session.ts` dispatches a tool call by offering it to each local service in turn and taking the first answer that is not `undefined` — returning `undefined` is how a service says "not mine, keep looking":

```js
for (const service of localServices) {
  const result = await service.callTool(toolName, args);
  if (result !== undefined) { return result; }
}
const result = await handler.callTool(toolName, args);   // plugin tools land here, last
```

`withCapabilityFilter` threw for every name outside its allowed set, including names the wrapped service does not own, so it answered for other domains' tools and aborted that walk on its first step. The React domain is first in `localServices` and keeps no tools at all on Lynx, so its wrapper threw for everything.

The filter now declines an undeclared tool with `undefined` and keeps throwing only for a tool it owns but cannot run.

## Related Issue

None — reported and diagnosed during release verification of the current `main`, and opened directly at the maintainer's request.

## Context

Introduced by #448. React Native is unaffected and always was: with the empty React Native profile, `allowed.size === declaredTools.length` for every service, so `withCapabilityFilter` returns each service unwrapped and no guard ever runs. That is also why the existing tests miss it — the only `callTool` case passes `startSampling`, a tool the memory service owns, so nothing ever exercised a wrapper with a foreign tool name.

The observable symptom was confusing in a specific way: `network`, `performance` and `react` appeared to behave correctly, because those are refused earlier and client-side by `applyCapabilities` in `@rozenite/agent-sdk`, before any HTTP request. Everything else passed the client gate, reached the server, and died on React's wrapper — so `console`, `memory.takeHeapSnapshot` and every plugin domain were refused while `rozenite agent domains` reported them `supported` and `list-tools` listed them. `packages/cli/docs/lynx.md`, added in #448, documents all three as supported.

Two regression tests are added: one asserting a wrapped service returns `undefined` for a tool it does not declare, and one that reproduces the dispatch walk across a fully-unsupported first domain. Both fail without the change.

## Testing

Automated:

- `pnpm --filter @rozenite/middleware test` — 200 passed
- Both new tests confirmed failing with the fix reverted, passing with it applied
- `pnpm checks:affected` and `pnpm test:affected` — green

Manual, on the running iPhone 17 Pro simulator with a Lynx app in LynxExplorer and an `@rozenite/lynx-dev` dev server, comparing the same session before and after:

| Call | Before | After |
| --- | --- | --- |
| `console.getMessages` | refused with React's reason | returns device logs |
| `controls.list-sections` | refused with React's reason | returns the section tree |
| `feature-flags.list-flags` | refused with React's reason | returns the flags |
| `memory.takeHeapSnapshot` | refused with React's reason | writes a `.heapsnapshot` artifact |
| `network.listRequests` | refused | still refused, with its own reason and fallback |

React Native re-checked on the same simulator: `console.getMessages` and `@rozenite/controls-plugin.list-sections` both return real data, unchanged.
