### PR TITLE
fix(website): make the Storybook build a Turborepo task

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -32,6 +32,25 @@
       "outputs": [],
       "outputLogs": "errors-only"
     },
+    // The site embeds a Storybook build of `@rozenite/ui` at /storybook. That
+    // build used to be chained inside the website's own `build` script, which
+    // put it outside Turborepo: it could not be cached or skipped, so editing
+    // one .mdx file rebuilt the whole Storybook, and its output was hidden
+    // inside the parent task's `errors-only` logs. Declaring it as a real task
+    // here makes it cache on its own inputs, so a docs-only change restores it
+    // instead of rebuilding it.
+    "@rozenite/docs#build": {
+      "dependsOn": ["^build", "ui-storybook#build-storybook"],
+      "inputs": ["$TURBO_DEFAULT$", "!README.md", "!CHANGELOG.md"],
+      "outputs": ["dist/**", "build/**"],
+      "outputLogs": "errors-only"
+    },
+    "ui-storybook#build-storybook": {
+      "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$", "!README.md", "!CHANGELOG.md"],
+      "outputs": ["storybook-static/**"],
+      "outputLogs": "errors-only"
+    },
     "lint": {
       "inputs": ["$TURBO_DEFAULT$", "!README.md", "!CHANGELOG.md"],
       "outputs": [],

--- a/website/package.json
+++ b/website/package.json
@@ -3,8 +3,7 @@
   "version": "1.0.9",
   "private": true,
   "scripts": {
-    "build": "rspress build && pnpm run build:storybook",
-    "build:storybook": "pnpm --filter ui-storybook run build-storybook && node scripts/copy-storybook.mjs",
+    "build": "rspress build && node scripts/copy-storybook.mjs",
     "dev": "rspress dev",
     "preview": "rspress preview"
   },

--- a/website/scripts/copy-storybook.mjs
+++ b/website/scripts/copy-storybook.mjs
@@ -8,7 +8,10 @@ const dest = resolve(__dirname, '../build/storybook');
 
 if (!existsSync(src)) {
   throw new Error(
-    `Storybook build output not found at ${src}. Run "pnpm --filter ui-storybook build-storybook" first.`,
+    `Storybook build output not found at ${src}. It is produced by the ` +
+      `"ui-storybook#build-storybook" Turborepo task, which "@rozenite/docs#build" ` +
+      `depends on -- build this site with "turbo run build --filter=@rozenite/docs" ` +
+      `rather than by calling rspress directly.`,
   );
 }
 

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "pnpm build",
+  "buildCommand": "pnpm turbo run build --filter=@rozenite/docs",
   "cleanUrls": true,
   "framework": null,
   "installCommand": "pnpm install",


### PR DESCRIPTION
## Description

The docs site embeds a Storybook build of `@rozenite/ui` at `/storybook`. That build was chained inside the website's own `build` script (`rspress build && pnpm --filter ui-storybook run build-storybook`), which put it outside Turborepo: not cached, not skippable, and invisible — it ran inside `@rozenite/docs#build`, whose `outputLogs` is `errors-only`, so it printed nothing while it worked.

This declares it as a real task:

- `ui-storybook#build-storybook`, with `outputs: ["storybook-static/**"]`, so it caches on its own inputs.
- `@rozenite/docs#build` gains `dependsOn: ["^build", "ui-storybook#build-storybook"]` and its script drops the shell-out, keeping only `rspress build && node scripts/copy-storybook.mjs`.
- Vercel's `buildCommand` becomes `pnpm turbo run build --filter=@rozenite/docs`, so the deploy and CI take the same path instead of diverging.

A docs-only change now restores the Storybook output from cache; a real `@rozenite/ui` change still rebuilds it.

## Related Issue

Closes https://github.com/callstackincubator/rozenite/issues/485

## Context

This came out of #484, whose CI never completed. That change touched one `.mdx` file alongside package code, which is enough to pull `@rozenite/docs` into the affected graph — and because CI has `paths-ignore: website/**`, it takes a commit touching *both* to get here, which is why this had gone unnoticed. Four runs in a row (the PR twice, the `main` push, and a re-run) produced ~5 minutes of task output, then silence, then a cancelled job with orphan `node`/`turbo` processes at cleanup. The silence is explained by `errors-only`: a long-running build in that position prints nothing at all.

`vercel.json` is pointed at turbo rather than teaching `copy-storybook.mjs` to build on demand, so there is exactly one way to build the site and it is the one CI exercises.

Note on scope: this removes the *trigger* — a docs edit can no longer set off a Storybook build — but it does not explain why that build fails to terminate on an `ubuntu-latest` runner. It completes in ~12s locally and exits 36ms after its last line, with no lingering handles. A change to `@rozenite/ui` would still run it on a runner, so that question stays open and deserves its own investigation.

**This PR is itself the experiment for that.** It touches `website/**` and `turbo.json`, so `@rozenite/docs#build` is affected and `ui-storybook#build-storybook` runs cold here, on a runner, with no cache. If the Validate job completes, the build does terminate in CI and the earlier hangs were pathological slowness on 2 vCPUs. If it wedges again, it is a genuine hang and worth chasing separately.

## Testing

Local, on this branch:

- `pnpm checks:all` — 64 tasks, all passing
- `pnpm test:all` — 70 tasks, all passing

The `:all` variants because `turbo.json` is a root config file.

Behaviour verified in both directions:

- Cold `pnpm turbo run build --filter=@rozenite/docs` from `website/` (exactly what Vercel now runs): 12.9s, `website/build/storybook` populated.
- Append a line to `website/src/docs/standalone-app.mdx`: 2.9s, `ui-storybook#build-storybook` is a cache hit and only `@rozenite/docs#build` re-runs. Before this change that rebuilt the entire Storybook.
- Append a line to `packages/ui/src/index.ts`: 3 tasks, 0 cached, 13.4s — the Storybook build correctly re-runs.

No version plan: the only packages touched are `@rozenite/docs` and `ui-storybook`, both private and excluded from versioning, plus root `turbo.json`.
