### PR TITLE
fix(website): guard welcome screen effects against static generation

### DIFF
--- a/website/src/welcome.tsx
+++ b/website/src/welcome.tsx
@@ -9,13 +9,26 @@ export const frontmatter = {
 export default function Welcome() {
   const [withPluginsInstalled, setWithPluginsInstalled] = useState(false);
 
+  // Rspress renders this page during static generation, and its markdown SSG
+  // entry flushes passive effects on the server -- where neither `window` nor
+  // `document` exists. Without these guards the build throws
+  // "Reconciler Error: window is not defined", and the rendering process then
+  // never exits, so the build hangs rather than failing.
   useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
     const withPluginsInstalled =
       new URLSearchParams(window.location.search).get('withPluginsInstalled') === 'true';
     setWithPluginsInstalled(withPluginsInstalled);
   }, []);
 
   useEffect(() => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+
     // Make sure links open in a new tab
     document.querySelectorAll('a').forEach((linkElement) => {
       linkElement.target = '_blank';


### PR DESCRIPTION
## Description

Guards the welcome screen's two effects against static generation. Rspress renders this page during SSG, and its markdown SSG entry flushes passive effects on the server, where neither `window` nor `document` exists:

```
Error: Reconciler Error:window is not defined
  at Welcome (website/build/__ssg_md__/src_welcome_tsx.cjs:40:79)
  at flushPassiveEffects (.../rspress-ssg-md-entry.cjs:12421:13)
```

The `web` environment then fails, and the rendering process **never exits** — it sits in `ep_poll` indefinitely, so `rspress build` hangs instead of failing.

## Related Issue

None — found while investigating a CI hang, and opened directly at the maintainer's request.

## Context

This is pre-existing on `main` and unrelated to any recent change; `welcome.tsx` last changed in #377 (the oxfmt migration). It goes unnoticed because `@rozenite/docs:build` effectively never runs in CI: `ci.yml` has `paths-ignore: website/**`, so a website-only change does not trigger CI at all, and the task is absent from recent `main` and pull-request runs.

It surfaces only when something pulls the whole workspace into Turborepo's `--affected` set — for example any change to `pnpm-lock.yaml`. When that happens the hang is close to invisible: `turbo.json` sets `build` to `outputLogs: "errors-only"`, so the stuck task prints nothing, and the last task visible in the log is an unrelated one that merely finished last. The job has no `timeout-minutes`, so it runs to GitHub's default rather than failing fast. One such run sat for 94 minutes before being cancelled.

It reproduces only on the Linux runner. The same build passes locally on macOS under both Node 22.20.0 and Node 24, so this is timing-sensitive rather than version-gated — which is why a guard is the right fix rather than chasing the scheduling difference.

Two follow-ups are worth considering separately, and are deliberately not bundled here: adding `timeout-minutes` to the Validate job so a hang fails fast, and deciding whether `@rozenite/docs` belongs in CI's affected set at all given `paths-ignore` already excludes it.

## Testing

Because this touches only `website/**`, `paths-ignore` means CI does not run on this pull request. It was verified by dispatching the isolated website build on a scratch branch, on the same runner image, with and without the change:

| Branch | `rspress build` exit | Result |
| --- | --- | --- |
| Unmodified `main` | `1` | `Reconciler Error: window is not defined` |
| With this change | `0` | builds, sitemap generated for 38 pages |

Locally: `pnpm turbo run lint typecheck --filter=@rozenite/docs` passes, `pnpm format:all` clean, and `pnpm exec rspress build` exits `0`.
