### PR TITLE
feat(middleware): report commit cost beyond render time in getProfileTimeline

### DIFF
--- a/.changeset/profile-timeline-commit-cost.md
+++ b/.changeset/profile-timeline-commit-cost.md
@@ -1,0 +1,5 @@
+---
+'@rozenite/middleware': patch
+---
+
+Expose commit cost beyond render time in the React agent `getProfileTimeline` tool. Each commit can now report `effectDurationMs`, `passiveEffectDurationMs`, `priorityLevel`, `updaterCount` and `hasChangeDescriptions`, so a commit that renders quickly but commits slowly is visible without a separate call.

--- a/packages/cli/docs/react.md
+++ b/packages/cli/docs/react.md
@@ -46,6 +46,12 @@ Drill down:
 `getProfileTimeline` lists every commit with its duration, and `getRenderData`
 opens one of them fiber by fiber.
 
+`getProfileTimeline` rows carry render duration and rendered-fiber count by
+default. Add `--fields ...,effectDurationMs,passiveEffectDurationMs` to see
+commits that render fast but commit slowly, `priorityLevel` and `updaterCount`
+for how an update was scheduled and how many fibers scheduled it, and
+`hasChangeDescriptions` to tell whether `getRenderData` can explain that commit.
+
 `getRenderData` and `getComponentRenders` rows carry `displayName` and timing by
 default. Add `--fields ...,changedKeys` for the exact changed prop, state, and
 context key names behind `changeTypeHints`, which attributes a re-render without

--- a/packages/middleware/src/agent/local-domains.ts
+++ b/packages/middleware/src/agent/local-domains.ts
@@ -1203,7 +1203,9 @@ export const createReactDomainService = (deps: {
       description:
         'List every commit in the captured profiling session with its duration and how many ' +
         'fibers rendered, chronologically or slowest first. Use it to pick a commitIndex for ' +
-        'getRenderData; unlike stopProfiling it stays queryable and pages through all commits.',
+        'getRenderData; unlike stopProfiling it stays queryable and pages through all commits. ' +
+        'Request the effectDurationMs, passiveEffectDurationMs, priorityLevel, updaterCount and ' +
+        'hasChangeDescriptions fields to see commit cost beyond render time.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -1229,6 +1231,11 @@ export const createReactDomainService = (deps: {
           'timestampMs',
           'renderedFiberCount',
           'isSlow',
+          'effectDurationMs',
+          'passiveEffectDurationMs',
+          'priorityLevel',
+          'updaterCount',
+          'hasChangeDescriptions',
         ],
         defaultFields: ['rootId', 'commitIndex', 'durationMs', 'renderedFiberCount', 'isSlow'],
       }),

