### PR TITLE
feat(cli): scan every integration's default port in `rozenite open`

### DIFF
--- a/.changeset/open-scans-lynx-dev-server.md
+++ b/.changeset/open-scans-lynx-dev-server.md
@@ -1,0 +1,10 @@
+---
+'rozenite': minor
+---
+
+`rozenite open` now finds Lynx devices too. Without `--port`, it queries the
+default port of every supported integration — Metro's `8081` and the Lynx dev
+server's `3000` — and offers everything it finds in one picker, labelling each
+target with the integration it belongs to. A port that is not listening is
+skipped, and the selected target is opened on the dev server it was found on.
+Passing `--port` still queries that one port only.

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -35,14 +35,16 @@ with the `rozenite` CLI's `open` command.
 
 ## Usage
 
-Start Metro (`rozenite open` needs a running dev server to talk to), then
-run:
+Start your dev server (`rozenite open` needs a running one to talk to),
+then run:
 
 ```bash
 npx rozenite open
 ```
 
-This lists the devices currently connected to Metro and opens this app,
+This looks at the default port of every supported integration — Metro's
+`8081` and the Lynx dev server's `3000` — lists the devices connected to
+whichever is running, labelled by integration, and opens this app,
 in an Electron window (via `@rozenite/electron-app`) for the one you
 pick, or your default browser if Electron isn't available.
 

