### PR TITLE
fix(playground): use the rozenite:// scheme for deep links

### DIFF
--- a/apps/playground/src/app/App.tsx
+++ b/apps/playground/src/app/App.tsx
@@ -133,7 +133,10 @@ const Wrapper = () => {
 };
 
 const linking = {
-  prefixes: ['playground://'],
+  // Must match `expo.scheme` in app.json. Deliberately not `playground://`:
+  // that scheme is registered by an unrelated app, so iOS routes those links
+  // elsewhere and they never reach this app at all.
+  prefixes: ['rozenite://'],
   config: {
     screens: {
       [routes.home.name]: routes.home.path,

--- a/apps/playground/src/app/navigation/routes.ts
+++ b/apps/playground/src/app/navigation/routes.ts
@@ -14,7 +14,7 @@ export type RouteGroup =
 
 export type RouteDef = {
   name: string;
-  /** Path segment under the `playground://` deep-link prefix. */
+  /** Path segment under the `rozenite://` deep-link prefix. */
   path: string;
   title: string;
   accessibilityLabel: string;

--- a/docs/agents/playground-testing.md
+++ b/docs/agents/playground-testing.md
@@ -10,30 +10,36 @@
 
 ## Navigate by deep link
 
-Use `playground://<path>` with `agent-device` (`open_url`) or `xcrun simctl
-openurl booted "playground://<path>"`. Every screen is reachable this way —
+Use `rozenite://<path>` with `agent-device` (`open_url`) or `xcrun simctl
+openurl booted "rozenite://<path>"`. Every screen is reachable this way —
 see `apps/playground/src/app/navigation/routes.ts` for the source of truth.
+
+The scheme is `rozenite://`, matching `expo.scheme` in `app.json`. Do not use
+`playground://`: that scheme is registered by an unrelated app that is commonly
+installed on the same simulator, so iOS routes those links to it instead. If a
+deep link appears to open the wrong app, confirm the bundle id under test is
+`com.callstackcincubator.rozenite`.
 
 | Route | Deep link | Title |
 | --- | --- | --- |
-| Home | `playground://` | Rozenite Playground |
-| ControlsPlugin | `playground://controls` | Controls |
-| ReduxTest | `playground://redux` | Redux |
-| StoragePlugin | `playground://storage` | Storage |
-| FeatureFlagsPlugin | `playground://feature-flags` | Feature Flags |
-| FileSystemTest | `playground://file-system` | File System |
-| NetworkTest | `playground://network` | Network Activity |
-| RequestBodyTest | `playground://network/request-body` | Request Body |
-| PerformanceMonitor | `playground://performance/monitor` | Performance Monitor |
-| RequireProfilerTest | `playground://performance/require-profiler` | Require Profiler |
-| PerfProblem | `playground://performance/perf-problem` | Perf Problem |
-| ReactHookFormPlugin | `playground://forms` | React Hook Form |
-| BottomTabs (Home tab) | `playground://navigation` | React Navigation Demo |
-| BottomTabs (Profile tab) | `playground://navigation/profile` | React Navigation Demo |
-| BottomTabs (Settings tab) | `playground://navigation/tab-settings` | React Navigation Demo |
-| ParameterDisplay | `playground://navigation/parameter-display` | Parameter Display |
-| SuccessiveScreensStack | `playground://navigation/successive` | Successive Screens |
-| Settings | `playground://settings` | Settings |
+| Home | `rozenite://` | Rozenite Playground |
+| ControlsPlugin | `rozenite://controls` | Controls |
+| ReduxTest | `rozenite://redux` | Redux |
+| StoragePlugin | `rozenite://storage` | Storage |
+| FeatureFlagsPlugin | `rozenite://feature-flags` | Feature Flags |
+| FileSystemTest | `rozenite://file-system` | File System |
+| NetworkTest | `rozenite://network` | Network Activity |
+| RequestBodyTest | `rozenite://network/request-body` | Request Body |
+| PerformanceMonitor | `rozenite://performance/monitor` | Performance Monitor |
+| RequireProfilerTest | `rozenite://performance/require-profiler` | Require Profiler |
+| PerfProblem | `rozenite://performance/perf-problem` | Perf Problem |
+| ReactHookFormPlugin | `rozenite://forms` | React Hook Form |
+| BottomTabs (Home tab) | `rozenite://navigation` | React Navigation Demo |
+| BottomTabs (Profile tab) | `rozenite://navigation/profile` | React Navigation Demo |
+| BottomTabs (Settings tab) | `rozenite://navigation/tab-settings` | React Navigation Demo |
+| ParameterDisplay | `rozenite://navigation/parameter-display` | Parameter Display |
+| SuccessiveScreensStack | `rozenite://navigation/successive` | Successive Screens |
+| Settings | `rozenite://settings` | Settings |
 
 ## Navigate by semantics
 


### PR DESCRIPTION
## Description

Points the playground's React Navigation linking prefix at `rozenite://`, the scheme the app actually registers, so deep links work.

- `apps/playground/src/app/App.tsx` — `prefixes: ['playground://']` → `['rozenite://']`, with a comment explaining why the old value must not come back.
- `apps/playground/src/app/navigation/routes.ts` — corrects the stale `playground://` reference in the `path` field's doc comment.
- `docs/agents/playground-testing.md` — every deep link in the prose and both route tables, plus a note on the colliding scheme and how to confirm which app is under test.

## Related Issue

Closes https://github.com/callstackincubator/rozenite/issues/474

## Context

`app.json` sets `"scheme": "rozenite"` while the linking config expected `playground://`. Nothing matched, so no deep link worked in either direction.

The `playground://` half is the more damaging one, because it fails loudly in a misleading place. That scheme is registered by an unrelated app — `com.aitwar.playground`, display name "Cordierite" — which is commonly installed on the same simulator, so iOS hands the link to it. Cordierite then attaches to whatever Metro is on port 8081, which is the playground's, fails to load a bundle built for a different app with `[runtime not ready]: ReferenceError: Property 'MessageQueue' doesn't exist`, and registers a phantom second device in `npx rozenite agent targets` whose sessions fail with "CDP connection closed before bootstrap completed". An agent following the testing guide sees a crashed app and a broken session, with nothing pointing at the deep link as the cause.

I did not keep `playground://` alongside the new prefix. Listing a scheme another installed app owns cannot work — iOS resolves the URL before the app is involved — so it would only preserve the confusion.

The docs note is deliberately about diagnosis rather than the rule alone: it names the bundle id to check when a deep link appears to open the wrong app, since that is the symptom that is hard to attribute.

`apps/playground` is in `.changeset/config.json`'s ignore list and the rest is documentation, so no version plan is needed.

## Testing

- `pnpm checks:affected` — typecheck, lint and format pass.
- `pnpm release:plan` — confirms no version plan is required for these paths.

Verified live on an iPhone 17 Pro simulator, with the playground running from this branch:

- `xcrun simctl openurl booted "rozenite://performance/perf-problem"` now navigates to the Perf Problem screen (confirmed by screenshot showing the "Heavy item N" rows). Before the change, the same command left the app on its current screen.