--- a/packages/middleware/src/agent/runtime/react/__tests__/store-profile-reports.test.ts
+++ b/packages/middleware/src/agent/runtime/react/__tests__/store-profile-reports.test.ts
@@ -216,6 +216,11 @@ describe('React getProfileTimeline', () => {
         timestampMs: 100,
         renderedFiberCount: 2,
         isSlow: false,
+        effectDurationMs: null,
+        passiveEffectDurationMs: null,
+        priorityLevel: null,
+        updaterCount: 0,
+        hasChangeDescriptions: true,
       },
       {
         rootId: 1,
@@ -224,6 +229,11 @@ describe('React getProfileTimeline', () => {
         timestampMs: 200,
         renderedFiberCount: 2,
         isSlow: true,
+        effectDurationMs: null,
+        passiveEffectDurationMs: null,
+        priorityLevel: null,
+        updaterCount: 0,
+        hasChangeDescriptions: true,
       },
       {
         rootId: 1,
@@ -232,6 +242,11 @@ describe('React getProfileTimeline', () => {
         timestampMs: 300,
         renderedFiberCount: 1,
         isSlow: false,
+        effectDurationMs: null,
+        passiveEffectDurationMs: null,
+        priorityLevel: null,
+        updaterCount: 0,
+        hasChangeDescriptions: true,
       },
       {
         rootId: 2,
@@ -240,6 +255,11 @@ describe('React getProfileTimeline', () => {
         timestampMs: 400,
         renderedFiberCount: 1,
         isSlow: false,
+        effectDurationMs: null,
+        passiveEffectDurationMs: null,
+        priorityLevel: null,
+        updaterCount: 0,
+        hasChangeDescriptions: false,
       },
     ]);
     expect(result.summary).toEqual({
@@ -249,6 +269,50 @@ describe('React getProfileTimeline', () => {
       slowCommitCount: 1,
       slowRenderThresholdMs: 16,
     });
+  });
+
+  it('reports commit cost beyond render time', async () => {
+    const store = createStore(
+      new Map([
+        [
+          1,
+          {
+            commitData: [
+              createCommit({
+                duration: 4,
+                timestamp: 100,
+                effectDuration: 21,
+                passiveEffectDuration: 9.5,
+                priorityLevel: 'Normal',
+                updaters: [{ id: 2 }, { id: 3 }],
+                fiberActualDurations: new Map([[2, 4]]),
+                fiberSelfDurations: new Map([[2, 4]]),
+              }),
+            ],
+          },
+        ],
+      ]),
+    );
+
+    const result = await store.getProfileTimeline(DEVICE_ID, {});
+
+    // A commit that renders in 4ms but spends 21ms in layout effects is not
+    // slow by render duration, and only these fields say so.
+    expect(result.items).toEqual([
+      {
+        rootId: 1,
+        commitIndex: 0,
+        durationMs: 4,
+        timestampMs: 100,
+        renderedFiberCount: 1,
+        isSlow: false,
+        effectDurationMs: 21,
+        passiveEffectDurationMs: 9.5,
+        priorityLevel: 'Normal',
+        updaterCount: 2,
+        hasChangeDescriptions: false,
+      },
+    ]);
   });
 
   it('sorts by duration and paginates', async () => {

--- a/packages/middleware/src/agent/runtime/react/store.ts
+++ b/packages/middleware/src/agent/runtime/react/store.ts
@@ -1733,6 +1733,11 @@ export const createReactTreeStore = (options?: {
         timestampMs: commit.timestamp,
         renderedFiberCount: commit.fiberActualDurations.size,
         isSlow: commit.duration > slowRenderThresholdMs,
+        effectDurationMs: commit.effectDuration,
+        passiveEffectDurationMs: commit.passiveEffectDuration,
+        priorityLevel: commit.priorityLevel,
+        updaterCount: commit.updaters?.length ?? 0,
+        hasChangeDescriptions: commit.changeDescriptions !== null,
       }),
     );
 

--- a/packages/middleware/src/agent/runtime/react/types.ts
+++ b/packages/middleware/src/agent/runtime/react/types.ts
@@ -239,6 +239,20 @@ export interface ReactProfileTimelineItem {
   timestampMs: number;
   renderedFiberCount: number;
   isSlow: boolean;
+  /**
+   * Time spent in layout effects for this commit, and in passive effects
+   * flushed after it. React only measures these when the renderer supports it,
+   * so both are null rather than 0 when the backend did not report them — a
+   * commit that is quick to render can still be slow to commit.
+   */
+  effectDurationMs: number | null;
+  passiveEffectDurationMs: number | null;
+  /** React scheduler priority for the commit, when the backend reports one. */
+  priorityLevel: string | null;
+  /** How many fibers scheduled the update that produced this commit. */
+  updaterCount: number;
+  /** Whether getRenderData can explain why fibers rendered in this commit. */
+  hasChangeDescriptions: boolean;
 }
 
 export interface ReactGetProfileTimelineResult {


### PR DESCRIPTION
## Description

Adds five commit-cost fields to the React agent `getProfileTimeline` tool, as optional pagination fields:

- `effectDurationMs` and `passiveEffectDurationMs` — time spent in layout effects for the commit, and in passive effects flushed after it
- `priorityLevel` — the React scheduler priority for the commit
- `updaterCount` — how many fibers scheduled the update that produced it
- `hasChangeDescriptions` — whether `getRenderData` can explain why fibers rendered in that commit

All five are already normalized and retained by `profiling-store.ts`; they were simply never surfaced. `defaultFields` is unchanged, so default responses do not grow — the fields are opt-in via `--fields` (or `--verbose`).

## Related Issue

Closes https://github.com/callstackincubator/rozenite/issues/462

## Context

This supersedes https://github.com/callstackincubator/rozenite/pull/464, which proposed the same underlying data as an unbounded `commits: ReactCommitSummary[]` array inline in the `stopProfiling` result. `getProfileTimeline` already covers that issue's stated purpose — the complete chronological timeline, with deterministic root/commit ordering — and does it with cursor pagination, `rootId` filtering, `timeline`/`duration-desc` sorting, and without expiring when `stopProfiling` returns. An unbounded array inline in a tool result is the shape cursor pagination exists to avoid, so the remaining gap was the five fields, not the delivery mechanism. #464 can be closed in favour of this.

Render duration alone hides a real class of problem: a commit can be quick to render and slow to commit. Commit 0 in the manual run below renders in 34.59ms but also spends 1.775ms in layout effects and 0.953ms in passive effects — invisible before this change.

`effectDurationMs` and `passiveEffectDurationMs` stay `null` rather than `0` when the renderer did not measure them, so "not reported" is distinguishable from "took no time".

## Testing

Automated:

- Added `React getProfileTimeline > reports commit cost beyond render time` to `store-profile-reports.test.ts`, covering a commit that renders in 4ms while spending 21ms in layout effects — the case only these fields reveal. Updated the existing chronological-listing expectation for the new fields.
- `pnpm checks:affected` — 90 tasks successful.
- `pnpm test:affected` — 51 tasks successful.

Manual, on the running iPhone 17 Pro simulator with the playground, driving a navigation round trip with `agent-device` between `startProfiling` and `stopProfiling`:

- Default fields unchanged: `"cols":["rootId","commitIndex","durationMs","renderedFiberCount","isSlow"]`.
- Requesting the new fields returns real backend data:
  `"cols":["rootId","commitIndex","durationMs","effectDurationMs","passiveEffectDurationMs","priorityLevel","updaterCount","hasChangeDescriptions"]`,
  `"rows":[[1,0,34.59,1.775,0.953,"Immediate",1,true],[1,1,1.53,0.231,0.015,"Immediate",1,true],[1,2,0.331,0,0,"Immediate",1,true],[1,3,4.525,1.466,0.395,"Immediate",1,true]]`.