--- a/packages/cli/src/__tests__/open-command.test.ts
+++ b/packages/cli/src/__tests__/open-command.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { MetroTarget } from '@rozenite/agent-shared';
+import type { OpenTarget } from '../commands/dev-servers.js';
 
 const mocks = vi.hoisted(() => ({
   isInteractive: vi.fn(),
@@ -45,7 +45,7 @@ const { openCommand, selectTargetById, NON_INTERACTIVE_MESSAGE } =
   await import('../commands/open-command.js');
 const { logger } = await import('../utils/logger.js');
 
-const targetA: MetroTarget = {
+const targetA: OpenTarget = {
   id: 'device-a',
   deviceId: 'device-a',
   name: 'iPhone 15',
@@ -54,9 +54,10 @@ const targetA: MetroTarget = {
   title: 'A',
   description: '',
   webSocketDebuggerUrl: 'ws://localhost:8081/inspector/debug?device=device-a&page=1',
+  port: 8081,
 };
 
-const targetB: MetroTarget = {
+const targetB: OpenTarget = {
   id: 'device-b',
   deviceId: 'device-b',
   name: 'Pixel 8',
@@ -65,6 +66,19 @@ const targetB: MetroTarget = {
   title: 'B',
   description: '',
   webSocketDebuggerUrl: 'ws://localhost:8081/inspector/debug?device=device-b&page=1',
+  port: 8081,
+};
+
+const lynxTarget: OpenTarget = {
+  id: 'device-lynx-1',
+  deviceId: 'device-lynx',
+  name: 'iPhone',
+  appId: 'LynxExplorer',
+  pageId: 'device-lynx-1',
+  title: 'http://localhost:3000/main.lynx.bundle?fullscreen=true',
+  description: '',
+  webSocketDebuggerUrl: 'ws://localhost:3000/inspector/debug?device=device-lynx&page=1',
+  port: 3000,
 };
 
 afterEach(() => {
@@ -101,6 +115,107 @@ describe('openCommand non-interactive refusal', () => {
 
     expect(process.exitCode).toBe(1);
     expect(mocks.getMetroTargets).not.toHaveBeenCalled();
+  });
+});
+
+describe('openCommand dev server discovery', () => {
+  const byPort = (targetsByPort: Record<number, OpenTarget[] | Error>) => {
+    return async (_host: string, port: number) => {
+      const result = targetsByPort[port] ?? [];
+
+      if (result instanceof Error) {
+        throw result;
+      }
+
+      return result;
+    };
+  };
+
+  it('scans both default ports when no --port is given, labelling each by integration', async () => {
+    mocks.isInteractive.mockReturnValue(true);
+    mocks.getMetroTargets.mockImplementation(byPort({ 8081: [targetA], 3000: [lynxTarget] }));
+    mocks.promptSelect.mockImplementation(
+      async ({ options }: { options: { value: OpenTarget }[] }) => options[1].value,
+    );
+    mocks.childProcessSpawn.mockReturnValue({ unref: vi.fn() });
+
+    await openCommand({ host: '127.0.0.1' });
+
+    expect(mocks.getMetroTargets).toHaveBeenCalledWith('127.0.0.1', 8081);
+    expect(mocks.getMetroTargets).toHaveBeenCalledWith('127.0.0.1', 3000);
+    expect(mocks.promptSelect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: [
+          expect.objectContaining({ label: 'React Native · iPhone 15 (com.example.a) — A' }),
+          expect.objectContaining({ label: 'Lynx · iPhone (LynxExplorer) — main.lynx.bundle' }),
+        ],
+      }),
+    );
+  });
+
+  it('opens the picked target on the port it was found on', async () => {
+    mocks.isInteractive.mockReturnValue(true);
+    mocks.getMetroTargets.mockImplementation(byPort({ 8081: [targetA], 3000: [lynxTarget] }));
+    mocks.childProcessSpawn.mockReturnValue({ unref: vi.fn() });
+
+    await openCommand({ host: '127.0.0.1', deviceId: 'device-lynx-1' });
+
+    expect(mocks.childProcessSpawn).toHaveBeenCalledWith(
+      process.execPath,
+      [expect.any(String), expect.stringContaining('http://127.0.0.1:3000/rozenite/app/')],
+      expect.objectContaining({ detached: true }),
+    );
+  });
+
+  // The common case: nobody runs Metro and a Lynx dev server at once, so
+  // one of the two default ports always refuses the connection.
+  it('ignores a default port that is not listening when the other one answers', async () => {
+    mocks.isInteractive.mockReturnValue(true);
+    mocks.getMetroTargets.mockImplementation(
+      byPort({
+        8081: new Error('Unable to reach Metro at http://127.0.0.1:8081/json/list.'),
+        3000: [lynxTarget],
+      }),
+    );
+    mocks.childProcessSpawn.mockReturnValue({ unref: vi.fn() });
+
+    await openCommand({ host: '127.0.0.1', deviceId: 'device-lynx-1' });
+
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('reports every scanned port when none of them can be reached', async () => {
+    mocks.isInteractive.mockReturnValue(true);
+    mocks.getMetroTargets.mockRejectedValue(new Error('connect ECONNREFUSED'));
+
+    await openCommand({ host: '127.0.0.1' });
+
+    expect(process.exitCode).toBe(1);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Could not reach a dev server at http://127.0.0.1:8081 (React Native), http://127.0.0.1:3000 (Lynx)',
+      ),
+    );
+  });
+
+  it('queries only the given port, and does not claim to know its integration', async () => {
+    mocks.isInteractive.mockReturnValue(true);
+    mocks.getMetroTargets.mockResolvedValue([targetA]);
+    mocks.promptSelect.mockImplementation(
+      async ({ options }: { options: { value: OpenTarget }[] }) => options[0].value,
+    );
+    mocks.childProcessSpawn.mockReturnValue({ unref: vi.fn() });
+
+    await openCommand({ host: '127.0.0.1', port: 9000 });
+
+    expect(mocks.getMetroTargets).toHaveBeenCalledTimes(1);
+    expect(mocks.getMetroTargets).toHaveBeenCalledWith('127.0.0.1', 9000);
+    expect(mocks.promptSelect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: [expect.objectContaining({ label: 'iPhone 15 (com.example.a) — A' })],
+      }),
+    );
   });
 });
 
@@ -162,8 +277,8 @@ describe('openCommand target selection', () => {
     expect(mocks.promptSelect).toHaveBeenCalledWith(
       expect.objectContaining({
         options: [
-          { value: targetA, label: 'iPhone 15 (com.example.a) — A' },
-          { value: targetB, label: 'Pixel 8 (com.example.b) — B' },
+          { value: { ...targetA, port: 8081 }, label: 'iPhone 15 (com.example.a) — A' },
+          { value: { ...targetB, port: 8081 }, label: 'Pixel 8 (com.example.b) — B' },
         ],
       }),
     );
@@ -208,7 +323,7 @@ describe('selectTargetById', () => {
   // Two cards of one Lynx app: same device, one target each. This is the
   // shape that used to be unreachable, because a device collapsed to a
   // single target and the lowest page id always won.
-  const cardOne: MetroTarget = {
+  const cardOne: OpenTarget = {
     id: 'device-c-1',
     deviceId: 'device-c',
     name: 'iPhone',
@@ -217,8 +332,9 @@ describe('selectTargetById', () => {
     title: '/Applications/LynxExplorer.app/Resource/homepage.lynx.bundle',
     description: '',
     webSocketDebuggerUrl: 'ws://localhost:8081/inspector/debug?device=device-c&page=1',
+    port: 8081,
   };
-  const cardTwo: MetroTarget = {
+  const cardTwo: OpenTarget = {
     ...cardOne,
     id: 'device-c-2',
     pageId: 'device-c-2',

--- a/packages/cli/src/commands/dev-servers.ts
+++ b/packages/cli/src/commands/dev-servers.ts
@@ -1,0 +1,131 @@
+import { DEFAULT_AGENT_PORT, type MetroTarget } from '@rozenite/agent-shared';
+import type { RozeniteHostIntegration } from '@rozenite/tools/integration';
+import { getMetroTargets } from './metro-discovery.js';
+
+/**
+ * Rspeedy's default dev-server port, which is the port `@rozenite/lynx-dev`
+ * ends up serving `/json/list` and `@rozenite/app` on. React Native's own
+ * default is Metro's 8081 (`DEFAULT_AGENT_PORT`).
+ */
+export const DEFAULT_LYNX_PORT = 3000;
+
+const INTEGRATION_LABELS: Record<RozeniteHostIntegration, string> = {
+  'react-native': 'React Native',
+  lynx: 'Lynx',
+};
+
+export type DevServer = {
+  port: number;
+  /**
+   * The integration this port serves, as a name to show a person.
+   *
+   * Only set for the default ports we scan on our own initiative, where
+   * the port *is* the integration's documented default. A `--port` the
+   * user chose says nothing about which integration listens on it — Metro
+   * is perfectly happy on 3000 — so an explicit port carries no name
+   * rather than a guessed (and possibly wrong) one.
+   */
+  integration?: string;
+};
+
+/**
+ * The dev servers `rozenite open` scans when it is not told which port to
+ * use. Both integrations can be running at once, so this is a list rather
+ * than a choice, and its order is the order targets are offered in.
+ */
+export const DEFAULT_DEV_SERVERS: readonly DevServer[] = [
+  { port: DEFAULT_AGENT_PORT, integration: INTEGRATION_LABELS['react-native'] },
+  { port: DEFAULT_LYNX_PORT, integration: INTEGRATION_LABELS.lynx },
+];
+
+export const resolveDevServers = (port: number | undefined): DevServer[] =>
+  port === undefined ? [...DEFAULT_DEV_SERVERS] : [{ port }];
+
+/** A target plus the dev server it was found on, which is where it opens. */
+export type OpenTarget = MetroTarget & Pick<DevServer, 'port' | 'integration'>;
+
+export type DevServerFailure = {
+  server: DevServer;
+  message: string;
+};
+
+export type DevServerDiscovery = {
+  targets: OpenTarget[];
+  /**
+   * The servers that could not be reached at all. Scanning defaults means
+   * most projects always have one of these — nobody runs Metro and a Lynx
+   * dev server at the same time — so a failure is only worth reporting
+   * when nothing was found anywhere.
+   */
+  failures: DevServerFailure[];
+};
+
+/**
+ * Asks every candidate dev server for its targets, at the same time, and
+ * keeps whatever answers. Servers are queried concurrently because one of
+ * them is usually not listening, and a connection refused on a port that
+ * was never going to be used should not add to the wait.
+ */
+export const discoverTargets = async (
+  host: string,
+  servers: readonly DevServer[],
+): Promise<DevServerDiscovery> => {
+  const results = await Promise.all(
+    servers.map(async (server): Promise<DevServerDiscovery> => {
+      try {
+        const targets = await getMetroTargets(host, server.port);
+
+        return {
+          targets: targets.map((target) => ({
+            ...target,
+            port: server.port,
+            integration: server.integration,
+          })),
+          failures: [],
+        };
+      } catch (error) {
+        return {
+          targets: [],
+          failures: [
+            {
+              server,
+              message: error instanceof Error ? error.message : String(error),
+            },
+          ],
+        };
+      }
+    }),
+  );
+
+  return {
+    targets: results.flatMap((result) => result.targets),
+    failures: results.flatMap((result) => result.failures),
+  };
+};
+
+const describeServer = (host: string, server: DevServer): string => {
+  const url = `http://${host}:${server.port}`;
+
+  return server.integration ? `${url} (${server.integration})` : url;
+};
+
+/**
+ * What to tell someone when the scan found nothing, which has two quite
+ * different causes: a dev server answered but has no app connected to it,
+ * or no dev server answered at all.
+ */
+export const formatNoTargetsMessage = (
+  host: string,
+  servers: readonly DevServer[],
+  failures: readonly DevServerFailure[],
+): string => {
+  const locations = servers.map((server) => describeServer(host, server)).join(', ');
+
+  if (failures.length < servers.length) {
+    return `No connected device found at ${locations}. Open the Rozenite-enabled app on a device or simulator so it registers with the dev server, then try again.`;
+  }
+
+  const details = failures.map((failure) => failure.message).join(' ');
+
+  return `Could not reach a dev server at ${locations}. Start your dev server, or pass --port if it listens on a different port. ${details}`;
+};

--- a/packages/cli/src/commands/open-command.ts
+++ b/packages/cli/src/commands/open-command.ts
@@ -1,8 +1,12 @@
 import { spawn as spawnChildProcess } from 'node:child_process';
 import { createRequire } from 'node:module';
 import path from 'node:path';
-import type { MetroTarget } from '@rozenite/agent-shared';
-import { getMetroTargets } from './metro-discovery.js';
+import {
+  discoverTargets,
+  formatNoTargetsMessage,
+  resolveDevServers,
+  type OpenTarget,
+} from './dev-servers.js';
 import { buildAppOpenUrl } from './open-url.js';
 import { isInteractive } from '../utils/isInteractive.js';
 import { intro, outro, promptSelect } from '../utils/prompts.js';
@@ -12,7 +16,12 @@ const require = createRequire(import.meta.url);
 
 export type OpenCommandOptions = {
   host: string;
-  port: number;
+  /**
+   * The dev server port to look at. Omitted means "look at the default
+   * port of every integration Rozenite supports", which is what makes the
+   * command work for a Lynx project without being told about it.
+   */
+  port?: number;
   deviceId?: string;
 };
 
@@ -44,14 +53,17 @@ const shortenTitle = (title: string): string => {
  * A device can offer several targets, so the label has to say which page
  * each one is -- the device name alone is the same for all of them.
  */
-const formatTargetLabel = (target: MetroTarget): string => {
+const formatTargetLabel = (target: OpenTarget): string => {
   const base = `${target.name} (${target.appId || target.title})`;
   const detail = shortenTitle(target.title);
+  const label = detail.length > 0 && detail !== target.appId ? `${base} — ${detail}` : base;
 
-  return detail.length > 0 && detail !== target.appId ? `${base} — ${detail}` : base;
+  // Scanning several dev servers means the list can mix integrations, and
+  // a device name alone does not say which one a target belongs to.
+  return target.integration ? `${target.integration} · ${label}` : label;
 };
 
-const promptForTarget = async (targets: MetroTarget[]): Promise<MetroTarget> => {
+const promptForTarget = async (targets: OpenTarget[]): Promise<OpenTarget> => {
   return promptSelect({
     message: 'Select a debugging target to open Rozenite DevTools for',
     options: targets.map((target) => ({
@@ -69,9 +81,9 @@ const promptForTarget = async (targets: MetroTarget[]): Promise<MetroTarget> => 
  * asks which page when the device actually has more than one.
  */
 export const selectTargetById = async (
-  targets: MetroTarget[],
+  targets: OpenTarget[],
   deviceId: string,
-): Promise<MetroTarget> => {
+): Promise<OpenTarget> => {
   const exactTarget = targets.find((candidate) => candidate.id === deviceId);
 
   if (exactTarget) {
@@ -129,18 +141,17 @@ export const openCommand = async (options: OpenCommandOptions): Promise<void> =>
 
   intro('Rozenite');
 
-  const targets = await getMetroTargets(options.host, options.port);
+  const servers = resolveDevServers(options.port);
+  const { targets, failures } = await discoverTargets(options.host, servers);
 
   if (targets.length === 0) {
-    logger.error(
-      `No connected device found at http://${options.host}:${options.port}. Open the Rozenite-enabled app on a device or simulator so it registers with Metro, then try again.`,
-    );
+    logger.error(formatNoTargetsMessage(options.host, servers, failures));
     process.exitCode = 1;
     outro('Done');
     return;
   }
 
-  let target: MetroTarget;
+  let target: OpenTarget;
 
   try {
     target = options.deviceId
@@ -153,7 +164,7 @@ export const openCommand = async (options: OpenCommandOptions): Promise<void> =>
     return;
   }
 
-  const url = buildAppOpenUrl(options.host, options.port, target);
+  const url = buildAppOpenUrl(options.host, target.port, target);
 
   if (!tryOpenElectron(url)) {
     logger.error(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { DEFAULT_AGENT_HOST, DEFAULT_AGENT_PORT } from '@rozenite/agent-shared';
+import { DEFAULT_AGENT_HOST } from '@rozenite/agent-shared';
 import { color } from './utils/color.js';
 import { outro } from './utils/prompts.js';
 import { getPackageJSON } from './package-json.js';
@@ -9,6 +9,7 @@ import { buildCommand } from './commands/build-command.js';
 import { devCommand } from './commands/dev-command.js';
 import { initCommand } from './commands/init-command.js';
 import { openCommand } from './commands/open-command.js';
+import { DEFAULT_DEV_SERVERS } from './commands/dev-servers.js';
 import { registerAgentCommand } from './commands/agent/register-agent-command.js';
 import { registerSkillsCommand } from './commands/register-skills-command.js';
 import { getErrorMessage } from './commands/agent/error-message.js';
@@ -92,13 +93,16 @@ const main = async () => {
   program
     .command('open')
     .description('Open Rozenite DevTools for a connected device')
-    .option('--host <host>', 'Metro host', DEFAULT_AGENT_HOST)
-    .option('--port <port>', 'Metro port', String(DEFAULT_AGENT_PORT))
+    .option('--host <host>', 'Dev server host', DEFAULT_AGENT_HOST)
+    .option(
+      '--port <port>',
+      `Dev server port (default: ${DEFAULT_DEV_SERVERS.map((server) => server.port).join(' and ')}, scanned together)`,
+    )
     .option('--deviceId <id>', 'Target device ID (skips the picker)')
-    .action(async (options: { host: string; port: string; deviceId?: string }) => {
+    .action(async (options: { host: string; port?: string; deviceId?: string }) => {
       await openCommand({
         host: options.host,
-        port: Number(options.port),
+        port: options.port === undefined ? undefined : Number(options.port),
         deviceId: options.deviceId,
       });
     });

--- a/website/src/docs/standalone-app.mdx
+++ b/website/src/docs/standalone-app.mdx
@@ -35,12 +35,14 @@ Run `rozenite open` in your project:
   }}
 />
 
-This lists all devices currently connected to Metro and opens the standalone app in an Electron window for the one you pick.
+This lists all devices currently connected to your dev server and opens the standalone app in an Electron window for the one you pick.
+
+Both supported integrations are looked up: React Native's Metro on port `8081` and Lynx's dev server on port `3000`. Whichever ones are running contribute their devices to the list, and each entry is labelled with the integration it belongs to, so a project running both is picked apart at the prompt. A port that isn't listening is simply skipped.
 
 ### Options
 
-- `--host <host>` — Metro host to connect to (default `127.0.0.1`).
-- `--port <port>` — Metro port to connect to (default `8081`).
+- `--host <host>` — Dev server host to connect to (default `127.0.0.1`).
+- `--port <port>` — A single dev server port to look at. Without it, both `8081` and `3000` are scanned.
 - `--deviceId <id>` — Open a specific device directly, skipping the picker prompt.
 
 **Examples:**
@@ -63,11 +65,13 @@ This lists all devices currently connected to Metro and opens the standalone app
   }}
 />
 
+Pass `--port` when your dev server listens somewhere other than its default — it then queries that port only, instead of scanning both defaults.
+
 `rozenite open` requires an interactive terminal — it opens an Electron window and (without `--deviceId`) prompts you to pick a device, so it refuses to run in CI or a piped/non-TTY shell.
 
 ## Limitations
 
-- **Metro must be running.** `rozenite open` discovers devices through Metro's own device list, and the app itself is served by Metro. If Metro stops after you've opened the app, it shows a "dev server unreachable" state until Metro is back.
+- **A dev server must be running.** `rozenite open` discovers devices through the dev server's own device list, and the app itself is served by that dev server. If it stops after you've opened the app, the app shows a "dev server unreachable" state until it is back.
 - **It competes for the single debugger slot.** The standalone app connects directly to the device the same way React Native DevTools and `rozenite agent` do. Only one of these can be attached to a given device at a time — the last one to connect wins, disconnecting whichever was attached before it.
 
 ## Troubleshooting


### PR DESCRIPTION
## Description

`rozenite open` no longer assumes React Native. With no `--port`, it queries the default port of every supported integration — Metro's `8081` and the Lynx dev server's `3000` — at the same time, and offers everything it finds in a single picker:

```
React Native · iPhone 15 (com.example.app)
Lynx · iPhone (LynxExplorer) — main.lynx.bundle
```

- Each target is labelled with the integration it belongs to, so a list mixing both is tellable apart.
- The picked target opens on the port it was discovered on, so a Lynx target opens `http://host:3000/rozenite/app/` rather than a hardcoded `8081`.
- A port that is not listening is skipped silently — most projects only ever run one of the two. Only an entirely empty scan is an error, and it names every port that was tried.
- `--port` still means "look at exactly this port", and now skips the scan instead of overriding a default.

## Related Issue

Closes https://github.com/callstackincubator/rozenite/issues/483

## Context

Metro and `@rozenite/lynx-dev` serve byte-identical `/json/list` shapes — the Lynx server synthesises Metro's dialect on purpose — so nothing in a response says which integration answered. The integration name has to come from the port.

That is sound for the two ports the CLI picks itself, where the port *is* the integration's documented default, but it would be a guess for a port the user chose: `react-native start --port 3000` would be labelled "Lynx". So the name is attached only to the default scan, and an explicit `--port` carries no integration label rather than a possibly wrong one. `DevServer.integration` is optional for exactly this reason.

Discovery is `Promise.all` rather than sequential because the *expected* case is one of the two ports refusing the connection, and a port that was never going to be used should not add to the wait.

The new port knowledge lives in `packages/cli/src/commands/dev-servers.ts` rather than in `@rozenite/agent-shared`, since only the CLI needs it today. That file is a thin layer over the existing `getMetroTargets` — no discovery logic was copied. Worth noting that discovery is already duplicated across the middleware, the CLI and `@rozenite/app`, which is tracked separately in https://github.com/callstackincubator/rozenite/issues/482; this PR deliberately does not touch that.

## Testing

Automated, from the repository root after `git fetch origin main`:

- `pnpm checks:affected` — 92 tasks, all passing (typecheck, lint, format)
- `pnpm test:affected` — 53 tasks, all passing

`packages/cli/src/__tests__/open-command.test.ts` covers the new behaviour with 5 added cases, 19 in the file total:

- both default ports are queried when `--port` is absent, and the picker labels each target by integration
- the picked target opens on the port it was found on (`http://127.0.0.1:3000/rozenite/app/` for the Lynx one)
- a default port that refuses the connection is ignored while the other one answers — no error, no non-zero exit
- an empty scan reports both `http://127.0.0.1:8081 (React Native)` and `http://127.0.0.1:3000 (Lynx)`
- `--port 9000` queries that port only, once, and claims no integration for it

Docs updated: `website/src/docs/standalone-app.mdx` (launch behaviour, options, limitations) and `packages/app/README.md`. Changeset added.
